### PR TITLE
added `skipHttpsPaths` to setup options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export interface SetupFunction {
 export interface SetupOptions {
 	configPath: string; // must be absolute or relative to `process.cwd()`
 	version?: string; // this will be reported along with exceptions to Sentry
+	skipHttpsPaths?: string[]; // a list of paths which should be exempt from https redirection
 
 	onInit?: SetupFunction;
 	onInitMiddleware?: SetupFunction;
@@ -66,7 +67,9 @@ export function setup(app: _express.Application, options: SetupOptions) {
 
 	// redirect to https if needed, except for requests to
 	// the /ping endpoint which must always return 200
-	app.use(fixProtocolMiddleware(['/ping']));
+	app.use(
+		fixProtocolMiddleware(['/ping'].concat(options.skipHttpsPaths || [])),
+	);
 
 	app.use((_req, res, next) => {
 		res.set('X-Frame-Options', 'DENY');


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Nick Payne <nickp@balena.io>

This will be used by `resin-api` to pass `/metrics` as a path which should not be redirected, as it is going to be hit by Prometheus instances sitting inside the VPC network, not going through the https-terminating ELB. (We could have simply added `X-Forwarded-Proto: https`, but Prometheus doesn't allow the setting of outgoing headers).