### PR TITLE
Add is_invalidated boolean term to the release resource

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -516,6 +516,7 @@ Fact type: release has source
 	Necessity: each release has exactly one source.
 Fact type: release has build log
 	Necessity: each release has at most one build log.
+Fact type: release is invalidated
 Fact type: release has start timestamp
 	Necessity: each release has exactly one start timestamp.
 Fact type: release has end timestamp

--- a/src/migrations/00025-release-is-invalidated.sql
+++ b/src/migrations/00025-release-is-invalidated.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "release" ADD COLUMN "is invalidated" INTEGER DEFAULT 0 NOT NULL;


### PR DESCRIPTION
We currently need the flag to mark host OS releases as invalid
so they can be filtered out from the list of available versions.
The future plan is for the supervisor to automatically rollback
invalidated releases, but there are no dedicated resources to
work on that just yet.

This was already discussed at an arch call: https://app.frontapp.com/open/msg_ad91xc3

Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>