### PR TITLE
Prepare the heartbeat interval queries only once, on first use

### DIFF
--- a/src/lib/device-online-state.ts
+++ b/src/lib/device-online-state.ts
@@ -21,8 +21,8 @@ import {
 
 const { root, api } = sbvrUtils;
 
-export const getPollInterval = async (uuid: string) => {
-	const getPollIntervalForDevice = api.resin.prepare<{ uuid: string }>({
+const getPollIntervalForDevice = _.once(() =>
+	api.resin.prepare<{ uuid: string }>({
 		resource: 'device_config_variable',
 		passthrough: { req: root },
 		options: {
@@ -45,9 +45,11 @@ export const getPollInterval = async (uuid: string) => {
 				name: 'desc',
 			},
 		},
-	});
+	}),
+);
 
-	const getPollIntervalForParentApplication = api.resin.prepare<{
+const getPollIntervalForParentApplication = _.once(() =>
+	api.resin.prepare<{
 		uuid: string;
 	}>({
 		resource: 'application_config_variable',
@@ -88,14 +90,16 @@ export const getPollInterval = async (uuid: string) => {
 				name: 'desc',
 			},
 		},
-	});
+	}),
+);
 
-	let pollIntervals = (await getPollIntervalForDevice({ uuid })) as Array<{
+export const getPollInterval = async (uuid: string) => {
+	let pollIntervals = (await getPollIntervalForDevice()({ uuid })) as Array<{
 		value: string;
 	}>;
 
 	if (pollIntervals.length === 0) {
-		pollIntervals = (await getPollIntervalForParentApplication({
+		pollIntervals = (await getPollIntervalForParentApplication()({
 			uuid,
 		})) as Array<{ value: string }>;
 	}


### PR DESCRIPTION
It seems that so far these were re-calculated on each
request. The queries are now prepared lazily, so the
startup time will not be affected, but had to do this
anyway since at the point that this loaded api.resin
was still undefined :)

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>