### PR TITLE
Block removal of the currently deployed release in isolation

### DIFF
--- a/src/migrations/00011-fix-violators.sql
+++ b/src/migrations/00011-fix-violators.sql
@@ -1,0 +1,19 @@
+UPDATE "application" AS "application.0"
+SET "commit" = NULL
+WHERE "application.0"."commit" IS NOT NULL
+AND EXISTS (
+		SELECT 1
+		FROM "release" AS "release.2"
+		WHERE "release.2"."commit" = "application.0"."commit"
+		AND "release.2"."commit" IS NOT NULL
+		AND "release.2"."belongs to-application" = "application.0"."id"
+)
+AND NOT EXISTS (
+		SELECT 1
+		FROM "release" AS "release.4"
+		WHERE "release.4"."commit" = "application.0"."commit"
+		AND "release.4"."commit" IS NOT NULL
+		AND "release.4"."status" = 'success'
+		AND "release.4"."status" IS NOT NULL
+		AND "release.4"."belongs to-application" = "application.0"."id"
+);

--- a/src/resin.sbvr
+++ b/src/resin.sbvr
@@ -617,3 +617,4 @@ Rule: It is necessary that each device1 that is managed by a device2, belongs to
 Rule: It is necessary that each image that has a status that is equal to "success", has a push timestamp.
 Rule: It is necessary that each release1 that has a status that is equal to "success" and has a commit1, belongs to an application that owns exactly one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.
 Rule: It is necessary that each device that should be running a release, should be running a release that belongs to an application that the device belongs to.
+Rule: It is necessary that each application that has a commit1 and owns at least 1 release that has a commit2 that is equal to the commit1, owns a release that has a commit3 that is equal to the commit1 and has a status that is equal to "success".


### PR DESCRIPTION
This still allows removing all releases at once, in order to allow
application deletes but avoids other modifications that make the
release undeployable

Change-type: patch