### PR TITLE
Add is_archived term to the application resource

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -388,6 +388,7 @@ Fact type: application1 depends on application2
 Fact type: application has application type
 	Necessity: each application has exactly one application type.
 Fact type: application is host
+Fact type: application is archived
 
 
 -- service instance

--- a/src/migrations/00026-application-is-archived.sql
+++ b/src/migrations/00026-application-is-archived.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "application" ADD COLUMN "is archived" INTEGER DEFAULT 0 NOT NULL;


### PR DESCRIPTION
The original purpose of the flag is to be able to
discontinue host applications, but the same concept
can be used by users to mark applications that are not
supported/developed anymore. This was discussed at a
product call and we decided to go with is_archived
based on Github's terminology as the meaning of both
are close.

Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>