### PR TITLE
Add a generic endpoint to generate ApiKeys scoped on specific roles

### DIFF
--- a/src/lib/api-keys.ts
+++ b/src/lib/api-keys.ts
@@ -1,6 +1,78 @@
+import type { Request } from 'express';
 import * as _ from 'lodash';
+import { errors } from '@balena/pinejs';
+import {
+	createApiKey,
+	ApiKeyOptions,
+	PartialCreateKey,
+} from '../platform/api-keys';
 
-import { createApiKey, PartialCreateKey } from '../platform/api-keys';
+const { BadRequestError } = errors;
+
+const supportedActorTypes = ['application', 'user', 'device'] as const;
+
+export type ApiKeyParameters = {
+	actorType: typeof supportedActorTypes[number];
+	actorTypeId: number;
+	roles: string[];
+} & Pick<ApiKeyOptions, 'name' | 'description' | 'apiKey'>;
+
+export const createGenericApiKey = async (
+	req: Request,
+	{
+		actorType,
+		actorTypeId,
+		roles,
+		name,
+		description,
+		apiKey,
+	}: ApiKeyParameters,
+) => {
+	if (!supportedActorTypes.includes(actorType)) {
+		throw new BadRequestError('Unsupported actor type');
+	}
+
+	if (!Number.isFinite(actorTypeId)) {
+		throw new BadRequestError('Actor type id must be a number');
+	}
+
+	if (
+		!Array.isArray(roles) ||
+		roles.length === 0 ||
+		roles.some((r) => typeof r !== 'string' || r.length === 0)
+	) {
+		throw new BadRequestError('Roles should be an array of role names');
+	}
+
+	if (roles.length !== 1) {
+		throw new BadRequestError('API Keys currently only support a single role');
+	}
+
+	if (!name) {
+		const namedRole = roles.find((r) => r.startsWith('named-'));
+
+		if (namedRole != null) {
+			throw new BadRequestError(
+				`API keys with the '${namedRole}' role require a name`,
+			);
+		}
+	}
+
+	const roleName = roles[0];
+
+	return createApiKey(
+		actorType,
+		roleName,
+		req,
+		actorTypeId,
+		// pass only the properties that the endpoint supports
+		{
+			name,
+			description,
+			apiKey,
+		},
+	);
+};
 
 export const createProvisioningApiKey: PartialCreateKey = _.partial(
 	createApiKey,

--- a/src/platform/api-keys.ts
+++ b/src/platform/api-keys.ts
@@ -7,7 +7,7 @@ import { isJWT } from './jwt';
 
 const { api } = sbvrUtils;
 
-interface ApiKeyOptions {
+export interface ApiKeyOptions {
 	apiKey?: string;
 	name?: string;
 	description?: string;

--- a/src/routes/api-keys.ts
+++ b/src/routes/api-keys.ts
@@ -8,11 +8,28 @@ import {
 } from '../platform/errors';
 
 import {
+	ApiKeyParameters,
+	createGenericApiKey as $createGenericApiKey,
 	createDeviceApiKey as $createDeviceApiKey,
 	createNamedUserApiKey as $createNamedUserApiKey,
 	createProvisioningApiKey as $createProvisioningApiKey,
 	createUserApiKey as $createUserApiKey,
 } from '../lib/api-keys';
+
+export const createGenericApiKey: RequestHandler = async (req, res) => {
+	const body = req.body as ApiKeyParameters;
+
+	try {
+		const apiKey = await $createGenericApiKey(req, body);
+		res.json(apiKey);
+	} catch (err) {
+		if (handleHttpErrors(req, res, err)) {
+			return;
+		}
+		captureException(err, 'Error generating API key', { req });
+		res.status(500).send(translateError(err));
+	}
+};
 
 export const createDeviceApiKey: RequestHandler = async (req, res) => {
 	const deviceId = parseInt(req.params.deviceId, 10);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -115,6 +115,8 @@ export const setup = (app: Application, onLogin: SetupOptions['onLogin']) => {
 		apiKeys.createDeviceApiKey,
 	);
 
+	app.post('/api-key/v1', authorized, apiKeys.createGenericApiKey);
+
 	app.get(
 		'/services/vpn/auth/:device_uuid',
 		apiKeyMiddleware,


### PR DESCRIPTION
On top of #397 so let's get that in first and ignore that commit while checking this.

Connects-to: #393
Change-type: minor
HQ: https://github.com/balena-io/balena-io/pull/2226
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/bFduRFrd1wEUZmDxFc5FHlGNcxl
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>