### PR TITLE
provisioning: allow supervisor_version at provision time

### DIFF
--- a/src/routes/devices.ts
+++ b/src/routes/devices.ts
@@ -52,6 +52,7 @@ export const register: RequestHandler = async (req, res) => {
 			throw new BadRequestError('API key must be used for registering');
 		}
 
+		const supervisorVersion = req.body.supervisor_version;
 		const deviceApiKey = req.body.api_key ?? randomstring.generate();
 
 		// Temporarily give the ability to fetch the device we create and create an api key for it,
@@ -71,6 +72,7 @@ export const register: RequestHandler = async (req, res) => {
 					belongs_to__user: userId,
 					belongs_to__application: applicationId,
 					device_type: deviceType,
+					supervisor_version: supervisorVersion,
 					uuid,
 				},
 			})) as AnyObject;

--- a/test/03-device-state-v2.ts
+++ b/test/03-device-state-v2.ts
@@ -306,7 +306,7 @@ describe('Device State v2 patch', function () {
 		applicationId = fx.applications.app1.id;
 
 		// create a new device in this test application...
-		device = await fakeDevice.provisionDevice(admin, applicationId);
+		device = await fakeDevice.provisionDevice(admin, applicationId, '9.11.1');
 	});
 
 	after(async () => {


### PR DESCRIPTION
In order to get closer to formally requiring a target supervisor
release in the model, we should expand our provisioning process to
provide the initial supervisor_version metadata. This connects back to
tri-app. Since this requires meta-balena changes as well, we need to
support both `null` and proper string values.

HQ: https://github.com/balena-io/balena-io/pull/2177
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>