### PR TITLE
Move device-log tests from balena-api

### DIFF
--- a/test/06-device_log.ts
+++ b/test/06-device_log.ts
@@ -1,0 +1,165 @@
+import * as _ from 'lodash';
+import { expect } from './test-lib/chai';
+import * as fixtures from './test-lib/fixtures';
+import { supertest } from './test-lib/supertest';
+
+import { app } from '../init';
+
+const createLog = (extra = {}) => {
+	return {
+		isStdErr: true,
+		isSystem: true,
+		message: 'a log line',
+		timestamp: Date.now(),
+		...extra,
+	};
+};
+
+describe('device log', () => {
+	const ctx: AnyObject = {};
+	before(async () => {
+		const fx = await fixtures.load('create-device-log');
+		ctx.loadedFixtures = fx;
+		ctx.user = fx.users.admin;
+		ctx.device = fx.devices.device1;
+		ctx.device2 = fx.devices.device2;
+
+		const res = await supertest(app, ctx.user)
+			.post(`/api-key/device/${ctx.device.id}/device-key`)
+			.expect(200);
+
+		expect(res.body).to.be.a('string');
+		ctx.device.apiKey = res.body;
+
+		const res2 = await supertest(app, ctx.user)
+			.post('/api-key/user/full')
+			.send({ name: 'name' })
+			.expect(200);
+
+		expect(res2.body).to.be.a('string');
+		ctx.user.apiKey = res2.body;
+	});
+	after(() => fixtures.clean(ctx.loadedFixtures));
+
+	// Creating
+
+	it('should allow devices to write their own logs', () =>
+		supertest(app, ctx.device.apiKey)
+			.post(`/device/v2/${ctx.device.uuid}/logs`)
+			.send([createLog()])
+			.expect(201));
+
+	it('should allow devices to write many logs in a batch', () =>
+		supertest(app, ctx.device.apiKey)
+			.post(`/device/v2/${ctx.device.uuid}/logs`)
+			.send([createLog(), createLog()])
+			.expect(201));
+
+	it("should not allow devices to write other devices' logs", () =>
+		supertest(app, ctx.device.apiKey)
+			.post(`/device/v2/${ctx.device2.uuid}/logs`)
+			.send([createLog()])
+			// Yields 404 because fetching device2 by uuid yields nothing
+			.expect(404));
+
+	it('should accept and store batches where some logs have serviceId', () =>
+		supertest(app, ctx.device.apiKey)
+			.post(`/device/v2/${ctx.device.uuid}/logs`)
+			.send([createLog({ serviceId: 10 }), createLog()])
+			.expect(201));
+
+	it('should return 201 even when the list of logs is empty', () =>
+		supertest(app, ctx.device.apiKey)
+			.post(`/device/v2/${ctx.device.uuid}/logs`)
+			.send([])
+			.expect(201));
+
+	it('should ignore logs with uuid (from dependent devices)', () =>
+		supertest(app, ctx.device.apiKey)
+			.post(`/device/v2/${ctx.device.uuid}/logs`)
+			.send([createLog({ uuid: 'abcdef' })])
+			.expect(201));
+
+	it('should ignore unknown properties on logs and store them', () =>
+		supertest(app, ctx.device.apiKey)
+			.post(`/device/v2/${ctx.device.uuid}/logs`)
+			.send([createLog({ hello: 'hi there' })])
+			.expect(201));
+
+	it('should reject batches with broken logs', async () => {
+		for (const extra of [
+			{ message: 123 },
+			{ message: null },
+			{ timestamp: new Date().toISOString() },
+		]) {
+			await supertest(app, ctx.device.apiKey)
+				.post(`/device/v2/${ctx.device.uuid}/logs`)
+				.send([createLog(extra)])
+				.expect(400);
+		}
+	});
+
+	// Reading Logs
+
+	it('should allow users to read device logs with a JWT', async () => {
+		const res = await supertest(app, ctx.user)
+			.get(`/device/v2/${ctx.device.uuid}/logs`)
+			.expect(200);
+
+		expect(res.body).to.have.lengthOf(6);
+		let lastTs = 0;
+		(res.body as AnyObject[]).forEach((log, index) => {
+			expect(log).to.have.property('message').that.equals('a log line');
+			expect(log).to.have.property('isStdErr').that.equals(true);
+			expect(log).to.have.property('isSystem').that.equals(true);
+			expect(log).to.have.property('timestamp').that.is.a('number');
+			expect(log).to.have.property('createdAt').that.is.a('number');
+			// Validate they are sorted chronologically
+			expect(log.createdAt).to.be.gte(lastTs);
+			lastTs = log.createdAt;
+			// The 4th is a service log and should have the correct serviceId
+			if (index === 3) {
+				expect(log).to.have.property('serviceId').that.equals(10);
+			} else {
+				expect(log).not.to.have.property('serviceId');
+			}
+		});
+	});
+
+	it('should allow users to read device logs with user-level API keys', async () => {
+		const res = await supertest(app, ctx.user.apiKey)
+			.get(`/device/v2/${ctx.device.uuid}/logs`)
+			.expect(200);
+		expect(res.body).to.have.lengthOf(6);
+	});
+
+	it('should support the `count` option in the custom read endpoint if available', async () => {
+		const res = await supertest(app, ctx.user)
+			.get(`/device/v2/${ctx.device.uuid}/logs?count=4`)
+			.expect(200);
+		expect(res.body).to.have.lengthOf(4);
+		// Test that it's sending the latest 4 and not just any other 4 logs
+		(res.body as AnyObject[]).forEach((log, index) => {
+			if (index === 1) {
+				expect(log).to.have.property('serviceId').that.equals(10);
+			} else {
+				expect(log).not.to.have.property('serviceId');
+			}
+		});
+	});
+
+	it('should support the `count=all` option in the custom read endpoint if available', async () => {
+		const res = await supertest(app, ctx.user)
+			.get(`/device/v2/${ctx.device.uuid}/logs?count=all`)
+			.expect(200);
+		expect(res.body).to.have.lengthOf(6);
+	});
+
+	it('should reject batches with more logs than allowed', () => {
+		const logs = _.times(11, createLog);
+		return supertest(app, ctx.device.apiKey)
+			.post(`/device/v2/${ctx.device.uuid}/logs`)
+			.send(logs)
+			.expect(400);
+	});
+});

