### PR TITLE
Change Loki backend to handle out of order error silently

### DIFF
--- a/src/features/device-logs/lib/backends/loki.ts
+++ b/src/features/device-logs/lib/backends/loki.ts
@@ -82,6 +82,7 @@ function convertToNanoseconds(milliseconds: number, nonce: number) {
 function backoff<T extends (...args: any[]) => any>(
 	fn: T,
 	retryIf: (err: Error) => boolean,
+	shouldThrow: (err: Error) => boolean,
 ) {
 	return async (...args: Parameters<T>): Promise<ReturnType<T> | undefined> => {
 		let nextBackoff = MIN_BACKOFF;
@@ -95,8 +96,10 @@ function backoff<T extends (...args: any[]) => any>(
 					// fibonacci
 					nextBackoff = nextBackoff + prevBackoff;
 					prevBackoff = nextBackoff - prevBackoff;
-				} else {
+				} else if (shouldThrow(err)) {
 					throw err;
+				} else {
+					return;
 				}
 			}
 		}
@@ -123,15 +126,27 @@ export class LokiBackend implements DeviceLogsBackend {
 			),
 		);
 		this.tailCalls = new Map();
-		this.push = backoff(this.push.bind(this), (err: ServiceError): boolean => {
-			incrementLokiPushErrorTotal(
-				err.code ? statusKeys[err.code] : 'UNDEFINED',
-			);
-			return (
-				RETRIES_ENABLED &&
-				[status.UNAVAILABLE, status.RESOURCE_EXHAUSTED].includes(err.code ?? -1)
-			);
-		});
+		this.push = backoff(
+			this.push.bind(this),
+			(err: ServiceError): boolean => {
+				const errorCode =
+					err.code && statusKeys[err.code]
+						? statusKeys[err.code]
+						: err.message.includes("reason: 'entry out of order'")
+						? 'OUT_OF_ORDER'
+						: 'UNDEFINED';
+				incrementLokiPushErrorTotal(errorCode);
+				return (
+					RETRIES_ENABLED &&
+					[status.UNAVAILABLE, status.RESOURCE_EXHAUSTED].includes(
+						err.code ?? -1,
+					)
+				);
+			},
+			(err: ServiceError): boolean => {
+				return !err.message.includes("reason: 'entry out of order'");
+			},
+		);
 	}
 
 	public get available(): boolean {

--- a/test/09-loki-backend.ts
+++ b/test/09-loki-backend.ts
@@ -125,4 +125,15 @@ describe('loki backend', () => {
 			await loki.publish(ctx, logs);
 		}).timeout(5000, 'Subscription did not receive logs');
 	});
+
+	it('should handle out-of-order errors silently', async function () {
+		const ctx = createContext({ belongs_to__application: 2 });
+		const loki = new LokiBackend();
+		const now = Date.now();
+		const logs = [
+			createLog({ timestamp: now }),
+			createLog({ timestamp: now - 1 }),
+		];
+		await loki.publish(ctx, logs)  // expect throw if not handled silently
+	});
 });


### PR DESCRIPTION
Loki will ignore out of order entries and only process ordered entries. Once complete the client will throw with a out of order message. The change correctly identifies the out of order error to increment metrics and swallows the error. 

Change-type: patch
Signed-off-by: Thomas Manning <thomasm@balena.io>