### PR TITLE
Remove `service_id` from LokiBackend labels to reduce cardinality

### DIFF
--- a/src/features/device-logs/lib/backends/loki.ts
+++ b/src/features/device-logs/lib/backends/loki.ts
@@ -62,7 +62,7 @@ const RETRIES_ENABLED = false;
 const PUSH_TIMEOUT = 1000;
 const MIN_BACKOFF = 100;
 const MAX_BACKOFF = 10 * 1000;
-const VERSION = 1;
+const VERSION = 2;
 
 function createTimestampFromDate(date = new Date()) {
 	const timestamp = new Timestamp();
@@ -277,8 +277,8 @@ export class LokiBackend implements DeviceLogsBackend {
 		return `app:${ctx.belongs_to__application}:device:${ctx.id}:${suffix}`;
 	}
 
-	private getLabels(ctx: LogContext, log: DeviceLog): string {
-		return `{device_id="${ctx.id}", service_id="${log.serviceId ?? 'null'}"}`;
+	private getLabels(ctx: LogContext): string {
+		return `{device_id="${ctx.id}"}`;
 	}
 
 	private validateLog(log: DeviceLog): asserts log is DeviceLog {
@@ -343,7 +343,7 @@ export class LokiBackend implements DeviceLogsBackend {
 			const logJson = JSON.stringify(log);
 			// create entry with labels, line and timestamp
 			const entry = new EntryAdapter().setLine(logJson).setTimestamp(timestamp);
-			const labels = this.getLabels(ctx, log);
+			const labels = this.getLabels(ctx);
 			// append entry to stream
 			let stream = streamIndex[labels];
 			if (!stream) {

--- a/test/09-loki-backend.ts
+++ b/test/09-loki-backend.ts
@@ -54,8 +54,8 @@ describe('loki backend', () => {
 		// @ts-expect-error usage of private function
 		const streams = loki.fromDeviceLogsToStreams(ctx, _.cloneDeep(logs));
 		expect(streams.length).to.be.equal(
-			4,
-			'should be 4 streams since 5 logs have 4 distinct services (null, 1, 2, 3)',
+			1,
+			'should be 1 stream since all logs share the same device id',
 		);
 		// @ts-expect-error usage of private function
 		const logsFromStreams = loki.fromStreamsToDeviceLogs(streams);


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Thomas Manning <thomasm@balena.io>