### PR TITLE
device-heartbeat: Only update for requests using the device API Key

### DIFF
--- a/src/features/api-keys/lib.ts
+++ b/src/features/api-keys/lib.ts
@@ -221,3 +221,42 @@ export const createGenericApiKey = async (
 		},
 	);
 };
+
+export const isApiKeyWithRole = async (
+	key: string,
+	roleName: string,
+	tx?: Tx,
+) => {
+	const role = await api.Auth.get({
+		resource: 'role',
+		passthrough: { tx, req: permissions.root },
+		id: {
+			name: roleName,
+		},
+		options: {
+			$select: 'id',
+			$filter: {
+				is_of__api_key: {
+					$any: {
+						$alias: 'khr',
+						$expr: {
+							khr: {
+								api_key: {
+									$any: {
+										$alias: 'k',
+										$expr: {
+											k: {
+												key,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	});
+	return role != null;
+};

--- a/src/features/device-state/index.ts
+++ b/src/features/device-state/index.ts
@@ -1,4 +1,4 @@
-import type { Application } from 'express';
+import type { Application, Request } from 'express';
 import type StrictEventEmitter from 'strict-event-emitter-types';
 
 import { EventEmitter } from 'events';
@@ -24,7 +24,7 @@ export const setup = (app: Application) => {
 };
 
 export interface Events {
-	'get-state': (uuid: string) => void;
+	'get-state': (uuid: string, req: Pick<Request, 'apiKey'>) => void;
 }
 export const events: StrictEventEmitter<
 	EventEmitter,

--- a/src/features/device-state/routes/state.ts
+++ b/src/features/device-state/routes/state.ts
@@ -162,7 +162,8 @@ export const state: RequestHandler = async (req, res) => {
 	if (!uuid) {
 		return res.status(400).end();
 	}
-	events.emit('get-state', uuid);
+	const { apiKey } = req;
+	events.emit('get-state', uuid, { apiKey });
 
 	try {
 		const device = await sbvrUtils.db.readTransaction!((tx) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ import {
 	prefetchApiKeyMiddleware,
 	sudoMiddleware,
 } from './infra/auth';
+import { isApiKeyWithRole } from './features/api-keys/lib';
 import { setupDeleteCascade as addDeleteHookForDependents } from './features/cascade-delete/setup-delete-cascade';
 import {
 	updateOrInsertModel,
@@ -200,6 +201,9 @@ export const utils = {
 	isValidInteger,
 	varListInsert,
 	throttledForEach,
+};
+export const apiKeys = {
+	isApiKeyWithRole,
 };
 export const device = {
 	supervisorProxy,

--- a/test/03-device-state-v2.ts
+++ b/test/03-device-state-v2.ts
@@ -202,7 +202,7 @@ describe('Device State v2', () => {
 				{
 					tokenType: 'user token',
 					getActor: () => admin,
-					heartbeatAfterGet: DeviceOnlineStates.Online,
+					heartbeatAfterGet: DeviceOnlineStates.Unknown,
 					getDevice: () => deviceUserRequestedState,
 					getStateV2: () =>
 						fakeDevice.getStateV2(admin, deviceUserRequestedState.uuid),
@@ -235,7 +235,9 @@ describe('Device State v2', () => {
 							}
 
 							expect(tracker.states[getDevice().uuid]).to.equal(
-								heartbeatAfterGet,
+								heartbeatAfterGet !== DeviceOnlineStates.Unknown
+									? heartbeatAfterGet
+									: undefined,
 							);
 
 							const { body } = await supertest(getActor())
@@ -249,6 +251,10 @@ describe('Device State v2', () => {
 								`API heartbeat state is not ${heartbeatAfterGet}`,
 							);
 						});
+
+						if (heartbeatAfterGet === DeviceOnlineStates.Unknown) {
+							return;
+						}
 
 						it(`Should see state become "timeout" following a delay of ${
 							devicePollInterval / 1000

--- a/test/test-lib/fake-device.ts
+++ b/test/test-lib/fake-device.ts
@@ -34,6 +34,21 @@ export interface DeviceState {
 	};
 }
 
+export const getStateV2 = async (
+	user: UserObjectParam,
+	deviceUuid: string,
+): Promise<DeviceState> => {
+	const { body: state } = await supertest(user)
+		.get(`/device/v2/${deviceUuid}/state`)
+		.expect(200);
+
+	expect(state).to.have.property('local');
+	expect(state.local).to.have.property('name');
+	expect(state.local).to.have.property('config');
+
+	return state;
+};
+
 export async function provisionDevice(
 	admin: UserObjectParam,
 	appId: number,
@@ -81,15 +96,7 @@ export async function provisionDevice(
 		}),
 		token: randomstring.generate(16),
 		getStateV2: async (): Promise<DeviceState> => {
-			const { body: state } = await supertest(device)
-				.get(`/device/v2/${device.uuid}/state`)
-				.expect(200);
-
-			expect(state).to.have.property('local');
-			expect(state.local).to.have.property('name');
-			expect(state.local).to.have.property('config');
-
-			return state;
+			return await getStateV2(device, device.uuid);
 		},
 		patchStateV2: async (devicePatchBody: AnyObject) => {
 			await supertest(device)


### PR DESCRIPTION
I suggest reviewing the commits individually, since the first is only adding tests for the current state and then the second will just be the actual changes.

Resolves: #267
Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/5zTYkavDVQisCX1p9iI2ZQsmUcf
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>