### PR TITLE
access: lower host OS access to OS version 2.0.0

### DIFF
--- a/src/routes/access.ts
+++ b/src/routes/access.ts
@@ -8,7 +8,7 @@ import { captureException } from '../platform/errors';
 
 const { UnauthorizedError } = sbvrUtils;
 
-const HOSTOS_ACCESS_MIN_RESINOS_VER = '2.7.5';
+const HOSTOS_ACCESS_MIN_RESINOS_VER = '2.0.0';
 
 export function hostOSAccess(
 	req: express.Request,

--- a/src/routes/access.ts
+++ b/src/routes/access.ts
@@ -8,7 +8,7 @@ import { captureException } from '../platform/errors';
 
 const { UnauthorizedError } = sbvrUtils;
 
-const HOSTOS_ACCESS_MIN_RESINOS_VER = '2.0.0';
+const HOSTOS_ACCESS_MIN_OS_VER = '2.0.0';
 
 export function hostOSAccess(
 	req: express.Request,
@@ -78,8 +78,8 @@ export function hostOSAccess(
 						return;
 					}
 
-					// Users are allowed to access hostOS for devices with resinOS >= HOSTOS_ACCESS_MIN_RESINOS_VER
-					if (rSemver.gte(device.os_version, HOSTOS_ACCESS_MIN_RESINOS_VER)) {
+					// Users are allowed to access hostOS for devices with version >= HOSTOS_ACCESS_MIN_OS_VER
+					if (rSemver.gte(device.os_version, HOSTOS_ACCESS_MIN_OS_VER)) {
 						res.sendStatus(200);
 						return;
 					}


### PR DESCRIPTION
Was discussed that there's no compelling reason to tie the host OS access (approximately) to the first hostapp enabled OS versions, but it can be lowered to earliest 2.x. Those OS versions have read-only root as well by default, so harder to mess things up (a bit). It's also required for an ongoing FleetOps task, giving some users access to their devices to do maintenance.

As a note, likely the variable's name should change as well (from `..._RESINOS_...` to `..._HOST_OS_..` or just `..._OS_`). If a form is agreed to, will add that change as an extra commit to this PR, as logically separate.

Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>