### PR TITLE
Expose the RPi family config vars to raspberrypi400-64

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -121,6 +121,7 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 			'raspberrypi3-64',
 			'raspberrypi3',
 			'raspberrypi4-64',
+			'raspberrypi400-64',
 			'fincm3',
 			'revpi-core-3',
 			'npe-x500-m3',


### PR DESCRIPTION
Change-type: minor
See: https://www.flowdock.com/app/rulemotion/resin-devices/threads/2gZsIuD2JGueoZRebq8nYyXtowN
See: https://github.com/balena-io/contracts/blob/master/contracts/hw.device-type/raspberrypi400-64/contract.json
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>