### PR TITLE
env-vars: Add SSDT overlays host configfs variable for the up-board

### DIFF
--- a/src/lib/env-vars.ts
+++ b/src/lib/env-vars.ts
@@ -152,6 +152,17 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 			},
 		},
 	},
+	{
+		capableDeviceTypes: ['up-board'],
+		properties: {
+			RESIN_HOST_CONFIGFS_ssdt: {
+				type: 'string',
+				description:
+					'Define SSDT overlays. Only supported by supervisor versions >= v10.9.2.',
+				examples: ['"spidev1.0","spidev1.1"'],
+			},
+		},
+	},
 ];
 
 const startsWithAny = (ns: string[], name: string) => {

--- a/test/01-basic.ts
+++ b/test/01-basic.ts
@@ -136,6 +136,10 @@ describe('Basic', () => {
 					'RESIN_HOST_CONFIG_gpu_mem',
 				],
 			},
+			{
+				deviceType: 'up-board',
+				extraConfigVarSchemaProperties: ['RESIN_HOST_CONFIGFS_ssdt'],
+			},
 		].forEach(({ deviceType, extraConfigVarSchemaProperties }) => {
 			it(`should be correct when device type ${deviceType} is specified`, async () => {
 				const { body: vars } = await supertest(app)


### PR DESCRIPTION
That's on top of #309 since it uses the new structure for the definitions.

Change-type: minor
See: https://github.com/balena-io/balena-supervisor/issues/1113
See: https://github.com/balena-io/balena-supervisor/pull/1187
See: https://github.com/balena-os/meta-balena/issues/1845
See: https://github.com/balena-os/balena-up-board/issues/74
See: https://www.flowdock.com/app/rulemotion/r-supervisor/threads/tBuZeGU8N3aqK2IOidtHiOQIdBf
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>