### PR TITLE
Use a mocharc and a huskyrc to keep the package.json cleaner

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+	"hooks": {
+		"pre-commit": "lint-staged"
+	}
+}

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,8 @@
+{
+	"reporter": "spec",
+	"sort": true,
+	"timeout": 20000,
+	"delay": true,
+	"exit": true,
+	"_": "index.js"
+}

--- a/package.json
+++ b/package.json
@@ -109,13 +109,5 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  },
-  "mocha": {
-    "reporter": "spec",
-    "sort": true,
-    "timeout": 20000,
-    "delay": true,
-    "exit": true,
-    "_": "index.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,10 +104,5 @@
   },
   "engines": {
     "node": ">=10.0"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   }
 }


### PR DESCRIPTION
Subjectively I prefer having a separate single purpose
file rather than a larger package.json.
This also avoids unnecessary extra lines on the
published package.json.
See: https://unpkg.com/browse/@balena/open-balena-api@0.78.4/package.json

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>