### PR TITLE
Fix password comparisons with null hash

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -12,7 +12,7 @@ interface PineResourceBase extends WithId {
 
 export interface User extends PineResourceBase, WithActor {
 	username: string;
-	password?: string;
-	jwt_secret?: string;
-	email?: string;
+	password: string | null;
+	jwt_secret: string | null;
+	email: string | null;
 }

--- a/src/platform/jwt.ts
+++ b/src/platform/jwt.ts
@@ -8,6 +8,7 @@ import * as passport from 'passport';
 import { sbvrUtils } from '@resin/pinejs';
 import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
 import { TypedError } from 'typed-error';
+import { User as DbUser } from '../models';
 import { captureException } from './errors';
 import { RequestHandler } from 'express';
 
@@ -105,7 +106,7 @@ export const strategy = new JwtStrategy(
 							$select: ['actor', 'jwt_secret'],
 						},
 					})
-					.then((user: AnyObject) => {
+					.then((user: Pick<DbUser, 'actor' | 'jwt_secret'>) => {
 						if (user == null) {
 							throw new InvalidJwtSecretError();
 						}

--- a/src/routes/registry.ts
+++ b/src/routes/registry.ts
@@ -8,6 +8,7 @@ import * as jsonwebtoken from 'jsonwebtoken';
 import { resinApi, root, sbvrUtils } from '../platform';
 import * as Promise from 'bluebird';
 
+import { User as DbUser } from '../models';
 import { captureException, handleHttpErrors } from '../platform/errors';
 import { retrieveAPIKey } from '../platform/api-keys';
 
@@ -380,7 +381,7 @@ const $getSubject = memoize(
 						$top: 1,
 					},
 				})
-				.then(([user]: AnyObject[]) => {
+				.then(([user]: [Pick<DbUser, 'username'>?]) => {
 					if (user) {
 						return user.username;
 					}

--- a/src/routes/session.ts
+++ b/src/routes/session.ts
@@ -3,7 +3,6 @@ import {
 	findUser,
 	getUser,
 	comparePassword,
-	runInvalidPasswordComparison,
 } from '../platform/auth';
 import { sbvrUtils } from '../platform';
 import { captureException, handleHttpErrors } from '../platform/errors';
@@ -42,12 +41,7 @@ export const login = (onLogin: SetupOptions['onLogin']): RequestHandler => (
 				throw new NotFoundError('User not found.');
 			}
 
-			const passwordComparison =
-				user.password == null
-					? runInvalidPasswordComparison()
-					: comparePassword(password, user.password);
-
-			return passwordComparison
+			return comparePassword(password, user.password)
 				.then(matches => {
 					if (!matches) {
 						throw new BadRequestError('Current password incorrect.');


### PR DESCRIPTION
Further typing `findUser()` calls revealed more places that we were comparing the password with a potentially null hash.
I now think that backing the null hash handling in `comparePassword` is more scalable and covers all possibly unhanded cases in the cloud API as well.
Also updated the typings to use `null` instead of `undefined`, to correctly match pine's results.

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/g2iRNTO3hHxm8Z9pQqsyYzaA8Sk
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>