### PR TITLE
Add limited retries to device type fetching from S3

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -65,3 +65,20 @@ export const throttledForEach = async <T, U>(
 	// We return the results of the iterator so the caller can await them as necessary
 	return await Promise.all(promises);
 };
+
+export const withRetries = async <T>(
+	func: () => Promise<T>,
+	delayDuration = 2000,
+	retries = 2,
+): Promise<T> => {
+	try {
+		return await func();
+	} catch (err) {
+		if (retries <= 0) {
+			throw err;
+		}
+
+		await delay(delayDuration);
+		return await withRetries(func, delayDuration, retries - 1);
+	}
+};

--- a/test/11-utils.ts
+++ b/test/11-utils.ts
@@ -1,0 +1,33 @@
+import * as _ from 'lodash';
+import { withRetries } from '../src/lib/utils';
+import { expect } from './test-lib/chai';
+
+describe('Utils', () => {
+	it('withRetries should retry before throwing', async () => {
+		let calls = 0;
+		const func = () => {
+			calls += 1;
+			return Promise.reject(new Error('Error'));
+		};
+		try {
+			await withRetries(func, 10, 2);
+		} catch (err) {
+			expect(err.message).to.equal('Error');
+			expect(calls).to.equal(3);
+		}
+	});
+
+	it('withRetries should resolve after a failure', async () => {
+		let calls = 0;
+		const func = () => {
+			calls += 1;
+			if (calls === 2) {
+				return Promise.reject(new Error('Error'));
+			}
+			return Promise.resolve('Resolved');
+		};
+
+		const res = await withRetries(func, 10, 2);
+		expect(res).to.equal('Resolved');
+	});
+});


### PR DESCRIPTION
Currently if the API fails to fetch the device types,
it would retry infinitely, making the dashboard fail
to load in BoB if there are no device types in S3, and
this should resolve that.

Change-type: minor
Signed-off-by: Stevche Radevski <stevche@balena.io>