### PR TITLE
Add “organization” resource

### DIFF
--- a/src/balena-init.sql
+++ b/src/balena-init.sql
@@ -24,6 +24,8 @@ CREATE INDEX IF NOT EXISTS "application_depends_on_application_idx"
 ON "application" ("depends on-application");
 CREATE INDEX IF NOT EXISTS "application_device_type_idx"
 ON "application" ("is for-device type");
+CREATE INDEX IF NOT EXISTS "application_organization_idx"
+ON "application" ("organization");
 CREATE INDEX IF NOT EXISTS "application_release_idx"
 ON "application" ("should be running-release");
 CREATE INDEX IF NOT EXISTS "application_application_type_idx"
@@ -88,6 +90,10 @@ CREATE INDEX IF NOT EXISTS "ipr_ipr_image_idx"
 ON "image-is part of-release" ("is part of-release", "image");
 
 -- "image label"."release image" is the first part of an automated unique index
+
+-- "organization membership"."user" is the first part of an automated unique index
+CREATE INDEX IF NOT EXISTS "organization_membership_is_member_of_organization_idx"
+ON "organization membership" ("is member of-organization");
 
 -- TODO: Check what the extra columns are optimizing for
 CREATE INDEX IF NOT EXISTS "release_application_commit_status_idx"

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -126,6 +126,9 @@ Term: env var name
 Term: error message
 	Concept Type: Text (Type)
 
+Term: handle
+	Concept Type: Short Text (Type)
+
 Term: image location
 	Concept Type: Short Text (Type)
 
@@ -248,9 +251,10 @@ Term: vpn address
 
 Term: application type
 Term: config
-Term: image
-Term: service instance
 Term: device type
+Term: image
+Term: organization
+Term: service instance
 Term: supervisor release
 
 Term: application
@@ -336,6 +340,22 @@ Fact type: image is part of release
 		Term Form: image environment variable
 		Database Table Name: image environment variable
 
+Fact type: user (Auth) is member of organization
+	Synonymous Form: organization includes user (Auth)
+	Database Table Name: organization membership
+	Term Form: organization membership
+
+
+-- organization
+
+Fact type: organization has name (Auth)
+	Necessity: each organization has exactly one name (Auth).
+	Necessity: each name (Auth) of an organization, has a Length (Type) that is greater than 0.
+Fact type: organization has handle
+	Necessity: each organization has exactly one handle.
+	Necessity: each handle is of exactly one organization.
+	Necessity: each handle of an organization, has a Length (Type) that is greater than 0.
+
 
 -- user
 
@@ -374,6 +394,9 @@ Fact type: application type has maximum device count
 
 -- application
 
