### PR TITLE
Cleanup imports and exports

### DIFF
--- a/src/abstract-sql-utils.ts
+++ b/src/abstract-sql-utils.ts
@@ -1,9 +1,9 @@
-import { Definition } from '@resin/odata-to-abstract-sql';
-
-import { AbstractSqlModel } from '@resin/abstract-sql-compiler';
-import { sbvrUtils } from '@resin/pinejs';
 import { readFileSync } from 'fs';
 import * as _ from 'lodash';
+
+import { AbstractSqlModel } from '@resin/abstract-sql-compiler';
+import { Definition } from '@resin/odata-to-abstract-sql';
+import { sbvrUtils } from '@resin/pinejs';
 
 export const generateAbstractSqlModel = (
 	seModelPath: string,

--- a/src/balena.ts
+++ b/src/balena.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+
 import {
 	aliasTable,
 	generateAbstractSqlModel,

--- a/src/balena.ts
+++ b/src/balena.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash';
-
 import {
 	aliasTable,
 	generateAbstractSqlModel,

--- a/src/hooks/common.ts
+++ b/src/hooks/common.ts
@@ -1,6 +1,8 @@
 import { sbvrUtils } from '@resin/pinejs';
-import * as deviceTypes from '../lib/device-types';
+
 import { PinejsClient } from '../platform';
+
+import * as deviceTypes from '../lib/device-types';
 
 export const resolveDeviceType = async (
 	api: PinejsClient,

--- a/src/hooks/common.ts
+++ b/src/hooks/common.ts
@@ -1,11 +1,9 @@
 import { sbvrUtils } from '@resin/pinejs';
 
-import { PinejsClient } from '../platform';
-
 import * as deviceTypes from '../lib/device-types';
 
 export const resolveDeviceType = async (
-	api: PinejsClient,
+	api: sbvrUtils.PinejsClient,
 	request: sbvrUtils.HookRequest,
 	fkValue: string,
 ): Promise<deviceTypes.DeviceType> => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 import { sbvrUtils } from '@resin/pinejs';
+
 import { retrieveAPIKey } from '../platform/api-keys';
 
 sbvrUtils.addPureHook('all', 'all', 'all', {

--- a/src/hooks/resources/api_key.ts
+++ b/src/hooks/resources/api_key.ts
@@ -1,7 +1,8 @@
-import { sbvrUtils } from '@resin/pinejs';
-import { getCurrentRequestAffectedIds } from '../../platform';
-
 import * as Bluebird from 'bluebird';
+
+import { sbvrUtils } from '@resin/pinejs';
+
+import { getCurrentRequestAffectedIds } from '../../platform';
 import { captureException } from '../../platform/errors';
 
 const { root, api } = sbvrUtils;

--- a/src/hooks/resources/application.ts
+++ b/src/hooks/resources/application.ts
@@ -1,18 +1,20 @@
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 
-import { Default as DefaultApplicationType } from '../../lib/application-types';
-import { postDevices } from '../../lib/device-proxy';
-import { resolveDeviceType } from '../common';
-
 import { sbvrUtils } from '@resin/pinejs';
+
 import {
 	addDeleteHookForDependents,
 	createActor,
 	getCurrentRequestAffectedIds,
 } from '../../platform';
-const { BadRequestError, ConflictError, NotFoundError, root } = sbvrUtils;
 import { captureException } from '../../platform/errors';
+
+import { Default as DefaultApplicationType } from '../../lib/application-types';
+import { postDevices } from '../../lib/device-proxy';
+import { resolveDeviceType } from '../common';
+
+const { BadRequestError, ConflictError, NotFoundError, root } = sbvrUtils;
 
 const checkDependentApplication: sbvrUtils.Hooks['POSTPARSE'] = async ({
 	request,

--- a/src/hooks/resources/application.ts
+++ b/src/hooks/resources/application.ts
@@ -1,5 +1,4 @@
 import * as Bluebird from 'bluebird';
-import * as _ from 'lodash';
 
 import { sbvrUtils } from '@resin/pinejs';
 

--- a/src/hooks/resources/device.ts
+++ b/src/hooks/resources/device.ts
@@ -8,7 +8,6 @@ import {
 	addDeleteHookForDependents,
 	createActor,
 	getCurrentRequestAffectedIds,
-	PinejsClient,
 } from '../../platform';
 
 import {
@@ -30,7 +29,7 @@ export const isDeviceNameValid = (name: string) => {
 };
 
 const createReleaseServiceInstalls = (
-	api: PinejsClient,
+	api: sbvrUtils.PinejsClient,
 	deviceId: number,
 	releaseFilter: PinejsClientCoreFactory.Filter,
 ): Bluebird<void> =>
@@ -94,7 +93,7 @@ const createReleaseServiceInstalls = (
 		.return();
 
 const createAppServiceInstalls = (
-	api: PinejsClient,
+	api: sbvrUtils.PinejsClient,
 	appId: number,
 	deviceIds: number[],
 ): Bluebird<void> =>
@@ -527,7 +526,7 @@ addDeleteHookForDependents('device', [
 ]);
 
 async function checkSupervisorReleaseUpgrades(
-	api: PinejsClient,
+	api: sbvrUtils.PinejsClient,
 	deviceIds: number[],
 	newSupervisorReleaseId: number,
 ) {

--- a/src/hooks/resources/device.ts
+++ b/src/hooks/resources/device.ts
@@ -1,6 +1,5 @@
 import * as balenaSemver from 'balena-semver';
 import * as Bluebird from 'bluebird';
-import * as _ from 'lodash';
 
 import { sbvrUtils } from '@resin/pinejs';
 import { PinejsClientCoreFactory } from 'pinejs-client-core';

--- a/src/hooks/resources/device.ts
+++ b/src/hooks/resources/device.ts
@@ -2,27 +2,27 @@ import * as balenaSemver from 'balena-semver';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 
-import {
-	checkDevicesCanBeInApplication,
-	checkDevicesCanHaveDeviceURL,
-} from '../../lib/application-types';
-
-import { postDevices } from '../../lib/device-proxy';
-import * as haikuName from '../../lib/haiku-name';
-
 import { sbvrUtils } from '@resin/pinejs';
+import { PinejsClientCoreFactory } from 'pinejs-client-core';
+
 import {
 	addDeleteHookForDependents,
 	createActor,
 	getCurrentRequestAffectedIds,
 	PinejsClient,
 } from '../../platform';
-const { BadRequestError, root } = sbvrUtils;
+
+import {
+	checkDevicesCanBeInApplication,
+	checkDevicesCanHaveDeviceURL,
+} from '../../lib/application-types';
+import { postDevices } from '../../lib/device-proxy';
 import { InaccessibleAppError } from '../../lib/errors';
+import * as haikuName from '../../lib/haiku-name';
+import { pseudoRandomBytesAsync } from '../../lib/utils';
 import { resolveDeviceType } from '../common';
 
-import { PinejsClientCoreFactory } from 'pinejs-client-core';
-import { pseudoRandomBytesAsync } from '../../lib/utils';
+const { BadRequestError, root } = sbvrUtils;
 
 const INVALID_NEWLINE_REGEX = /\r|\n/;
 

--- a/src/hooks/resources/device.ts
+++ b/src/hooks/resources/device.ts
@@ -1,4 +1,4 @@
-import * as balenaSemver from 'balena-semver';
+import * as semver from 'balena-semver';
 import * as Bluebird from 'bluebird';
 
 import { sbvrUtils } from '@resin/pinejs';
@@ -570,7 +570,7 @@ async function checkSupervisorReleaseUpgrades(
 
 	for (const release of releases) {
 		const oldVersion = release.supervisor_version;
-		if (balenaSemver.lt(newSupervisorVersion, oldVersion)) {
+		if (semver.lt(newSupervisorVersion, oldVersion)) {
 			throw new BadRequestError(
 				`Attempt to downgrade supervisor, which is not allowed`,
 			);

--- a/src/hooks/resources/envvars.ts
+++ b/src/hooks/resources/envvars.ts
@@ -1,14 +1,17 @@
-import { sbvrUtils } from '@resin/pinejs';
 import * as _ from 'lodash';
+
+import { sbvrUtils } from '@resin/pinejs';
 import { PinejsClientCoreFactory } from 'pinejs-client-core';
+
+import { getCurrentRequestAffectedIds, Tx } from '../../platform';
+import { captureException } from '../../platform/errors';
+
 import { postDevices } from '../../lib/device-proxy';
 import {
 	checkConfigVarNameValidity,
 	checkEnvVarNameValidity,
 	checkEnvVarValueValidity,
 } from '../../lib/env-vars';
-import { getCurrentRequestAffectedIds, Tx } from '../../platform';
-import { captureException } from '../../platform/errors';
 
 type ValidateFn = (varName?: string, varValue?: string) => void;
 

--- a/src/hooks/resources/envvars.ts
+++ b/src/hooks/resources/envvars.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash';
-
 import { sbvrUtils } from '@resin/pinejs';
 import { PinejsClientCoreFactory } from 'pinejs-client-core';
 

--- a/src/hooks/resources/envvars.ts
+++ b/src/hooks/resources/envvars.ts
@@ -1,7 +1,8 @@
 import { sbvrUtils } from '@resin/pinejs';
+import { Tx } from '@resin/pinejs/out/database-layer/db';
 import { PinejsClientCoreFactory } from 'pinejs-client-core';
 
-import { getCurrentRequestAffectedIds, Tx } from '../../platform';
+import { getCurrentRequestAffectedIds } from '../../platform';
 import { captureException } from '../../platform/errors';
 
 import { postDevices } from '../../lib/device-proxy';

--- a/src/hooks/resources/image.ts
+++ b/src/hooks/resources/image.ts
@@ -1,7 +1,9 @@
 import { sbvrUtils } from '@resin/pinejs';
+
+import { addDeleteHookForDependents } from '../../platform';
+
 import { REGISTRY2_HOST } from '../../lib/config';
 import { pseudoRandomBytesAsync } from '../../lib/utils';
-import { addDeleteHookForDependents } from '../../platform';
 
 const { InternalRequestError, root } = sbvrUtils;
 

--- a/src/hooks/resources/release.ts
+++ b/src/hooks/resources/release.ts
@@ -1,6 +1,8 @@
-import { sbvrUtils } from '@resin/pinejs';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import { addDeleteHookForDependents } from '../../platform';
 
 const updateLatestRelease = async (

--- a/src/hooks/resources/service_instance.ts
+++ b/src/hooks/resources/service_instance.ts
@@ -1,5 +1,7 @@
-import { sbvrUtils } from '@resin/pinejs';
 import { Request } from 'express';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import { getServiceFromRequest } from '../../lib/auth';
 import { getIP } from '../../lib/utils';
 

--- a/src/hooks/resources/tags.ts
+++ b/src/hooks/resources/tags.ts
@@ -1,5 +1,7 @@
-import { sbvrUtils } from '@resin/pinejs';
 import * as _ from 'lodash';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import { checkTagKeyValidity } from '../../lib/tags';
 
 // Tag hooks

--- a/src/hooks/resources/tags.ts
+++ b/src/hooks/resources/tags.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash';
-
 import { sbvrUtils } from '@resin/pinejs';
 
 import { checkTagKeyValidity } from '../../lib/tags';

--- a/src/hooks/resources/user.ts
+++ b/src/hooks/resources/user.ts
@@ -1,12 +1,12 @@
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 
-import { captureException } from '../../platform/errors';
-import { assignUserRole } from '../../platform/permissions';
-
 import { sbvrUtils } from '@resin/pinejs';
+
 import { createActor } from '../../platform';
 import { getUser } from '../../platform/auth';
+import { captureException } from '../../platform/errors';
+import { assignUserRole } from '../../platform/permissions';
 
 const { root, api, BadRequestError, InternalRequestError } = sbvrUtils;
 

--- a/src/hooks/resources/user.ts
+++ b/src/hooks/resources/user.ts
@@ -1,5 +1,4 @@
 import * as Bluebird from 'bluebird';
-import * as _ from 'lodash';
 
 import { sbvrUtils } from '@resin/pinejs';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,15 @@
-import { Server } from 'http';
-import * as path from 'path';
-
-import * as _express from 'express';
-import * as _ from 'lodash';
-
 import * as Bluebird from 'bluebird';
-import * as Raven from 'raven';
-
 import * as bodyParser from 'body-parser';
 import * as compression from 'compression';
 import * as cookieParser from 'cookie-parser';
+import cookieSession = require('cookie-session');
+import * as _express from 'express';
+import { Server } from 'http';
+import * as _ from 'lodash';
 import * as methodOverride from 'method-override';
 import * as passport from 'passport';
-
-import cookieSession = require('cookie-session');
+import * as path from 'path';
+import * as Raven from 'raven';
 
 import * as pine from '@resin/pinejs';
 import * as pineEnv from '@resin/pinejs/out/config-loader/env';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as bodyParser from 'body-parser';
 import * as compression from 'compression';
 import * as cookieParser from 'cookie-parser';
 import cookieSession = require('cookie-session');
-import * as _express from 'express';
+import * as express from 'express';
 import { Server } from 'http';
 import * as _ from 'lodash';
 import * as methodOverride from 'method-override';
@@ -32,7 +32,7 @@ import * as _applicationRoutes from './routes/applications';
 export const AUTH_PATH = '/auth';
 
 export type SetupFunction = (
-	app: _express.Application,
+	app: express.Application,
 ) => void | PromiseLike<void>;
 
 export interface SetupOptions {
@@ -49,7 +49,7 @@ export interface SetupOptions {
 	onLogin?: (user: AnyObject) => PromiseLike<void> | void;
 }
 
-export async function setup(app: _express.Application, options: SetupOptions) {
+export async function setup(app: express.Application, options: SetupOptions) {
 	if (DB_POOL_SIZE != null) {
 		pineEnv.db.poolSize = DB_POOL_SIZE;
 	}
@@ -141,7 +141,7 @@ export async function setup(app: _express.Application, options: SetupOptions) {
 	};
 }
 
-function fixProtocolMiddleware(skipUrls: string[] = []): _express.Handler {
+function fixProtocolMiddleware(skipUrls: string[] = []): express.Handler {
 	return (req, res, next) => {
 		if (req.protocol === 'https' || skipUrls.includes(req.url)) {
 			return next();
@@ -150,7 +150,7 @@ function fixProtocolMiddleware(skipUrls: string[] = []): _express.Handler {
 	};
 }
 
-function setupMiddleware(app: _express.Application) {
+function setupMiddleware(app: express.Application) {
 	app.use(compression());
 	app.use(AUTH_PATH, cookieParser());
 
@@ -186,7 +186,7 @@ function setupMiddleware(app: _express.Application) {
 }
 
 async function startServer(
-	app: _express.Application,
+	app: express.Application,
 	port: string | number,
 ): Promise<Server> {
 	let server: Server;
@@ -198,7 +198,7 @@ async function startServer(
 }
 
 async function runCommand(
-	app: _express.Application,
+	app: express.Application,
 	cmd: string,
 	argv: string[],
 ): Promise<void> {
@@ -207,7 +207,7 @@ async function runCommand(
 	process.exit(0);
 }
 
-function runFromCommandLine(app: _express.Application): Promise<void> {
+function runFromCommandLine(app: express.Application): Promise<void> {
 	const cmd = process.argv[2];
 	const args = process.argv.slice(3);
 	return runCommand(app, cmd, args);

--- a/src/lib/application-types.ts
+++ b/src/lib/application-types.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 
 import { sbvrUtils } from '@resin/pinejs';
-import * as resinSemver from 'balena-semver';
+import * as semver from 'balena-semver';
 
 export interface ApplicationType {
 	id?: number;
@@ -137,7 +137,7 @@ export const checkDevicesCanBeInApplication = async (
 		}
 		if (
 			device.os_version != null &&
-			!resinSemver.satisfies(device.os_version, appType.needs__os_version_range)
+			!semver.satisfies(device.os_version, appType.needs__os_version_range)
 		) {
 			throw new DeviceOSVersionIsTooLow(
 				`Device ${device.device_name} has OS version ${device.os_version} but needs to satisfy version range: ${appType.needs__os_version_range}`,

--- a/src/lib/application-types.ts
+++ b/src/lib/application-types.ts
@@ -1,7 +1,7 @@
-import * as resinSemver from 'balena-semver';
 import * as _ from 'lodash';
 
 import { sbvrUtils } from '@resin/pinejs';
+import * as resinSemver from 'balena-semver';
 
 export interface ApplicationType {
 	id?: number;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@
 //
 
 import { sbvrUtils } from '@resin/pinejs';
+
 import {
 	API_VPN_SERVICE_API_KEY,
 	VPN_GUEST_API_KEY,

--- a/src/lib/certs.ts
+++ b/src/lib/certs.ts
@@ -1,4 +1,5 @@
 import * as jsonwebtoken from 'jsonwebtoken';
+
 import {
 	TOKEN_AUTH_CERT_ISSUER,
 	TOKEN_AUTH_CERT_KEY,

--- a/src/lib/device-config.ts
+++ b/src/lib/device-config.ts
@@ -1,18 +1,17 @@
-import * as _ from 'lodash';
-
+import { Request } from 'express';
 import * as fs from 'fs';
-
-import * as resinSemver from 'balena-semver';
-import * as deviceConfig from 'resin-device-config';
-
-import { DeviceType } from './device-types';
+import * as _ from 'lodash';
 
 import { Option as DeviceTypeOption } from '@resin.io/device-types';
 import { sbvrUtils } from '@resin/pinejs';
-import { Request } from 'express';
+import * as resinSemver from 'balena-semver';
+import * as deviceConfig from 'resin-device-config';
+
 import { getUser } from '../platform/auth';
 import { captureException } from '../platform/errors';
+
 import { createProvisioningApiKey, createUserApiKey } from './api-keys';
+import { DeviceType } from './device-types';
 
 const { BadRequestError } = sbvrUtils;
 

--- a/src/lib/device-config.ts
+++ b/src/lib/device-config.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 
 import { Option as DeviceTypeOption } from '@resin.io/device-types';
 import { sbvrUtils } from '@resin/pinejs';
-import * as resinSemver from 'balena-semver';
+import * as semver from 'balena-semver';
 import * as deviceConfig from 'resin-device-config';
 
 import { getUser } from '../platform/auth';
@@ -35,7 +35,7 @@ export const generateConfig = async (
 	const userPromise = getUser(req);
 
 	// Devices running ResinOS >=1.2.1 are capable of using Registry v2, while earlier ones must use v1
-	if (resinSemver.lte(osVersion, '1.2.0')) {
+	if (semver.lte(osVersion, '1.2.0')) {
 		throw new BadRequestError(
 			'balenaOS versions <= 1.2.0 are no longer supported, please update',
 		);
@@ -44,7 +44,7 @@ export const generateConfig = async (
 
 	const apiKeyPromise = (async () => {
 		// Devices running ResinOS >= 2.7.8 can use provisioning keys
-		if (resinSemver.satisfies(osVersion, '<2.7.8')) {
+		if (semver.satisfies(osVersion, '<2.7.8')) {
 			// Older ones have to use the old "user api keys"
 			return createUserApiKey(req, (await userPromise).id);
 		}

--- a/src/lib/device-logs/backends/redis.ts
+++ b/src/lib/device-logs/backends/redis.ts
@@ -1,10 +1,13 @@
-import { sbvrUtils } from '@resin/pinejs';
 import * as avro from 'avsc';
 import * as Bluebird from 'bluebird';
 import { EventEmitter } from 'events';
 import * as _ from 'lodash';
 import * as redis from 'redis';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import { captureException } from '../../../platform/errors';
+
 import { DAYS, MINUTES, REDIS_HOST, REDIS_PORT } from '../../config';
 import {
 	DeviceLog,

--- a/src/lib/device-logs/supervisor.ts
+++ b/src/lib/device-logs/supervisor.ts
@@ -1,5 +1,7 @@
-import { sbvrUtils } from '@resin/pinejs';
 import * as _ from 'lodash';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import {
 	AnySupervisorLog,
 	DeviceLog,

--- a/src/lib/device-online-state.ts
+++ b/src/lib/device-online-state.ts
@@ -1,9 +1,12 @@
-import { sbvrUtils } from '@resin/pinejs';
 import * as Bluebird from 'bluebird';
 import * as events from 'eventemitter3';
 import * as _ from 'lodash';
 import * as RedisSMQ from 'rsmq';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import { captureException } from '../platform/errors';
+
 import {
 	API_HEARTBEAT_STATE_ENABLED,
 	API_HEARTBEAT_STATE_TIMEOUT_SECONDS,

--- a/src/lib/device-proxy.ts
+++ b/src/lib/device-proxy.ts
@@ -1,20 +1,20 @@
 import * as Bluebird from 'bluebird';
+import { Request, Response } from 'express';
 import * as _ from 'lodash';
 
-import { NoDevicesFoundError } from '../lib/errors';
+import { sbvrUtils } from '@resin/pinejs';
+import { PinejsClientCoreFactory } from 'pinejs-client-core';
+
 import {
 	captureException,
 	handleHttpErrors,
 	translateError,
 } from '../platform/errors';
 
-import { sbvrUtils } from '@resin/pinejs';
-import { Request, Response } from 'express';
-import { PinejsClientCoreFactory } from 'pinejs-client-core';
-import { checkInt } from './utils';
-
+import { NoDevicesFoundError } from '../lib/errors';
 import { API_VPN_SERVICE_API_KEY, VPN_CONNECT_PROXY_PORT } from './config';
 import { requestAsync, RequestResponse } from './request';
+import { checkInt } from './utils';
 
 // Degraded network, slow devices, compressed docker binaries and any combination of these factors
 // can cause proxied device requests to surpass the default timeout.

--- a/src/lib/device-state.ts
+++ b/src/lib/device-state.ts
@@ -1,5 +1,6 @@
-import * as semver from 'balena-semver';
 import * as _ from 'lodash';
+
+import * as semver from 'balena-semver';
 
 import { DEFAULT_SUPERVISOR_POLL_INTERVAL } from './config';
 

--- a/src/lib/device-types/build-info-facade.ts
+++ b/src/lib/device-types/build-info-facade.ts
@@ -1,5 +1,7 @@
-import * as deviceTypesLib from '@resin.io/device-types';
 import * as memoizee from 'memoizee';
+
+import * as deviceTypesLib from '@resin.io/device-types';
+
 import { FILES_HOST } from '../config';
 import { fileExists, getFile, getFolderSize, getImageKey } from './storage';
 

--- a/src/lib/device-types/index.ts
+++ b/src/lib/device-types/index.ts
@@ -4,10 +4,10 @@ import * as _ from 'lodash';
 
 import * as deviceTypesLib from '@resin.io/device-types';
 import { sbvrUtils } from '@resin/pinejs';
+import { Tx } from '@resin/pinejs/out/database-layer/db';
 import * as semver from 'balena-semver';
 import { PinejsClientCoreFactory } from 'pinejs-client-core';
 
-import { PinejsClient, Tx } from '../../platform';
 import { captureException } from '../../platform/errors';
 
 import {
@@ -306,7 +306,7 @@ function getDeviceTypes(): Promise<Dictionary<DeviceTypeInfo>> {
  * @param slugs The slugs to check, these cannot be aliases.
  */
 const getAccessibleSlugs = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	slugs?: string[],
 ): Promise<string[]> => {
 	const options: PinejsClientCoreFactory.ODataOptions = {
@@ -325,7 +325,7 @@ const getAccessibleSlugs = async (
 };
 
 export const findDeviceTypeInfoBySlug = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	slug: string,
 ): Promise<DeviceTypeInfo> => {
 	const deviceTypeInfos = await getDeviceTypes();
@@ -354,7 +354,7 @@ export const validateSlug = (slug?: string) => {
 };
 
 export const getAccessibleDeviceTypes = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 ): Promise<DeviceType[]> => {
 	const [deviceTypesInfos, accessibleDeviceTypes] = await Promise.all([
 		getDeviceTypes(),
@@ -373,7 +373,7 @@ export const getAccessibleDeviceTypes = async (
 };
 
 export const findBySlug = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	slug: string,
 ): Promise<DeviceType> => {
 	const deviceTypes = await getAccessibleDeviceTypes(resinApi);
@@ -385,7 +385,7 @@ export const findBySlug = async (
 };
 
 export const normalizeDeviceType = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	slug: string,
 ): Promise<string> => {
 	if (SPECIAL_SLUGS.includes(slug)) {
@@ -404,7 +404,7 @@ export const normalizeDeviceType = async (
 };
 
 export const getImageSize = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	slug: string,
 	buildId: string,
 ): Promise<number> => {
@@ -446,7 +446,7 @@ export interface ImageVersions {
 }
 
 export const getDeviceTypeIdBySlug = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	slug: string,
 ): Promise<{ id: number; slug: string }> => {
 	const deviceType = await normalizeDeviceType(resinApi, slug);
@@ -465,7 +465,7 @@ export const getDeviceTypeIdBySlug = async (
 };
 
 export const getImageVersions = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	slug: string,
 ): Promise<ImageVersions> => {
 	const deviceTypeInfo = await findDeviceTypeInfoBySlug(resinApi, slug);

--- a/src/lib/device-types/index.ts
+++ b/src/lib/device-types/index.ts
@@ -1,12 +1,15 @@
-import * as deviceTypesLib from '@resin.io/device-types';
-import { sbvrUtils } from '@resin/pinejs';
 import * as arraySort from 'array-sort';
-import * as semver from 'balena-semver';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
+
+import * as deviceTypesLib from '@resin.io/device-types';
+import { sbvrUtils } from '@resin/pinejs';
+import * as semver from 'balena-semver';
 import { PinejsClientCoreFactory } from 'pinejs-client-core';
+
 import { PinejsClient, Tx } from '../../platform';
 import { captureException } from '../../platform/errors';
+
 import {
 	getCompressedSize,
 	getDeviceTypeJson,

--- a/src/lib/device-types/storage/s3.ts
+++ b/src/lib/device-types/storage/s3.ts
@@ -1,6 +1,7 @@
 import * as AWS from 'aws-sdk';
 import * as _ from 'lodash';
 import * as path from 'path';
+
 import {
 	IMAGE_STORAGE_ACCESS_KEY,
 	IMAGE_STORAGE_BUCKET as S3_BUCKET,

--- a/src/lib/env-vars.ts
+++ b/src/lib/env-vars.ts
@@ -1,6 +1,8 @@
-import { sbvrUtils } from '@resin/pinejs';
 import { JSONSchema6Definition } from 'json-schema';
 import * as _ from 'lodash';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import { DEFAULT_SUPERVISOR_POLL_INTERVAL } from './config';
 
 const { BadRequestError } = sbvrUtils;

--- a/src/lib/env-vars.ts
+++ b/src/lib/env-vars.ts
@@ -1,5 +1,4 @@
 import { JSONSchema6Definition } from 'json-schema';
-import * as _ from 'lodash';
 
 import { sbvrUtils } from '@resin/pinejs';
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,5 +1,6 @@
-import { sbvrUtils } from '@resin/pinejs';
 import { TypedError } from 'typed-error';
+
+import { sbvrUtils } from '@resin/pinejs';
 
 export const { NotFoundError } = sbvrUtils;
 

--- a/src/lib/rate-limiting.ts
+++ b/src/lib/rate-limiting.ts
@@ -1,5 +1,5 @@
 import { isMaster } from 'cluster';
-import * as _express from 'express';
+import * as express from 'express';
 import * as _ from 'lodash';
 import {
 	IRateLimiterOptions,
@@ -72,7 +72,7 @@ const getStore = (opts: IRateLimiterOptions) => {
 	});
 };
 
-export const getUserIDFromCreds = (req: _express.Request): string => {
+export const getUserIDFromCreds = (req: express.Request): string => {
 	if (req.creds != null && 'id' in req.creds) {
 		return `userID:${req.creds.id}`;
 	}
@@ -80,8 +80,8 @@ export const getUserIDFromCreds = (req: _express.Request): string => {
 };
 
 export type PartialRateLimitMiddleware = (
-	field?: string | ((req: _express.Request, res: _express.Response) => string),
-) => _express.RequestHandler;
+	field?: string | ((req: express.Request, res: express.Response) => string),
+) => express.RequestHandler;
 
 export const createRateLimitMiddleware = (
 	opts: IRateLimiterOptions,
@@ -106,9 +106,9 @@ const $createRateLimitMiddleware = (
 		ignoreIP = false,
 		allowReset = true,
 	}: { ignoreIP?: boolean; allowReset?: boolean } = {},
-	field?: string | ((req: _express.Request, res: _express.Response) => string),
-): _express.RequestHandler => {
-	let fieldFn: (req: _express.Request, res: _express.Response) => string;
+	field?: string | ((req: express.Request, res: express.Response) => string),
+): express.RequestHandler => {
+	let fieldFn: (req: express.Request, res: express.Response) => string;
 	if (field != null) {
 		if (_.isFunction(field)) {
 			fieldFn = field;
@@ -119,7 +119,7 @@ const $createRateLimitMiddleware = (
 	} else {
 		fieldFn = () => '';
 	}
-	let keyFn: (req: _express.Request, res: _express.Response) => string;
+	let keyFn: (req: express.Request, res: express.Response) => string;
 	if (ignoreIP) {
 		keyFn = fieldFn;
 	} else {
@@ -127,7 +127,7 @@ const $createRateLimitMiddleware = (
 	}
 	const addReset = !allowReset
 		? _.noop
-		: (req: _express.Request, key: string) => {
+		: (req: express.Request, key: string) => {
 				const resetRatelimit = req.resetRatelimit;
 				req.resetRatelimit = async () => {
 					try {

--- a/src/lib/rate-limiting.ts
+++ b/src/lib/rate-limiting.ts
@@ -1,4 +1,6 @@
+import { isMaster } from 'cluster';
 import * as _express from 'express';
+import * as _ from 'lodash';
 import {
 	IRateLimiterOptions,
 	RateLimiterAbstract,
@@ -9,10 +11,8 @@ import {
 } from 'rate-limiter-flexible';
 import * as redis from 'redis';
 
-import { isMaster } from 'cluster';
-
-import * as _ from 'lodash';
 import { captureException } from '../platform/errors';
+
 import {
 	RATE_LIMIT_FACTOR,
 	RATE_LIMIT_MEMORY_BACKEND,

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,5 +1,6 @@
 import * as Bluebird from 'bluebird';
 import * as request from 'request';
+
 import { EXTERNAL_HTTP_TIMEOUT_MS } from './config';
 
 type Request = typeof request;

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,5 +1,6 @@
-import { sbvrUtils } from '@resin/pinejs';
 import * as _ from 'lodash';
+
+import { sbvrUtils } from '@resin/pinejs';
 
 const RESERVED_NAMESPACES = ['io.resin.', 'io.balena.'];
 

--- a/src/platform/api-keys.ts
+++ b/src/platform/api-keys.ts
@@ -1,7 +1,9 @@
-import { sbvrUtils } from '@resin/pinejs';
 import { Request } from 'express';
 import * as _ from 'lodash';
 import * as randomstring from 'randomstring';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import { Tx } from './index';
 import { isJWT } from './jwt';
 

--- a/src/platform/api-keys.ts
+++ b/src/platform/api-keys.ts
@@ -3,8 +3,8 @@ import * as _ from 'lodash';
 import * as randomstring from 'randomstring';
 
 import { sbvrUtils } from '@resin/pinejs';
+import { Tx } from '@resin/pinejs/out/database-layer/db';
 
-import { Tx } from './index';
 import { isJWT } from './jwt';
 
 const { root, api } = sbvrUtils;

--- a/src/platform/auth.ts
+++ b/src/platform/auth.ts
@@ -1,13 +1,15 @@
-import { sbvrUtils } from '@resin/pinejs';
+import { Request, RequestHandler, Response } from 'express';
 import * as _ from 'lodash';
 import * as base32 from 'thirty-two';
-import { User as DbUser } from '../models';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import { retrieveAPIKey } from './api-keys';
 import { Tx } from './index';
 import { createJwt, SignOptions, User } from './jwt';
 
-import { Request, RequestHandler, Response } from 'express';
 import { getIP, pseudoRandomBytesAsync } from '../lib/utils';
+import { User as DbUser } from '../models';
 
 const {
 	BadRequestError,

--- a/src/platform/auth.ts
+++ b/src/platform/auth.ts
@@ -3,9 +3,9 @@ import * as _ from 'lodash';
 import * as base32 from 'thirty-two';
 
 import { sbvrUtils } from '@resin/pinejs';
+import { Tx } from '@resin/pinejs/out/database-layer/db';
 
 import { retrieveAPIKey } from './api-keys';
-import { Tx } from './index';
 import { createJwt, SignOptions, User } from './jwt';
 
 import { getIP, pseudoRandomBytesAsync } from '../lib/utils';

--- a/src/platform/errors.ts
+++ b/src/platform/errors.ts
@@ -1,8 +1,8 @@
+import { Request, Response } from 'express';
 import * as _ from 'lodash';
 import * as Raven from 'raven';
 
 import { sbvrUtils } from '@resin/pinejs';
-import { Request, Response } from 'express';
 
 const { InternalRequestError, HttpError } = sbvrUtils;
 

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -6,9 +6,6 @@ import { PinejsClientCoreFactory } from 'pinejs-client-core';
 
 import { captureException } from './errors';
 
-export type PinejsClient = sbvrUtils.PinejsClient;
-export { Tx } from '@resin/pinejs/out/database-layer/db';
-
 const { root } = sbvrUtils;
 
 if (sbvrUtils.db.readTransaction == null) {
@@ -47,7 +44,7 @@ const $getOrInsertId = async (
 // update it to the values specified in updateFields, otherwise
 // insert it with a combination of the filter and updateFields value
 const $updateOrInsert = async (
-	api: PinejsClient,
+	api: sbvrUtils.PinejsClient,
 	resource: string,
 	filter: PinejsClientCoreFactory.FilterObj,
 	updateFields: AnyObject,

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -1,15 +1,13 @@
 import * as _ from 'lodash';
 
-import { Tx } from '@resin/pinejs/out/database-layer/db';
-export { Tx } from '@resin/pinejs/out/database-layer/db';
-
 import { sbvrUtils } from '@resin/pinejs';
-
+import { Tx } from '@resin/pinejs/out/database-layer/db';
 import { PinejsClientCoreFactory } from 'pinejs-client-core';
 
 import { captureException } from './errors';
 
 export type PinejsClient = sbvrUtils.PinejsClient;
+export { Tx } from '@resin/pinejs/out/database-layer/db';
 
 const { root } = sbvrUtils;
 

--- a/src/platform/jwt.ts
+++ b/src/platform/jwt.ts
@@ -1,4 +1,3 @@
-import { sbvrUtils } from '@resin/pinejs';
 import * as Bluebird from 'bluebird';
 import { RequestHandler } from 'express';
 import * as jsonwebtoken from 'jsonwebtoken';
@@ -7,15 +6,18 @@ import * as passport from 'passport';
 import { ExtractJwt, Strategy as JwtStrategy } from 'passport-jwt';
 import * as randomstring from 'randomstring';
 import { TypedError } from 'typed-error';
-import { User as DbUser } from '../models';
-import { captureException } from './errors';
 
-export { SignOptions } from 'jsonwebtoken';
+import { sbvrUtils } from '@resin/pinejs';
 
 import {
 	JSON_WEB_TOKEN_EXPIRY_MINUTES,
 	JSON_WEB_TOKEN_SECRET,
 } from '../lib/config';
+import { User as DbUser } from '../models';
+
+import { captureException } from './errors';
+
+export { SignOptions } from 'jsonwebtoken';
 
 const EXPIRY_SECONDS = JSON_WEB_TOKEN_EXPIRY_MINUTES * 60;
 

--- a/src/platform/middleware.ts
+++ b/src/platform/middleware.ts
@@ -1,15 +1,16 @@
 import { RequestHandler } from 'express';
-import { API_HEARTBEAT_STATE_ENABLED } from '../lib/config';
-import { retrieveAPIKey } from './api-keys';
-import { getUser, reqHasPermission } from './auth';
+import * as _ from 'lodash';
 
 import { sbvrUtils } from '@resin/pinejs';
 
-const { root, api } = sbvrUtils;
-
-import * as _ from 'lodash';
-import * as DeviceOnlineState from '../lib/device-online-state';
+import { retrieveAPIKey } from './api-keys';
+import { getUser, reqHasPermission } from './auth';
 import { captureException } from './errors';
+
+import { API_HEARTBEAT_STATE_ENABLED } from '../lib/config';
+import * as DeviceOnlineState from '../lib/device-online-state';
+
+const { root, api } = sbvrUtils;
 
 export const authenticated: RequestHandler = async (req, res, next) => {
 	try {

--- a/src/platform/permissions.ts
+++ b/src/platform/permissions.ts
@@ -3,10 +3,11 @@ import * as _ from 'lodash';
 import * as randomstring from 'randomstring';
 
 import { sbvrUtils } from '@resin/pinejs';
+import { Tx } from '@resin/pinejs/out/database-layer/db';
 
 import { findUser } from './auth';
 import { captureException } from './errors';
-import { getOrInsertId, Tx } from './index';
+import { getOrInsertId } from './index';
 
 const { root, api } = sbvrUtils;
 

--- a/src/platform/permissions.ts
+++ b/src/platform/permissions.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import * as randomstring from 'randomstring';
 
 import { sbvrUtils } from '@resin/pinejs';
+
 import { findUser } from './auth';
 import { captureException } from './errors';
 import { getOrInsertId, Tx } from './index';

--- a/src/platform/versions.ts
+++ b/src/platform/versions.ts
@@ -1,8 +1,8 @@
-import * as _express from 'express';
+import * as express from 'express';
 import * as _ from 'lodash';
 
 export const forwardRequests = (
-	app: _express.Application,
+	app: express.Application,
 	fromVersion: string,
 	toVersion: string,
 ) => {

--- a/src/routes/access.ts
+++ b/src/routes/access.ts
@@ -1,7 +1,9 @@
-import { sbvrUtils } from '@resin/pinejs';
-import * as rSemver from 'balena-semver';
 import * as express from 'express';
 import * as _ from 'lodash';
+
+import { sbvrUtils } from '@resin/pinejs';
+import * as rSemver from 'balena-semver';
+
 import { reqHasPermission } from '../platform/auth';
 import { captureException } from '../platform/errors';
 

--- a/src/routes/access.ts
+++ b/src/routes/access.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import * as _ from 'lodash';
 
 import { sbvrUtils } from '@resin/pinejs';
-import * as rSemver from 'balena-semver';
+import * as semver from 'balena-semver';
 
 import { reqHasPermission } from '../platform/auth';
 import { captureException } from '../platform/errors';
@@ -77,7 +77,7 @@ export async function hostOSAccess(
 		// Users are allowed to access hostOS for devices with version >= HOSTOS_ACCESS_MIN_OS_VER or if the version is still unknown
 		if (
 			!device.os_version ||
-			rSemver.gte(device.os_version, HOSTOS_ACCESS_MIN_OS_VER)
+			semver.gte(device.os_version, HOSTOS_ACCESS_MIN_OS_VER)
 		) {
 			res.sendStatus(200);
 			return;

--- a/src/routes/api-keys.ts
+++ b/src/routes/api-keys.ts
@@ -1,17 +1,19 @@
 import { RequestHandler } from 'express';
 import * as _ from 'lodash';
-import {
-	createDeviceApiKey as $createDeviceApiKey,
-	createNamedUserApiKey as $createNamedUserApiKey,
-	createProvisioningApiKey as $createProvisioningApiKey,
-	createUserApiKey as $createUserApiKey,
-} from '../lib/api-keys';
+
 import { getUser } from '../platform/auth';
 import {
 	captureException,
 	handleHttpErrors,
 	translateError,
 } from '../platform/errors';
+
+import {
+	createDeviceApiKey as $createDeviceApiKey,
+	createNamedUserApiKey as $createNamedUserApiKey,
+	createProvisioningApiKey as $createProvisioningApiKey,
+	createUserApiKey as $createUserApiKey,
+} from '../lib/api-keys';
 
 export const createDeviceApiKey: RequestHandler = async (req, res) => {
 	const deviceId = _.parseInt(req.params.deviceId, 10);

--- a/src/routes/applications.ts
+++ b/src/routes/applications.ts
@@ -1,5 +1,4 @@
 import { Request, RequestHandler } from 'express';
-import * as _ from 'lodash';
 
 import { sbvrUtils } from '@resin/pinejs';
 

--- a/src/routes/applications.ts
+++ b/src/routes/applications.ts
@@ -1,15 +1,16 @@
+import { Request, RequestHandler } from 'express';
 import * as _ from 'lodash';
 
-import { generateConfig } from '../lib/device-config';
-import { findBySlug } from '../lib/device-types';
-
 import { sbvrUtils } from '@resin/pinejs';
-import { Request, RequestHandler } from 'express';
+
 import {
 	captureException,
 	handleHttpErrors,
 	translateError,
 } from '../platform/errors';
+
+import { generateConfig } from '../lib/device-config';
+import { findBySlug } from '../lib/device-types';
 
 const { UnauthorizedError, api } = sbvrUtils;
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express';
 
 import { sbvrUtils } from '@resin/pinejs';
+
 import { captureException, handleHttpErrors } from '../platform/errors';
 
 export const getUserPublicKeys: RequestHandler = async (req, res) => {

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -1,6 +1,5 @@
 import { RequestHandler } from 'express';
 import { JSONSchema6 } from 'json-schema';
-import * as _ from 'lodash';
 
 import {
 	BLACKLISTED_NAMES,

--- a/src/routes/device-logs.ts
+++ b/src/routes/device-logs.ts
@@ -1,11 +1,15 @@
 import { Request, RequestHandler, Response } from 'express';
 import * as _ from 'lodash';
 import * as ndjson from 'ndjson';
+import onFinished = require('on-finished');
 import { createGunzip } from 'zlib';
 
 import { sbvrUtils } from '@resin/pinejs';
 import { Resolvable } from '@resin/pinejs/out/sbvr-api/common-types';
-import onFinished = require('on-finished');
+
+import { PinejsClient } from '../platform';
+import { captureException, handleHttpErrors } from '../platform/errors';
+
 import { RedisBackend } from '../lib/device-logs/backends/redis';
 import {
 	AnySupervisorLog,
@@ -17,8 +21,6 @@ import {
 	SupervisorLog,
 } from '../lib/device-logs/struct';
 import { Supervisor } from '../lib/device-logs/supervisor';
-import { PinejsClient } from '../platform';
-import { captureException, handleHttpErrors } from '../platform/errors';
 
 const {
 	BadRequestError,

--- a/src/routes/device-logs.ts
+++ b/src/routes/device-logs.ts
@@ -7,7 +7,6 @@ import { createGunzip } from 'zlib';
 import { sbvrUtils } from '@resin/pinejs';
 import { Resolvable } from '@resin/pinejs/out/sbvr-api/common-types';
 
-import { PinejsClient } from '../platform';
 import { captureException, handleHttpErrors } from '../platform/errors';
 
 import { RedisBackend } from '../lib/device-logs/backends/redis';
@@ -329,7 +328,7 @@ function handleStreamingWrite(
 }
 
 async function getReadContext(
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	req: Request,
 ): Promise<LogContext> {
 	const { uuid } = req.params;
@@ -349,7 +348,7 @@ async function getReadContext(
 }
 
 async function getWriteContext(
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	req: Request,
 ): Promise<LogWriteContext> {
 	const { uuid } = req.params;
@@ -408,7 +407,7 @@ function addRetentionLimit(ctx: LogContext) {
 }
 
 async function checkWritePermissions(
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	ctx: LogWriteContext,
 ): Promise<void> {
 	const allowedDevices = (await resinApi.post({

--- a/src/routes/device-types.ts
+++ b/src/routes/device-types.ts
@@ -1,12 +1,15 @@
-import { sbvrUtils } from '@resin/pinejs';
 import { RequestHandler } from 'express';
 import * as _ from 'lodash';
-import * as deviceTypesLib from '../lib/device-types';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import {
 	captureException,
 	handleHttpErrors,
 	translateError,
 } from '../platform/errors';
+
+import * as deviceTypesLib from '../lib/device-types';
 
 const { api } = sbvrUtils;
 

--- a/src/routes/devices.ts
+++ b/src/routes/devices.ts
@@ -1,16 +1,18 @@
 import * as Bluebird from 'bluebird';
+import { RequestHandler } from 'express';
 import * as _ from 'lodash';
+import * as randomstring from 'randomstring';
 
+import { sbvrUtils } from '@resin/pinejs';
+import { PinejsClientCoreFactory } from 'pinejs-client-core';
+
+import { PinejsClient } from '../platform';
 import {
 	captureException,
 	handleHttpErrors,
 	translateError,
 } from '../platform/errors';
 
-import { sbvrUtils } from '@resin/pinejs';
-import { RequestHandler } from 'express';
-import { PinejsClientCoreFactory } from 'pinejs-client-core';
-import * as randomstring from 'randomstring';
 import { createDeviceApiKey } from '../lib/api-keys';
 import {
 	filterDeviceConfig,
@@ -20,8 +22,6 @@ import {
 	setMinPollInterval,
 } from '../lib/device-state';
 import { checkInt, getIP, isValidInteger, varListInsert } from '../lib/utils';
-import { PinejsClient } from '../platform';
-
 export { proxy } from '../lib/device-proxy';
 
 const { BadRequestError, UnauthorizedError, root, api } = sbvrUtils;

--- a/src/routes/devices.ts
+++ b/src/routes/devices.ts
@@ -6,7 +6,6 @@ import * as randomstring from 'randomstring';
 import { sbvrUtils } from '@resin/pinejs';
 import { PinejsClientCoreFactory } from 'pinejs-client-core';
 
-import { PinejsClient } from '../platform';
 import {
 	captureException,
 	handleHttpErrors,
@@ -611,7 +610,7 @@ export const state: RequestHandler = async (req, res) => {
 };
 
 const upsertImageInstall = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	imageId: number,
 	deviceId: number,
 	status: string,
@@ -667,7 +666,7 @@ const upsertImageInstall = async (
 };
 
 const upsertGatewayDownload = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	deviceId: number,
 	imageId: number,
 	status: string,
@@ -712,7 +711,7 @@ const upsertGatewayDownload = async (
 };
 
 const deleteOldGatewayDownloads = async (
-	resinApi: PinejsClient,
+	resinApi: sbvrUtils.PinejsClient,
 	deviceId: number,
 	imageIds: number[],
 ): Promise<void> => {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,6 +1,5 @@
 import { Application } from 'express';
 import * as _ from 'lodash';
-import { SECONDS_PER_HOUR } from '../lib/config';
 
 import {
 	apiKeyMiddleware,
@@ -11,6 +10,7 @@ import {
 	registerDeviceStateEvent,
 } from '../platform/middleware';
 
+import { SECONDS_PER_HOUR } from '../lib/config';
 import { createRateLimitMiddleware } from '../lib/rate-limiting';
 
 // Rate limit for unauthenticated access
@@ -32,7 +32,7 @@ export const deviceLogsRateLimiter = createRateLimitMiddleware(
 	},
 );
 
-import { SetupOptions } from '..';
+import { SetupOptions } from '../index';
 import * as access from '../routes/access';
 import * as apiKeys from '../routes/api-keys';
 import * as applications from '../routes/applications';

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,4 @@
 import { Application } from 'express';
-import * as _ from 'lodash';
 
 import {
 	apiKeyMiddleware,

--- a/src/routes/os.ts
+++ b/src/routes/os.ts
@@ -1,4 +1,5 @@
 import { RequestHandler } from 'express';
+
 import {
 	DEVICE_CONFIG_OPENVPN_CA,
 	DEVICE_CONFIG_OPENVPN_CONFIG,

--- a/src/routes/registry.ts
+++ b/src/routes/registry.ts
@@ -1,26 +1,27 @@
 // Implements the server part of: https://docs.docker.com/registry/spec/auth/token/
 // Reference: https://docs.docker.com/registry/spec/auth/jwt/
 
-import { sbvrUtils } from '@resin/pinejs';
 import * as BasicAuth from 'basic-auth';
 import * as Bluebird from 'bluebird';
+import { Request, RequestHandler } from 'express';
 import * as jsonwebtoken from 'jsonwebtoken';
 import * as _ from 'lodash';
+import * as memoize from 'memoizee';
 import * as uuid from 'uuid';
 
-import { User as DbUser } from '../models';
+import { sbvrUtils } from '@resin/pinejs';
+import { Resolvable } from '@resin/pinejs/out/sbvr-api/common-types';
+
 import { retrieveAPIKey } from '../platform/api-keys';
 import { captureException, handleHttpErrors } from '../platform/errors';
 
-import { Resolvable } from '@resin/pinejs/out/sbvr-api/common-types';
-import { Request, RequestHandler } from 'express';
-import * as memoize from 'memoizee';
 import { registryAuth as CERT } from '../lib/certs';
 import {
 	AUTH_RESINOS_REGISTRY_CODE,
 	REGISTRY2_HOST,
 	TOKEN_AUTH_BUILDER_TOKEN,
 } from '../lib/config';
+import { User as DbUser } from '../models';
 
 const { UnauthorizedError, root, api } = sbvrUtils;
 

--- a/src/routes/services.ts
+++ b/src/routes/services.ts
@@ -1,5 +1,7 @@
-import { sbvrUtils } from '@resin/pinejs';
 import { Request, Response } from 'express';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import { captureException, handleHttpErrors } from '../platform/errors';
 
 const { api } = sbvrUtils;

--- a/src/routes/session.ts
+++ b/src/routes/session.ts
@@ -1,8 +1,8 @@
-import { sbvrUtils } from '@resin/pinejs';
 import { RequestHandler } from 'express';
 import * as _ from 'lodash';
-import { SetupOptions } from '..';
-import { User as DbUser } from '../models';
+
+import { sbvrUtils } from '@resin/pinejs';
+
 import {
 	comparePassword,
 	findUser,
@@ -10,6 +10,9 @@ import {
 	loginUserXHR,
 } from '../platform/auth';
 import { captureException, handleHttpErrors } from '../platform/errors';
+
+import { SetupOptions } from '../index';
+import { User as DbUser } from '../models';
 
 const { BadRequestError, NotFoundError, root, api } = sbvrUtils;
 

--- a/src/routes/session.ts
+++ b/src/routes/session.ts
@@ -1,5 +1,4 @@
 import { RequestHandler } from 'express';
-import * as _ from 'lodash';
 
 import { sbvrUtils } from '@resin/pinejs';
 

--- a/test/03-device-state-v2.ts
+++ b/test/03-device-state-v2.ts
@@ -3,7 +3,6 @@ import { app } from '../init';
 import { expect } from './test-lib/chai';
 
 import * as Bluebird from 'bluebird';
-import * as _ from 'lodash';
 import * as mockery from 'mockery';
 import * as fakeDevice from './test-lib/fake-device';
 import { supertest, UserObjectParam } from './test-lib/supertest';


### PR DESCRIPTION
A few insignificant commits, except one that removes PineJS types that were re-exported by the API

Also, the first commit groups imports based on their origin:

- First are third-party libraries
- Then, first-party libraries
- Then, imports from “./platform”
- Finally, project imports

We don't enforce this (nor can we), but it'll hopefully encourage our future selves to preserve this separation.

Commits
=======

- Group imports by origin
- Remove unused lodash imports
- Remove underscored imports: Underscored imports where used to import only types and guard against using it for other reasons, but this can be enforced with type-only imports now where needed.
- Consistently import balena-semver as “semver”
- Stop re-exporting PineJS types: Back in the open sourcing days, it was thought that open-balena-api would completely wrap PineJS and expose higher level abstractions for clients, such as the cloud API. For this reason, it re-exported a few common PineJS types. This is not where we’re going however, so remove those exports, and have clients import them from PineJS.