--- a/test/fixtures/create-device-log/applications.json
+++ b/test/fixtures/create-device-log/applications.json
@@ -1,0 +1,12 @@
+{
+	"app1": {
+		"user": "admin",
+		"app_name": "test_create_device_log",
+		"device_type": "raspberry-pi"
+	},
+	"app2": {
+		"user": "admin",
+		"app_name": "test_create_device_log2",
+		"device_type": "raspberry-pi"
+	}
+}

--- a/test/fixtures/create-device-log/devices.json
+++ b/test/fixtures/create-device-log/devices.json
@@ -1,0 +1,16 @@
+{
+	"device1": {
+		"belongs_to__application": "app1",
+		"device_type": "intel-nuc",
+		"belongs_to__user": "admin",
+		"logs_channel": "c47e4dec05f76ee37c4b8e805c35c1eee54335803b3a40458928f8afce618b",
+		"uuid": "c47e4dec05f76ee37c4b8e805c35c1eee54335803b3a40458928f8afce618b"
+	},
+	"device2": {
+		"belongs_to__application": "app2",
+		"device_type": "intel-nuc",
+		"belongs_to__user": "admin",
+		"logs_channel": "5b7f3888c7824fda80ea0d26b3aefb7d778da302ffa9423694a0915b8896d0",
+		"uuid": "5b7f3888c7824fda80ea0d26b3aefb7d778da302ffa9423694a0915b8896d0"
+	}
+}

--- a/test/fixtures/create-device-log/permissions.json
+++ b/test/fixtures/create-device-log/permissions.json
@@ -1,0 +1,5 @@
+{
+	"retention": {
+		"name": "privilege.retention_limit.2"
+	}
+}

--- a/test/fixtures/create-device-log/user-permissions.json
+++ b/test/fixtures/create-device-log/user-permissions.json
@@ -1,0 +1,6 @@
+{
+	"retention": {
+		"user": "admin",
+		"permission": "retention"
+	}
+}

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -111,6 +111,47 @@ const loaders: Dictionary<LoaderFunc> = {
 			user,
 		});
 	},
+	devices: async (jsonData, fixtures) => {
+		const user = await fixtures.users[jsonData.belongs_to__user];
+		if (user == null) {
+			logErrorAndThrow(`Could not find user: ${jsonData.user}`);
+		}
+		const application = await fixtures.applications[
+			jsonData.belongs_to__application
+		];
+		if (application == null) {
+			logErrorAndThrow(
+				`Could not find application: ${jsonData.belongs_to__application}`,
+			);
+		}
+
+		return createResource({
+			resource: 'device',
+			body: {
+				belongs_to__application: application.id,
+				belongs_to__user: user.id,
+				is_of__device_type: (await fixtures.deviceTypes[jsonData.device_type])
+					.id,
+				..._.pick(
+					jsonData,
+					'uuid',
+					'is_managed_by__device',
+					'os_version',
+					'supervisor_version',
+					'logs_channel',
+					'custom_latitude',
+					'custom_longitude',
+					'os_variant',
+					'os_version',
+					'supervisor_version',
+					'is_online',
+					'latitude',
+					'longitude',
+				),
+			},
+			user,
+		});
+	},
 };
 
 const deleteResource = (resource: string) => async (obj: { id: number }) => {


### PR DESCRIPTION
Since device-log routes and logging backends are defined in `open-balena-api`, I believe it makes sense for the `device-log` tests to also be in this repo.

I'm working on a new logging backend (Loki) and having the tests in the same repo made it easier. Feel free to let me know if I have misunderstood the intended architecture.

- modified user fixtures to use the one admin user
- copied `device` fixture loader from `balena-api` fixtures
- skipped access control test not relevant to admin user

Change-type: minor
Signed-off-by: Thomas Manning <thomasm@balena.io>