### PR TITLE
env-vars: Add dtoverlay host config variable

### DIFF
--- a/src/lib/env-vars.ts
+++ b/src/lib/env-vars.ts
@@ -135,6 +135,11 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 				description: 'Define DT parameters',
 				default: '"i2c_arm=on","spi=on","audio=on"',
 			},
+			RESIN_HOST_CONFIG_dtoverlay: {
+				type: 'string',
+				description: 'Define DT overlays',
+				examples: ['"i2c-rtc,ds1307","lirc-rpi"'],
+			},
 			RESIN_HOST_CONFIG_enable_uart: {
 				enum: ['0', '1'],
 				description: 'Enable / Disable UART',

--- a/test/01-basic.ts
+++ b/test/01-basic.ts
@@ -131,6 +131,7 @@ describe('Basic', () => {
 				extraConfigVarSchemaProperties: [
 					'RESIN_HOST_CONFIG_disable_splash',
 					'RESIN_HOST_CONFIG_dtparam',
+					'RESIN_HOST_CONFIG_dtoverlay',
 					'RESIN_HOST_CONFIG_enable_uart',
 					'RESIN_HOST_CONFIG_gpu_mem',
 				],


### PR DESCRIPTION
That's on top of #309 since it uses the new structure for the definitions.

Looks like we have forgotten to add it in here, even
though our docs do mention it along with dtparams.

Change-type: minor
See: https://www.balena.io/docs/reference/OS/advanced/#setting-device-tree-overlays-dtoverlay-and-parameters-dtparam
See: https://www.flowdock.com/app/rulemotion/r-supervisor/threads/F-ibcGI_Y4EhkBJbuS5UIqMYi5t
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>