### PR TITLE
Also create service installs for devices that are currently pinned

### DIFF
--- a/src/hooks/resources/release.ts
+++ b/src/hooks/resources/release.ts
@@ -18,9 +18,6 @@ const updateLatestRelease = (id: number, { request, api }: HookArgs) => {
 							$expand: {
 								owns__device: {
 									$select: ['id'],
-									$filter: {
-										should_be_running__release: null,
-									},
 								},
 							},
 						},


### PR DESCRIPTION
This stops an issue when a pinned device is later unpinned and needs
service installs for services that were created whilst it was pinned

Change-type: patch