### PR TITLE
Add a contract JSON field to the image resource

### DIFF
--- a/src/migrations/00014-add-image-contracts.sql
+++ b/src/migrations/00014-add-image-contracts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "image" ADD COLUMN "contract" TEXT NULL;

--- a/src/resin.sbvr
+++ b/src/resin.sbvr
@@ -96,6 +96,9 @@ Term: composition
 Term: content hash
 	Concept Type: Short Text (Type)
 
+Term: contract
+	Concept Type: JSON (Type)
+
 Term: date
 	Concept Type: Date Time (Type)
 
@@ -546,6 +549,8 @@ Fact type: image has status
 	Necessity: each image has exactly one status.
 Fact type: image has content hash
 	Necessity: each image has at most one content hash.
+Fact type: image has contract
+	Necessity: each image has at most one contract
 
 
 -- image label

--- a/src/routes/devices.ts
+++ b/src/routes/devices.ts
@@ -291,6 +291,7 @@ const stateQuery = resinApi.prepare<{ uuid: string }>({
 									'is_stored_at__image_location',
 									'content_hash',
 									'is_a_build_of__service',
+									'contract',
 								],
 							},
 							image_label: {
@@ -466,6 +467,7 @@ export const state: RequestHandler = (req, res) => {
 								image: formatImageLocation(imgRegistry),
 								// This needs spoken about...
 								running: true,
+								contract: image.contract,
 								environment,
 								labels,
 							};


### PR DESCRIPTION
We add a `contract` field on the `image` resource, which will be used to fill the container contract for this image at runtime. This is returned to the supervisor who will act upon it, denying or allowing the use of the image based on whether the device fulfils the requirements detailed by the contract.

Change-type: minor
Signed-off-by: Cameron Diver <cameron@balena.io>