### PR TITLE
env-vars: Add DTB config vars for nvidia boards

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -182,6 +182,29 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 		},
 	},
 	{
+		capableDeviceTypes: [
+			'astro-tx2',
+			'blackboard-tx2',
+			'jetson-tx2',
+			'n310-tx2',
+			'n510-tx2',
+			'orbitty-tx2',
+			'spacely-tx2',
+			'srd3-tx2',
+			'jetson-nano',
+			'jetson-nano-emmc',
+			'jn30b-nano',
+			'photon-nano',
+		],
+		properties: {
+			RESIN_HOST_EXTLINUX_fdt: {
+				type: 'string',
+				description:
+					'Define the file name of the DTB to be used. Only supported by supervisor versions >= v11.14.2.',
+			},
+		},
+	},
+	{
 		capableDeviceTypes: ['up-board'],
 		properties: {
 			RESIN_HOST_CONFIGFS_ssdt: {

--- a/test/01-basic.ts
+++ b/test/01-basic.ts
@@ -117,8 +117,15 @@ describe('Basic', () => {
 				],
 			},
 			{
+				deviceType: 'jetson-nano',
+				extraConfigVarSchemaProperties: ['RESIN_HOST_EXTLINUX_fdt'],
+			},
+			{
 				deviceType: 'jetson-tx2',
-				extraConfigVarSchemaProperties: ['RESIN_HOST_ODMDATA_configuration'],
+				extraConfigVarSchemaProperties: [
+					'RESIN_HOST_EXTLINUX_fdt',
+					'RESIN_HOST_ODMDATA_configuration',
+				],
 			},
 			{
 				deviceType: 'up-board',


### PR DESCRIPTION
That's on top of #309 since it uses the new structure for the definitions.

Change-type: minor
See: https://github.com/balena-io/balenacloud-dashboard/issues/3413
HQ: https://github.com/balena-io/balena/issues/2166
Depends-on: https://github.com/balena-io/balenacloud-dashboard/issues/3486
Depends-on: https://github.com/balena-io/balena-supervisor/issues/1207
See: https://www.flowdock.com/app/rulemotion/r-supervisor/threads/54GM3Zqzk75loM4ELl77Zt1w7Vt
See: https://www.flowdock.com/app/rulemotion/resin-devices/threads/h4rhav-nPtFC6vROZyub47lVoRB
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>