### PR TITLE
Advertise X-Balena-Client as accepted CORS header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export function setup(app: _express.Application, options: SetupOptions) {
 		);
 		res.header(
 			'Access-Control-Allow-Headers',
-			'Content-Type, Authorization, Application-Record-Count, MaxDataServiceVersion, X-Requested-With',
+			'Content-Type, Authorization, Application-Record-Count, MaxDataServiceVersion, X-Requested-With, X-Balena-Client',
 		);
 		res.header('Access-Control-Allow-Credentials', 'true');
 		res.header('Access-Control-Max-Age', '86400');


### PR DESCRIPTION
Balena modules are going to use this to report their name and version.
Eg: `"X-Balena-Client": "balena-sdk v12.12.0"`

Resolves: #222
HQ: https://github.com/balena-io/balena/issues/2036
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>