### PR TITLE
fix: Ensure API heartbeat queue consumption is started during setup

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -4,7 +4,6 @@ import { setup } from './src';
 import config = require('./config');
 import { version } from './package.json';
 import { sbvrUtils } from '@resin/pinejs';
-import * as deviceOnlineState from './src/lib/device-online-state';
 
 async function onInitMiddleware(app: express.Application) {
 	const { forwardRequests } = await import('./src/platform/versions');
@@ -107,10 +106,6 @@ setup(app, {
 })
 	.tap(createSuperuser)
 	.then(({ startServer }) => startServer(process.env.PORT || 1337).return())
-	.then(() => {
-		console.log('Starting API heartbeat state worker...');
-		deviceOnlineState.getInstance().start();
-	})
 	.then(() => {
 		if (doRunTests) {
 			console.log('Running tests...');

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ import * as pineEnv from '@resin/pinejs/out/config-loader/env';
 import * as jwt from './platform/jwt';
 passport.use(jwt.strategy);
 
+import * as deviceOnlineState from './lib/device-online-state';
+
 import {
 	API_HOST,
 	DB_POOL_SIZE,
@@ -127,6 +129,9 @@ export function setup(app: _express.Application, options: SetupOptions) {
 		.then(runSetupFunction(app, options.onInitRoutes))
 		.then(() => {
 			app.use(Raven.errorHandler());
+
+			// start consuming the API heartbeat state queue...
+			deviceOnlineState.getInstance().start();
 
 			return {
 				app,

--- a/test/03-device-state-v2.ts
+++ b/test/03-device-state-v2.ts
@@ -39,10 +39,6 @@ const tracker = new StateTracker();
 	TIMEOUT_MSEC / 1000,
 );
 
-// mock the device state lib to hook the update of Pine models...
-(stateMock.DeviceOnlineStateManager as AnyObject)[
-	'QUEUE_STATS_INTERVAL_MSEC'
-] = 1000;
 const updateDeviceModel = stateMock.getInstance()['updateDeviceModel'];
 stateMock.getInstance()['updateDeviceModel'] = function(
 	uuid: string,

--- a/test/test-lib/init_mocks.ts
+++ b/test/test-lib/init_mocks.ts
@@ -1,3 +1,7 @@
 import('./aws-mock');
 
+// override the interval used to emit the queue stats event...
+import { DeviceOnlineStateManager } from '../../src/lib/device-online-state';
+(DeviceOnlineStateManager as any)['QUEUE_STATS_INTERVAL_MSEC'] = 1000;
+
 export {};


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>