### PR TITLE
Add a "cpu_architecture" resource

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -7,7 +7,7 @@ export = {
 		{
 			username: 'guest',
 			password: ' ',
-			permissions: ['resin.device_type.read'],
+			permissions: ['resin.device_type.read', 'resin.cpu_architecture.read'],
 		},
 	],
 } as ConfigLoader.Config;

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -274,6 +274,7 @@ Term: vpn address
 -- Complex terms
 
 Term: application type
+Term: cpu architecture
 Term: config
 Term: device type
 Term: image
@@ -553,6 +554,13 @@ Fact type: device type has slug
 
 Fact type: device type has name (Auth)
 	Necessity: each device type has exactly one name (Auth)
+
+-- cpu architecture
+
+Fact type: cpu architecture has slug
+	Necessity: each cpu architecture has exactly one slug
+	Necessity: each slug is of exactly one cpu architecture
+
 
 -- release
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -33,6 +33,7 @@ export const ROLES: {
 		'resin.api_key.read?is_of__actor eq @__ACTOR_ID',
 		'resin.application.all',
 		'resin.device_type.read',
+		'resin.cpu_architecture.read',
 		'resin.application_config_variable.all',
 		'resin.application_environment_variable.all',
 		'resin.application_tag.all',

--- a/src/migrations/00031-drop-supervisor-release.sql
+++ b/src/migrations/00031-drop-supervisor-release.sql
@@ -1,7 +1,7 @@
-DROP TRIGGER "supervisor release_trigger_update_modified_at"
-DROP INDEX "device_supervisor_release_device_type_idx";
+DROP TRIGGER IF EXISTS "supervisor release_trigger_update_modified_at" ON "supervisor release";
+DROP INDEX IF EXISTS "device_supervisor_release_device_type_idx";
 
 ALTER TABLE "device"
-DROP COLUMN "should be managed by-supervisor release",
-DROP CONSTRAINT "device_should be managed by-supervisor release_fkey"
-DROP TABLE "supervisor release";
+DROP COLUMN IF EXISTS "should be managed by-supervisor release",
+DROP CONSTRAINT IF EXISTS "device_should be managed by-supervisor release_fkey";
+DROP TABLE IF EXISTS "supervisor release";


### PR DESCRIPTION
As discussed in the architecture call on 25th of August 2020, the device type resource will have a foreign key to an
architecture, which for now only has a slug.

Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>