### PR TITLE
os-config: disable client-initiated vpn tls key renegotiation

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -25,6 +25,10 @@ persist-tun
 verb 3
 user openvpn
 group openvpn
+
+reneg-bytes 0
+reneg-pkts 0
+reneg-sec 0
 `;
 
 export const requiredVar = (varName: string): string => {


### PR DESCRIPTION
Allowing the server to dictate when keys are renegotiated allows us to
control load spikes more effectively.

Change-type: patch
Signed-off-by: Will Boyce \<will@balena.io\>