### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "12:00"
+  open-pull-requests-limit: 99
+  commit-message:
+    prefix: patch
+  rebase-strategy: disabled


### PR DESCRIPTION
This configures dependabot to title commits in a way that versionist can detect the change type.

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/d-build-pipelines/threads/mqmgXw4ASi4gKIs1hQdfJkH0OTy
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>