### PR TITLE
✨ Add redis prefix for rate limiting

### DIFF
--- a/src/lib/rate-limiting.ts
+++ b/src/lib/rate-limiting.ts
@@ -60,6 +60,7 @@ const getStore = _.once(() => {
 
 	const opts: ExpressBruteRedisOpts = {
 		client,
+		prefix: 'api:ratelimiting:',
 	};
 
 	const redisStore = new ExpressBruteRedis(opts);


### PR DESCRIPTION
This scopes the rate limit entries for redis
into a prefix called `api:ratelimiting:`.

Change-type: minor
Signed-off-by: Andreas Fitzek <andreas@balena.io>