### PR TITLE
config: Embed device OpenVPN config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@balena/open-balena-api",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,9 +1,8 @@
 import * as _ from 'lodash';
-import * as memoizee from 'memoizee';
 
 const openVpnConfig = `
 client
-remote VPN_DETAILS
+remote {{VPN_DETAILS}}
 resolv-retry infinite
 
 remote-cert-tls server
@@ -55,15 +54,6 @@ export function intVar<R>(varName: string, defaultValue?: R): number | R {
 	return i;
 }
 
-export const openVpnVar = memoizee(
-	(): string => {
-		return openVpnConfig.replace(
-			'remote VPN_DETAILS',
-			`remote ${requiredVar('VPN_HOST')} ${requiredVar('VPN_PORT')}`,
-		);
-	},
-)();
-
 export const API_HOST = requiredVar('API_HOST');
 export const API_VPN_SERVICE_API_KEY = requiredVar('API_VPN_SERVICE_API_KEY');
 export const AUTH_RESINOS_REGISTRY_CODE =
@@ -72,7 +62,10 @@ export const COOKIE_SESSION_SECRET = requiredVar('COOKIE_SESSION_SECRET');
 export const DB_POOL_SIZE = intVar('DB_POOL_SIZE', undefined);
 export const DELTA_HOST = requiredVar('DELTA_HOST');
 export const DEVICE_CONFIG_OPENVPN_CA = requiredVar('DEVICE_CONFIG_OPENVPN_CA');
-export const DEVICE_CONFIG_OPENVPN_CONFIG = openVpnVar;
+export const DEVICE_CONFIG_OPENVPN_CONFIG = openVpnConfig.replace(
+	'remote {{VPN_DETAILS}}',
+	`remote ${requiredVar('VPN_HOST')} ${requiredVar('VPN_PORT')}`,
+);
 export const DEVICE_CONFIG_SSH_AUTHORIZED_KEYS =
 	process.env.DEVICE_CONFIG_SSH_AUTHORIZED_KEYS || '';
 export const EXTERNAL_HTTP_TIMEOUT_MS = intVar(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,11 +1,38 @@
 import * as _ from 'lodash';
+import * as memoizee from 'memoizee';
+
+const openVpnConfig = `
+client
+remote VPN_DETAILS
+resolv-retry infinite
+
+remote-cert-tls server
+ca /etc/openvpn/ca.crt
+auth-user-pass /var/volatile/vpn-auth
+auth-retry none
+script-security 2
+up /etc/openvpn-misc/upscript.sh
+up-restart
+down /etc/openvpn-misc/downscript.sh
+
+comp-lzo
+dev resin-vpn
+dev-type tun
+proto tcp
+nobind
+
+persist-key
+persist-tun
+verb 3
+user openvpn
+group openvpn
+`;
 
 export const requiredVar = (varName: string): string => {
 	const s = process.env[varName];
 	if (s == null) {
-		console.error(`Missing environment variable: ${varName}`);
-		process.exit(1);
-		throw new Error('Unreachable');
+		process.exitCode = 1;
+		throw new Error(`Missing environment variable: ${varName}`);
 	}
 	return s;
 };
@@ -28,6 +55,15 @@ export function intVar<R>(varName: string, defaultValue?: R): number | R {
 	return i;
 }
 
+export const openVpnVar = memoizee(
+	(): string => {
+		return openVpnConfig.replace(
+			'remote VPN_DETAILS',
+			`remote ${requiredVar('VPN_HOST')} ${requiredVar('VPN_PORT')}`,
+		);
+	},
+)();
+
 export const API_HOST = requiredVar('API_HOST');
 export const API_VPN_SERVICE_API_KEY = requiredVar('API_VPN_SERVICE_API_KEY');
 export const AUTH_RESINOS_REGISTRY_CODE =
@@ -36,9 +72,7 @@ export const COOKIE_SESSION_SECRET = requiredVar('COOKIE_SESSION_SECRET');
 export const DB_POOL_SIZE = intVar('DB_POOL_SIZE', undefined);
 export const DELTA_HOST = requiredVar('DELTA_HOST');
 export const DEVICE_CONFIG_OPENVPN_CA = requiredVar('DEVICE_CONFIG_OPENVPN_CA');
-export const DEVICE_CONFIG_OPENVPN_CONFIG = requiredVar(
-	'DEVICE_CONFIG_OPENVPN_CONFIG',
-);
+export const DEVICE_CONFIG_OPENVPN_CONFIG = openVpnVar;
 export const DEVICE_CONFIG_SSH_AUTHORIZED_KEYS =
 	process.env.DEVICE_CONFIG_SSH_AUTHORIZED_KEYS || '';
 export const EXTERNAL_HTTP_TIMEOUT_MS = intVar(

--- a/src/routes/os.ts
+++ b/src/routes/os.ts
@@ -13,7 +13,7 @@ export const getOsConfiguration = (
 	res.json({
 		services: {
 			openvpn: {
-				config: b64decode(DEVICE_CONFIG_OPENVPN_CONFIG),
+				config: DEVICE_CONFIG_OPENVPN_CONFIG,
 				ca: b64decode(DEVICE_CONFIG_OPENVPN_CA),
 			},
 			ssh: {


### PR DESCRIPTION
We've currently got multiple sources of truth for
the OpenVPN config. This change ensures there's a single
point which is dynamically filled in for the appropriate
VPN endpoints.

Connects-to: #46
Change-type: patch
Signed-off-by: Heds Simons <heds@balena.io>