### PR TITLE
env-vars: Add ODMDATA config vars for nvidia boards

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -154,6 +154,34 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 		},
 	},
 	{
+		capableDeviceTypes: [
+			'astro-tx2',
+			'blackboard-tx2',
+			'jetson-tx2',
+			'n310-tx2',
+			'n510-tx2',
+			'orbitty-tx2',
+			'spacely-tx2',
+			'srd3-tx2',
+		],
+		properties: {
+			RESIN_HOST_ODMDATA_configuration: {
+				type: 'integer',
+				oneOf: [
+					{ const: 1, title: 'Configuration #1' },
+					{ const: 2, title: 'Configuration #2' },
+					{ const: 3, title: 'Configuration #3' },
+					{ const: 4, title: 'Configuration #4' },
+					{ const: 5, title: 'Configuration #5' },
+					{ const: 6, title: 'Configuration #6' },
+				],
+				description:
+					'Define the ODMDATA configuration. Only supported by supervisor versions >= v11.13.0.',
+				default: 2,
+			},
+		},
+	},
+	{
 		capableDeviceTypes: ['up-board'],
 		properties: {
 			RESIN_HOST_CONFIGFS_ssdt: {

--- a/test/01-basic.ts
+++ b/test/01-basic.ts
@@ -117,6 +117,10 @@ describe('Basic', () => {
 				],
 			},
 			{
+				deviceType: 'jetson-tx2',
+				extraConfigVarSchemaProperties: ['RESIN_HOST_ODMDATA_configuration'],
+			},
+			{
 				deviceType: 'up-board',
 				extraConfigVarSchemaProperties: ['RESIN_HOST_CONFIGFS_ssdt'],
 			},


### PR DESCRIPTION
Change-type: minor
HQ: https://github.com/balena-io/balena/issues/2166
See: https://github.com/balena-io/balenacloud-dashboard/issues/3413
Depends-on: https://github.com/balena-io/balena-supervisor/issues/1206
See: https://www.flowdock.com/app/rulemotion/r-supervisor/threads/54GM3Zqzk75loM4ELl77Zt1w7Vt
Depends-on: https://github.com/balena-io/balena-supervisor/issues/1206
See: https://codepen.io/thgreasi/pen/poyzMRz
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>