### PR TITLE
env-vars: whitelist other Raspberry-Pi devices for config capable device types

### DIFF
--- a/src/lib/env-vars.ts
+++ b/src/lib/env-vars.ts
@@ -142,7 +142,10 @@ export const RESIN_HOST_CONFIG_CAPABLE_DEVICE_TYPES = [
 	'raspberry-pi2',
 	'raspberrypi3-64',
 	'raspberrypi3',
+	'raspberrypi4-64',
 	'fincm3',
+	'revpi-core-3',
+	'npe-x500-m3',
 ];
 
 const startsWithAny = (ns: string[], name: string) => {


### PR DESCRIPTION
Pi4, RevPi, NPE. Covers things now from https://github.com/balena-os/balena-raspberrypi


Connects-to: #183
Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>