+Fact type: application has organization
+	Synonymous Form: organization has application
+	Necessity: each application has exactly one organization.
 Fact type: application has app name
 	Necessity: each application has exactly one app name
 	Necessity: each application has an app name that has a Length (Type) that is greater than or equal to 4 and is less than or equal to 30.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -49,6 +49,8 @@ export const ROLES: {
 		'resin.image_environment_variable.all',
 		'resin.image_install.all',
 		'resin.image_label.all',
+		'resin.organization.read',
+		'resin.organization_membership.read',
 		'resin.release.all',
 		'resin.release_tag.all',
 		'resin.service.all',

--- a/src/migrations/00030-organizations.sql
+++ b/src/migrations/00030-organizations.sql
@@ -1,0 +1,94 @@
+CREATE TABLE IF NOT EXISTS "organization" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	"name" VARCHAR(255) NOT NULL
+,	"handle" VARCHAR(255) NOT NULL UNIQUE
+);
+
+DO
+$$
+BEGIN
+IF NOT EXISTS(
+	SELECT 1
+	FROM "information_schema"."triggers"
+	WHERE "event_object_table" = 'organization'
+	AND "trigger_name" = 'organization_trigger_update_modified_at'
+) THEN
+	CREATE TRIGGER "organization_trigger_update_modified_at"
+	BEFORE UPDATE ON "organization"
+	FOR EACH ROW
+	EXECUTE PROCEDURE "trigger_update_modified_at"();
+END IF;
+END;
+$$
+
+CREATE TABLE IF NOT EXISTS "organization membership" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"user" INTEGER NOT NULL
+,	"is member of-organization" INTEGER NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	FOREIGN KEY ("user") REFERENCES "user" ("id")
+,	FOREIGN KEY ("is member of-organization") REFERENCES "organization" ("id")
+,	UNIQUE("user", "is member of-organization")
+);
+
+DO
+$$
+BEGIN
+IF NOT EXISTS(
+	SELECT 1
+	FROM "information_schema"."triggers"
+	WHERE "event_object_table" = 'organization membership'
+	AND "trigger_name" = 'organization membership_trigger_update_modified_at'
+) THEN
+	CREATE TRIGGER "organization membership_trigger_update_modified_at"
+	BEFORE UPDATE ON "organization membership"
+	FOR EACH ROW
+	EXECUTE PROCEDURE "trigger_update_modified_at"();
+END IF;
+END;
+$$
+
+ALTER TABLE "application"
+ADD COLUMN "organization" INTEGER NULL,
+ADD CONSTRAINT "application_organization_fkey"
+	FOREIGN KEY ("organization")
+	REFERENCES "organization" ("id");
+
+INSERT INTO "organization" ("name", "handle")
+SELECT 'admin', 'admin'
+WHERE NOT EXISTS (
+	SELECT "id"
+	FROM "organization"
+	WHERE "handle" = 'admin'
+);
+
+INSERT INTO "organization membership" (
+	"user",
+	"is member of-organization"
+)
+SELECT u."id", o."id"
+FROM "user" u, "organization" o
+WHERE u."username" = 'admin'
+	AND o."handle" = 'admin'
+	AND NOT EXISTS (
+			SELECT 1
+			FROM "organization membership" om
+			WHERE om."user" = u."id"
+				AND om."is member of-organization" = o."id"
+	);
+
+UPDATE "application" SET
+	"organization" = (SELECT "id" FROM "organization" WHERE "handle" = 'admin'),
+	"slug" = 'admin/' || lower("application"."app name")
+WHERE "organization" is NULL;
+
+ALTER TABLE "application" ALTER COLUMN "organization" SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "organization_membership_is_member_of_organization_idx"
+ON "organization membership" ("is member of-organization");
+
+CREATE INDEX IF NOT EXISTS "application_organization_idx"
+ON "application" ("organization");

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -63,6 +63,10 @@ const loaders: Dictionary<LoaderFunc> = {
 		if (user == null) {
 			logErrorAndThrow(`Could not find user: ${jsonData.user}`);
 		}
+		const org = await fixtures.organizations['admin'];
+		if (org == null) {
+			logErrorAndThrow('Could not find admin org');
+		}
 
 		if (jsonData.depends_on__application != null) {
 			const gatewayApp = await fixtures.applications[
@@ -76,16 +80,21 @@ const loaders: Dictionary<LoaderFunc> = {
 			jsonData.depends_on__application = gatewayApp.id;
 		}
 
+		const body = _.pick(
+			jsonData,
+			'app_name',
+			'device_type',
+			'depends_on__application',
+			'should_track_latest_release',
+			'application_type',
+		);
+
 		return createResource({
 			resource: 'application',
-			body: _.pick(
-				jsonData,
-				'app_name',
-				'device_type',
-				'depends_on__application',
-				'should_track_latest_release',
-				'application_type',
-			),
+			body: {
+				...body,
+				organization: org.id,
+			},
 			user,
 		});
 	},


### PR DESCRIPTION
Organizations sit one level higher than applications and users, and scope access to resources. Applications belong to organizations and users are members of organizations, which grants users access to those applications.

Because the core API is single-user, organizations offer nothing new (the admin user has full access to every resource unconditionally) but allow the core and cloud APIs to expose a uniform interface to clients, which is the motivation of this change.

People familiar with the cloud model will observe that I’ve included the bare minimum of resources that would let clients:

- query which organizations exist
- query which users are members of an organization
- query which organizations a user is a member of

You’ll also observe that I’ve not updated user authorization to go through org membership. We’d still have to grant all permissions unconditionally and it would make things explicit, but the permissions would become much more complicated adding both maintenance and performance ovehead and we’d still not be able to reuse the permissions on the cloud API. I don’t think the tradeoff is worth it and we can easily change that in the future if there’s a solid need.

I’ve also omitted DELETE hooks — the single org and org mebership are not expected to (and should not) be deleted on instances of the core API.

Change-type: minor