### PR TITLE
Allow hostOS access if the os version is unknown

### DIFF
--- a/src/routes/access.ts
+++ b/src/routes/access.ts
@@ -72,8 +72,11 @@ export async function hostOSAccess(
 			return;
 		}
 
-		// Users are allowed to access hostOS for devices with version >= HOSTOS_ACCESS_MIN_OS_VER
-		if (rSemver.gte(device.os_version, HOSTOS_ACCESS_MIN_OS_VER)) {
+		// Users are allowed to access hostOS for devices with version >= HOSTOS_ACCESS_MIN_OS_VER or if the version is still unknown
+		if (
+			!device.os_version ||
+			rSemver.gte(device.os_version, HOSTOS_ACCESS_MIN_OS_VER)
+		) {
 			res.sendStatus(200);
 			return;
 		}


### PR DESCRIPTION
There are cases when the device fails to notify its OS version to the API, and being able to SSH into such a device for troubleshooting purposes is quite useful. This also makes sense since we don't support OS 1.x anymore, and there are probably no newly provisioned devices that will be on OS 1.x

See: https://www.flowdock.com/app/rulemotion/r-product/threads/UTfEJ72tVEnu4qnXgbZLeXcB4Kd
Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>