### PR TITLE
Fix fetching contracts randomly failing due to a bug in request

### DIFF
--- a/src/features/contracts/contracts-directory.ts
+++ b/src/features/contracts/contracts-directory.ts
@@ -65,17 +65,17 @@ const handleResponse: request.RequestCallback = (err, response) => {
 export const fetchContractsLocally = async (repos: RepositoryInfo[]) => {
 	await Promise.all(
 		repos.map(async (repo) => {
+			const untar = tar.extract({
+				C: await prepareContractDirectory(repo),
+				strip: 1,
+			});
+
 			// We cast to ReadableStream explicitly because `request.get is of type `request.Request` and it controls whether it is a readable or writable stream internally so it is not typings-compatible with ReadableStream, even though it it functionally equivalent.
 			const get = (request.get(
 				getArchiveLinkForRepo(repo),
 				getRequestOptions(repo),
 				handleResponse,
 			) as unknown) as NodeJS.ReadableStream;
-
-			const untar = tar.extract({
-				C: await prepareContractDirectory(repo),
-				strip: 1,
-			});
 
 			await pipeline(get, untar);
 		}),


### PR DESCRIPTION
Based on my tests this should fix it (I added `Bluebird.delay(2000)` before calling `pipeline` to reproduce it). The reason this works is, `PassThrough` doesn't switch to `flowing` mode until it is piped somewhere, unlike `request.get`

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>