### PR TITLE
bug: Resolve NPM dependency issues preventing startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -778,8 +778,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
       "version": "0.2.4",
@@ -1523,8 +1522,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "optional": true
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -3994,7 +3992,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -4003,8 +4000,7 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -6318,7 +6314,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
       "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-      "dev": true,
       "requires": {
         "arrify": "^1.0.0",
         "buffer-from": "^1.1.0",
@@ -6333,14 +6328,12 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "yn": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-          "dev": true
+          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "resin-semver": "^1.5.1",
     "supervisor": "^0.12.0",
     "thirty-two": "^1.0.0",
+    "ts-node": "^7.0.1",
     "typed-error": "^2.0.0",
     "typescript": "^3.4.3"
   },
@@ -88,8 +89,7 @@
     "prettier": "^1.17.0",
     "resin-lint": "^2.0.0",
     "rimraf": "^2.6.3",
-    "supertest": "^4.0.2",
-    "ts-node": "^7.0.1"
+    "supertest": "^4.0.2"
   },
   "engines": {
     "node": ">=8.0"


### PR DESCRIPTION
Add `ts-node` as a dependency, as it had been marked as devOnly
in a previous PR.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>