### PR TITLE
Set Loki timeout to 1 second with no retries so log writes are not delayed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3550,9 +3550,9 @@
       }
     },
     "loki-grpc-client": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/loki-grpc-client/-/loki-grpc-client-1.0.1.tgz",
-      "integrity": "sha512-sKTdJOdw27+gAwBfactl9wKRlxqTgRFyZ4gsCFkOuxzeZ7q5m1MP3K5wttlS2zAUj8LkSHB3mZcKdMR4VbKh0Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/loki-grpc-client/-/loki-grpc-client-1.0.2.tgz",
+      "integrity": "sha512-1TKd4m/EGlFmeBXt84D7KHIKaxsA/a2FdyN/4i2L57X/ERy/rjnjyrWb07TKtlZTIppFEm4WJBxDgGQWOc+Jsw==",
       "requires": {
         "@types/google-protobuf": "^3.7.2",
         "google-protobuf": "^3.12.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "json-schema": "^0.2.5",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",
-    "loki-grpc-client": "1.0.1",
+    "loki-grpc-client": "1.0.2",
     "memoizee": "^0.4.14",
     "method-override": "^3.0.0",
     "morgan": "^1.10.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Thomas Manning <thomasm@balena.io>