### PR TITLE
device-proxy: use `.balena` tld in favour of `.resin`

### DIFF
--- a/src/lib/device-proxy.ts
+++ b/src/lib/device-proxy.ts
@@ -241,7 +241,7 @@ export function requestDevices({
 					const promises: Array<ReturnType<typeof requestAsync>> = [];
 					const waitPromise = Promise.each(devices, device => {
 						const vpnIp = device.is_managed_by__service_instance[0].ip_address;
-						const deviceUrl = `http://${device.uuid}.resin:${device.api_port ||
+						const deviceUrl = `http://${device.uuid}.balena:${device.api_port ||
 							80}${url}?apikey=${device.api_secret}`;
 						promises.push(
 							requestAsync({


### PR DESCRIPTION
Ref: [open-balena-vpn](https://github.com/balena-io/open-balena-vpn/blob/7e252b0993c3e9e4fd8ba6ffed726a00298ebcac/src/connect-proxy/worker.ts#L55).

Change-type: patch
Signed-off-by: Will Boyce \<will@balena.io\>