### PR TITLE
Add DeviceLogsUsageMeter interface to be updated by DeviceLogsBackend

### DIFF
--- a/src/features/device-logs/lib/struct.ts
+++ b/src/features/device-logs/lib/struct.ts
@@ -66,3 +66,7 @@ export enum StreamState {
 	Saturated,
 	Closed,
 }
+
+export interface DeviceLogsUsageMeter {
+	incrementBytesRetained(ctx: LogContext, bytes: number): void;
+}


### PR DESCRIPTION
Customers subscribed to the logging add-on will be billed according to their usage. This PR allows for a `DeviceLogsUsageMeter` to be "attached" to the `DeviceLogsBackend`. This usage meter is updated by the backend when usage is incurred.

Part 1 of 2. Part 2 will be implemented in `balena-api`

Change-type: patch
Signed-off-by: Thomas Manning <thomasm@balena.io>