### PR TITLE
Refactor how device type specific config vars are synthesized

### DIFF
--- a/src/lib/env-vars.ts
+++ b/src/lib/env-vars.ts
@@ -109,42 +109,44 @@ export const SUPERVISOR_CONFIG_VAR_PROPERTIES: {
 	},
 };
 
-export const HOST_CONFIG_VAR_PROPERTIES: {
-	[k: string]: JSONSchema6Definition;
-} = {
-	RESIN_HOST_CONFIG_disable_splash: {
-		enum: ['0', '1'],
-		description: 'Enable / Disable the rainbow splash screen',
-		default: '1',
+export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
+	capableDeviceTypes: string[];
+	properties: Dictionary<JSONSchema6Definition>;
+}> = [
+	{
+		capableDeviceTypes: [
+			'raspberry-pi',
+			'raspberry-pi2',
+			'raspberrypi3-64',
+			'raspberrypi3',
+			'raspberrypi4-64',
+			'fincm3',
+			'revpi-core-3',
+			'npe-x500-m3',
+		],
+		properties: {
+			RESIN_HOST_CONFIG_disable_splash: {
+				enum: ['0', '1'],
+				description: 'Enable / Disable the rainbow splash screen',
+				default: '1',
+			},
+			RESIN_HOST_CONFIG_dtparam: {
+				type: 'string',
+				description: 'Define DT parameters',
+				default: '"i2c_arm=on","spi=on","audio=on"',
+			},
+			RESIN_HOST_CONFIG_enable_uart: {
+				enum: ['0', '1'],
+				description: 'Enable / Disable UART',
+				default: '1',
+			},
+			RESIN_HOST_CONFIG_gpu_mem: {
+				type: 'integer',
+				description: 'Define device GPU memory in megabytes.',
+				default: 16,
+			},
+		},
 	},
-	RESIN_HOST_CONFIG_dtparam: {
-		type: 'string',
-		description: 'Define DT parameters',
-		default: '"i2c_arm=on","spi=on","audio=on"',
-	},
-	RESIN_HOST_CONFIG_enable_uart: {
-		enum: ['0', '1'],
-		description: 'Enable / Disable UART',
-		default: '1',
-	},
-	RESIN_HOST_CONFIG_gpu_mem: {
-		type: 'integer',
-		description: 'Define device GPU memory in megabytes.',
-		default: 16,
-	},
-};
-
-// the namespace RESIN_HOST_CONFIG_ is only applicable for raspberrypis
-// as it supports the config.txt file
-export const RESIN_HOST_CONFIG_CAPABLE_DEVICE_TYPES = [
-	'raspberry-pi',
-	'raspberry-pi2',
-	'raspberrypi3-64',
-	'raspberrypi3',
-	'raspberrypi4-64',
-	'fincm3',
-	'revpi-core-3',
-	'npe-x500-m3',
 ];
 
 const startsWithAny = (ns: string[], name: string) => {

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -4,11 +4,10 @@ import * as _ from 'lodash';
 
 import {
 	BLACKLISTED_NAMES,
-	HOST_CONFIG_VAR_PROPERTIES,
+	DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES,
 	INVALID_CHARACTER_REGEX,
 	RESERVED_NAMES,
 	RESERVED_NAMESPACES,
-	RESIN_HOST_CONFIG_CAPABLE_DEVICE_TYPES,
 	SUPERVISOR_CONFIG_VAR_PROPERTIES,
 	WHITELISTED_NAMES,
 	WHITELISTED_NAMESPACES,
@@ -21,13 +20,13 @@ export const vars: RequestHandler = (req, res) => {
 	const schema: JSONSchema6 = {
 		type: 'object',
 		$schema: 'http://json-schema.org/draft-06/schema#',
-		properties: {
-			...SUPERVISOR_CONFIG_VAR_PROPERTIES,
-
-			...(RESIN_HOST_CONFIG_CAPABLE_DEVICE_TYPES.includes(req.query.deviceType)
-				? HOST_CONFIG_VAR_PROPERTIES
-				: {}),
-		},
+		properties: Object.assign(
+			{},
+			SUPERVISOR_CONFIG_VAR_PROPERTIES,
+			...DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES.filter(config =>
+				config.capableDeviceTypes.includes(req.query.deviceType),
+			).map(config => config.properties),
+		),
 	};
 
 	const varsConfig = {

--- a/test/01-basic.ts
+++ b/test/01-basic.ts
@@ -4,6 +4,109 @@ import { app } from '../init';
 
 import { supertest } from './test-lib/supertest';
 
+const checkBaseVarsResult = (
+	vars: AnyObject,
+	extraConfigVarSchemaProperties: string[] = [],
+) => {
+	expect(vars).to.be.an('object');
+	expect(vars)
+		.to.have.property('reservedNames')
+		.that.is.an('array');
+	expect(vars)
+		.to.have.property('reservedNamespaces')
+		.that.is.an('array');
+	expect(vars)
+		.to.have.property('whiteListedNames')
+		.that.is.an('array');
+	expect(vars)
+		.to.have.property('whiteListedNamespaces')
+		.that.is.an('array');
+	expect(vars)
+		.to.have.property('blackListedNames')
+		.that.is.an('array');
+
+	expect(vars.reservedNames.sort()).to.deep.equal(['BALENA', 'RESIN', 'USER']);
+
+	expect(vars.reservedNamespaces.sort()).to.deep.equal(['BALENA_', 'RESIN_']);
+
+	expect(vars.whiteListedNames.sort()).to.deep.equal([
+		'BALENA_APP_RESTART_POLICY',
+		'BALENA_APP_RESTART_RETRIES',
+		'BALENA_DEPENDENT_DEVICES_HOOK_ADDRESS',
+		'BALENA_SUPERVISOR_CONNECTIVITY_CHECK',
+		'BALENA_SUPERVISOR_HANDOVER_TIMEOUT',
+		'BALENA_SUPERVISOR_INSTANT_UPDATE_TRIGGER',
+		'BALENA_SUPERVISOR_LOCAL_MODE',
+		'BALENA_SUPERVISOR_LOG_CONTROL',
+		'BALENA_SUPERVISOR_PERSISTENT_LOGGING',
+		'BALENA_SUPERVISOR_POLL_INTERVAL',
+		'BALENA_SUPERVISOR_UPDATE_STRATEGY',
+		'BALENA_SUPERVISOR_VPN_CONTROL',
+		'RESIN_APP_RESTART_POLICY',
+		'RESIN_APP_RESTART_RETRIES',
+		'RESIN_DEPENDENT_DEVICES_HOOK_ADDRESS',
+		'RESIN_SUPERVISOR_CONNECTIVITY_CHECK',
+		'RESIN_SUPERVISOR_HANDOVER_TIMEOUT',
+		'RESIN_SUPERVISOR_INSTANT_UPDATE_TRIGGER',
+		'RESIN_SUPERVISOR_LOCAL_MODE',
+		'RESIN_SUPERVISOR_LOG_CONTROL',
+		'RESIN_SUPERVISOR_PERSISTENT_LOGGING',
+		'RESIN_SUPERVISOR_POLL_INTERVAL',
+		'RESIN_SUPERVISOR_UPDATE_STRATEGY',
+		'RESIN_SUPERVISOR_VPN_CONTROL',
+	]);
+
+	expect(vars.whiteListedNamespaces.sort()).to.deep.equal([
+		'BALENA_HOST_',
+		'BALENA_UI_',
+		'RESIN_HOST_',
+		'RESIN_UI_',
+	]);
+
+	expect(vars.blackListedNames.sort()).to.deep.equal([
+		'BALENA_DEVICE_RESTART',
+		'BALENA_HOST_LOG_TO_DISPLAY',
+		'BALENA_OVERRIDE_LOCK',
+		'BALENA_RESTART',
+		'BALENA_SUPERVISOR_NATIVE_LOGGER',
+		'BALENA_SUPERVISOR_OVERRIDE_LOCK',
+		'RESIN_DEVICE_RESTART',
+		'RESIN_HOST_LOG_TO_DISPLAY',
+		'RESIN_OVERRIDE_LOCK',
+		'RESIN_RESTART',
+		'RESIN_SUPERVISOR_NATIVE_LOGGER',
+		'RESIN_SUPERVISOR_OVERRIDE_LOCK',
+	]);
+
+	expect(vars)
+		.to.have.property('configVarSchema')
+		.that.is.an('object');
+
+	const { configVarSchema } = vars;
+
+	expect(configVarSchema).to.have.property('type', 'object');
+	expect(configVarSchema).to.have.property(
+		'$schema',
+		'http://json-schema.org/draft-06/schema#',
+	);
+	expect(configVarSchema)
+		.to.have.property('properties')
+		.that.is.an('object');
+
+	const configVarSchemaKeys = Object.keys(configVarSchema.properties).sort();
+	expect(configVarSchemaKeys).to.deep.equal(
+		[
+			'RESIN_SUPERVISOR_CONNECTIVITY_CHECK',
+			'RESIN_SUPERVISOR_INSTANT_UPDATE_TRIGGER',
+			'RESIN_SUPERVISOR_LOG_CONTROL',
+			'RESIN_SUPERVISOR_PERSISTENT_LOGGING',
+			'RESIN_SUPERVISOR_POLL_INTERVAL',
+			'RESIN_SUPERVISOR_VPN_CONTROL',
+			...extraConfigVarSchemaProperties,
+		].sort(),
+	);
+};
+
 describe('Basic', () => {
 	it('check /ping route is OK', async () => {
 		const res = await supertest(app)
@@ -12,87 +115,34 @@ describe('Basic', () => {
 		expect(res.text).to.equal('OK');
 	});
 
-	it('check /config/vars are correct', () => {
-		return supertest(app)
-			.get('/config/vars')
-			.expect(200)
-			.expect(res => {
-				expect(res.body).to.be.an('object');
-				expect(res.body)
-					.to.have.property('reservedNames')
-					.that.is.an('array');
-				expect(res.body)
-					.to.have.property('reservedNamespaces')
-					.that.is.an('array');
-				expect(res.body)
-					.to.have.property('whiteListedNames')
-					.that.is.an('array');
-				expect(res.body)
-					.to.have.property('whiteListedNamespaces')
-					.that.is.an('array');
-				expect(res.body)
-					.to.have.property('blackListedNames')
-					.that.is.an('array');
+	describe('/config/vars', function() {
+		it('should be correct when no device type is provided', async () => {
+			const { body: vars } = await supertest(app)
+				.get('/config/vars')
+				.expect(200);
 
-				expect(res.body.reservedNames.sort()).to.deep.equal([
-					'BALENA',
-					'RESIN',
-					'USER',
-				]);
+			checkBaseVarsResult(vars);
+		});
 
-				expect(res.body.reservedNamespaces.sort()).to.deep.equal([
-					'BALENA_',
-					'RESIN_',
-				]);
+		[
+			{ deviceType: 'beaglebone-black' },
+			{
+				deviceType: 'fincm3',
+				extraConfigVarSchemaProperties: [
+					'RESIN_HOST_CONFIG_disable_splash',
+					'RESIN_HOST_CONFIG_dtparam',
+					'RESIN_HOST_CONFIG_enable_uart',
+					'RESIN_HOST_CONFIG_gpu_mem',
+				],
+			},
+		].forEach(({ deviceType, extraConfigVarSchemaProperties }) => {
+			it(`should be correct when device type ${deviceType} is specified`, async () => {
+				const { body: vars } = await supertest(app)
+					.get(`/config/vars?deviceType=${deviceType}`)
+					.expect(200);
 
-				expect(res.body.whiteListedNames.sort()).to.deep.equal([
-					'BALENA_APP_RESTART_POLICY',
-					'BALENA_APP_RESTART_RETRIES',
-					'BALENA_DEPENDENT_DEVICES_HOOK_ADDRESS',
-					'BALENA_SUPERVISOR_CONNECTIVITY_CHECK',
-					'BALENA_SUPERVISOR_HANDOVER_TIMEOUT',
-					'BALENA_SUPERVISOR_INSTANT_UPDATE_TRIGGER',
-					'BALENA_SUPERVISOR_LOCAL_MODE',
-					'BALENA_SUPERVISOR_LOG_CONTROL',
-					'BALENA_SUPERVISOR_PERSISTENT_LOGGING',
-					'BALENA_SUPERVISOR_POLL_INTERVAL',
-					'BALENA_SUPERVISOR_UPDATE_STRATEGY',
-					'BALENA_SUPERVISOR_VPN_CONTROL',
-					'RESIN_APP_RESTART_POLICY',
-					'RESIN_APP_RESTART_RETRIES',
-					'RESIN_DEPENDENT_DEVICES_HOOK_ADDRESS',
-					'RESIN_SUPERVISOR_CONNECTIVITY_CHECK',
-					'RESIN_SUPERVISOR_HANDOVER_TIMEOUT',
-					'RESIN_SUPERVISOR_INSTANT_UPDATE_TRIGGER',
-					'RESIN_SUPERVISOR_LOCAL_MODE',
-					'RESIN_SUPERVISOR_LOG_CONTROL',
-					'RESIN_SUPERVISOR_PERSISTENT_LOGGING',
-					'RESIN_SUPERVISOR_POLL_INTERVAL',
-					'RESIN_SUPERVISOR_UPDATE_STRATEGY',
-					'RESIN_SUPERVISOR_VPN_CONTROL',
-				]);
-
-				expect(res.body.whiteListedNamespaces.sort()).to.deep.equal([
-					'BALENA_HOST_',
-					'BALENA_UI_',
-					'RESIN_HOST_',
-					'RESIN_UI_',
-				]);
-
-				expect(res.body.blackListedNames.sort()).to.deep.equal([
-					'BALENA_DEVICE_RESTART',
-					'BALENA_HOST_LOG_TO_DISPLAY',
-					'BALENA_OVERRIDE_LOCK',
-					'BALENA_RESTART',
-					'BALENA_SUPERVISOR_NATIVE_LOGGER',
-					'BALENA_SUPERVISOR_OVERRIDE_LOCK',
-					'RESIN_DEVICE_RESTART',
-					'RESIN_HOST_LOG_TO_DISPLAY',
-					'RESIN_OVERRIDE_LOCK',
-					'RESIN_RESTART',
-					'RESIN_SUPERVISOR_NATIVE_LOGGER',
-					'RESIN_SUPERVISOR_OVERRIDE_LOCK',
-				]);
+				checkBaseVarsResult(vars, extraConfigVarSchemaProperties);
 			});
+		});
 	});
 });


### PR DESCRIPTION
Gives us a more flexible way to define per device env var schemas, like in #304 #305 #306 

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>
