### PR TITLE
bug: Remove dependency from release delete hook

### DIFF
--- a/src/hooks/resources/release.ts
+++ b/src/hooks/resources/release.ts
@@ -148,5 +148,4 @@ sbvrUtils.addPureHook('POST', 'resin', 'release', releaseUpdateTimestampHook);
 addDeleteHookForDependents('release', [
 	['image__is_part_of__release', 'is_part_of__release'],
 	['image_install', 'is_provided_by__release'],
-	['release_tag', 'release'],
 ]);


### PR DESCRIPTION
When deleting an application an error is thrown due to an invalid
dependant resource. This patch removes that dependency.

Change-type: minor
Signed-off-by: Rich Bayliss <rich@balena.io>