### PR TITLE
registry: Allow registry authentication for docker login

### DIFF
--- a/src/routes/registry.ts
+++ b/src/routes/registry.ts
@@ -21,7 +21,7 @@ import {
 import { Resolvable } from '@resin/pinejs/out/sbvr-api/common-types';
 import * as memoize from 'memoizee';
 
-const { BadRequestError, UnauthorizedError } = sbvrUtils;
+const { UnauthorizedError } = sbvrUtils;
 
 // Set a large expiry so that huge pulls/pushes go through
 // without needing to re-authenticate mid-process.
@@ -292,7 +292,7 @@ export const token: RequestHandler = (req, res) =>
 		} else if (_.isObject(scope)) {
 			scopes = _.values(scope);
 		} else {
-			throw new BadRequestError('Invalid scope');
+			scopes = [];
 		}
 
 		return Promise.join(


### PR DESCRIPTION
docker login happens with no scopes provided (unlike docker pull and push, where there's always a scope). In this login case, provide authentication for an empty scope. This means any username/password is allowed for login, but nonetheless this does not weaken access, as on pull and push the request will be rechecked whether it can access the specific images.

This allows docker login to work again, that stopped working in v0.17.4, that is #85

Tested the a) not logged in; b) logged in with wrong credentials; c) logged in correctly cases, and seems to check out:
```
~> docker logout registry2.earth.milkyway.local
Not logged in to registry2.earth.milkyway.local

~> docker pull registry2.earth.milkyway.local/v2/68e0c194410f7edbe24940e40226ead2@sha256:e9fc3ac3990f9319700b962cd27dac48daa803a3b79294e80b8c39eb6361c837
Error response from daemon: pull access denied for registry2.earth.milkyway.local/v2/68e0c194410f7edbe24940e40226ead2, repository does not exist or may require 'docker login'
exit 1

~> docker login registry2.earth.milkyway.local -u "anything" -p "anything"
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded

~> docker pull registry2.earth.milkyway.local/v2/68e0c194410f7edbe24940e40226ead2@sha256:e9fc3ac3990f9319700b962cd27dac48daa803a3b79294e80b8c39eb6361c837
Error response from daemon: pull access denied for registry2.earth.milkyway.local/v2/68e0c194410f7edbe24940e40226ead2, repository does not exist or may require 'docker login'
exit 1

~> docker logout registry2.earth.milkyway.local                                                                                                          
Removing login credentials for registry2.earth.milkyway.local

~> docker login registry2.earth.milkyway.local -u "46d03220a7666f3006b07ba910387e05" -p "5af908a4fdd751d1e8e5d04601717422"
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded

~> docker pull registry2.earth.milkyway.local/v2/68e0c194410f7edbe24940e40226ead2@sha256:e9fc3ac3990f9319700b962cd27dac48daa803a3b79294e80b8c39eb6361c837
sha256:e9fc3ac3990f9319700b962cd27dac48daa803a3b79294e80b8c39eb6361c837: Pulling from v2/68e0c194410f7edbe24940e40226ead2
Digest: sha256:e9fc3ac3990f9319700b962cd27dac48daa803a3b79294e80b8c39eb6361c837
Status: Image is up to date for registry2.earth.milkyway.local/v2/68e0c194410f7edbe24940e40226ead2@sha256:e9fc3ac3990f9319700b962cd27dac48daa803a3b79294e80b8c39eb6361c837
```

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/5epJKyvEdIEIXDn9U4cYW0fvT-B
Signed-off-by: Gergely Imreh <gergely@balena.io>