### PR TITLE
Vastly increase permitted app name length

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -398,7 +398,7 @@ Fact type: application has organization
 	Necessity: each application has exactly one organization.
 Fact type: application has app name
 	Necessity: each application has exactly one app name
-	Necessity: each application has an app name that has a Length (Type) that is greater than or equal to 4 and is less than or equal to 30.
+	Necessity: each application has an app name that has a Length (Type) that is greater than or equal to 4 and is less than or equal to 100.
 Fact type: application has slug
 	Necessity: each application has exactly one slug
 	Necessity: each slug is of exactly one application


### PR DESCRIPTION
Application name was used as part of the image name deployed to devices, which meant it had to be compatible with Docker’s name requirements. We’ve long moved away from that naming scheme so the limit is now superfluous and this patch effectively removes it.

Change-type: patch