### PR TITLE
Fix device log read serialization to ignore `nanoTimestamp`

### DIFF
--- a/src/features/device-logs/lib/read.ts
+++ b/src/features/device-logs/lib/read.ts
@@ -61,7 +61,11 @@ async function handleStreamingRead(
 			dropped++;
 		} else if (state !== StreamState.Closed) {
 			if (
-				!res.write(JSON.stringify(log) + '\n') &&
+				!res.write(
+					JSON.stringify(log, (key, value) =>
+						key === 'nanoTimestamp' ? undefined : value,
+					) + '\n',
+				) &&
 				state === StreamState.Writable
 			) {
 				state = StreamState.Saturated;


### PR DESCRIPTION
Fix for "TypeError: Do not know how to serialize a BigInt". Fails to stringify BigInt `nanoTimestamp` when reading via `onLog`, added replacer to exclude `nanoTimestamp`. Will consider how to remove the need for this is in subsequent PRs.

Change-type: patch
Signed-off-by: Thomas Manning <thomasm@balena.io>