### PR TITLE
Allow gateway downloads to have a null download progress

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -637,7 +637,7 @@ Fact type: image install is provided by release
 Fact type: gateway download has status
 	Necessity: each gateway download has exactly one status.
 Fact type: gateway download has download progress
-	Necessity: each gateway download has exactly one download progress.
+	Necessity: each gateway download has at most one download progress.
 
 
 -- config

--- a/src/migrations/00027-gateway-download-nullable-download-progress.sql
+++ b/src/migrations/00027-gateway-download-nullable-download-progress.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "gateway download"
+ALTER COLUMN "download progress" SET NULL;

--- a/src/routes/devices.ts
+++ b/src/routes/devices.ts
@@ -669,7 +669,7 @@ const upsertGatewayDownload = async (
 	deviceId: number,
 	imageId: number,
 	status: string,
-	downloadProgress: number,
+	downloadProgress: number | null,
 ): Promise<void> => {
 	const [gatewayDownload] = (await resinApi.get({
 		resource: 'gateway_download',


### PR DESCRIPTION
This matches other download progress entries, and the supervisor attempts to send null progress in at least some cases

Change-type: minor