### PR TITLE
hooks: Escalate permission to root when setting is_web_accessible

### DIFF
--- a/src/hooks/resources/device.ts
+++ b/src/hooks/resources/device.ts
@@ -326,9 +326,14 @@ sbvrUtils.addPureHook('PATCH', 'resin', 'device', {
 		}
 
 		if (request.values.is_web_accessible) {
+			const rootApi = api.clone({
+				passthrough: {
+					req: root,
+				},
+			});
 			waitPromises.push(
 				getCurrentRequestAffectedIds(args).then(deviceIds =>
-					checkDevicesCanHaveDeviceURL(api, deviceIds),
+					checkDevicesCanHaveDeviceURL(rootApi, deviceIds),
 				),
 			);
 		}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -21,7 +21,6 @@ export const ROLES: {
 		`resin.device.update?${matchesActor}`,
 		`resin.supervisor_release.get?should_manage__device/any(d:d/${matchesActor})`,
 		`resin.application.read?${ownsDevice} or depends_on__application/any(a:a/${ownsDevice})`,
-		`resin.application_type.read`,
 		`resin.device_config_variable.get?device/any(d:d/${matchesActor} or d/belongs_to__application/any(a:a/depends_on__application/any(da:da/${ownsDevice})))`,
 		`resin.device_config_variable.set?device/any(d:d/${matchesActor})`,
 		`resin.device_tag.get?device/any(d:d/${matchesActor})`,


### PR DESCRIPTION
This check should be performed as the root user and not require the
device API key to have access to the application_type records.

Signed-off-by: Rich Bayliss <rich@balena.io>
Change-type: patch