### PR TITLE
Avoid fetching deleted image installs for log write context

### DIFF
--- a/src/routes/device-logs.ts
+++ b/src/routes/device-logs.ts
@@ -367,6 +367,9 @@ function getWriteContext(
 								$expand: { is_a_build_of__service: { $select: 'id' } },
 							},
 						},
+						$filter: {
+							status: { $ne: 'deleted' },
+						},
 					},
 				},
 			},


### PR DESCRIPTION
This both reduces the amount of data we need to fetch from the database
as well as reducing the amount of data we need to keep in memory

Change-type: patch