### PR TITLE
✨ Add `host` flag to application type model

### DIFF
--- a/src/lib/application-types.ts
+++ b/src/lib/application-types.ts
@@ -14,6 +14,7 @@ export interface ApplicationType {
 	supports_gateway_mode: boolean;
 	requires_payment: boolean;
 	is_legacy: boolean;
+	is_host_os: boolean;
 	needs__os_version_range: null | string;
 	maximum_device_count: null | number;
 	description: string;
@@ -28,6 +29,7 @@ export const Default: ApplicationType = {
 	supports_gateway_mode: true,
 	requires_payment: false,
 	is_legacy: false,
+	is_host_os: false,
 	needs__os_version_range: '>=2.11.0',
 	maximum_device_count: null,
 	description:

--- a/src/migrations/00006-add-app-type-host-flag.sql
+++ b/src/migrations/00006-add-app-type-host-flag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "application type" ADD COLUMN "is host os" INTEGER DEFAULT 0 NOT NULL;

--- a/src/resin.sbvr
+++ b/src/resin.sbvr
@@ -346,6 +346,7 @@ Fact type: application type needs os version range
 	Necessity: each application type needs at most one os version range
 Fact type: application type requires payment
 Fact type: application type is legacy
+Fact type: application type is host os
 Fact type: application type has slug
 	Necessity: each application type has exactly one slug
 	Necessity: each slug is of exactly one application type


### PR DESCRIPTION
Add a `host` flag to the application type model.

We need to make a migration in the data model for this PR.

See: https://github.com/balena-io/balena/pull/1654
Change-type: minor
Signed-off-by: Andreas Fitzek <andreas@balena.io>