### PR TITLE
Catch exception when resolving asset real path to prevent other contract syncing from failing

### DIFF
--- a/src/features/contracts/contracts-directory.ts
+++ b/src/features/contracts/contracts-directory.ts
@@ -49,29 +49,29 @@ const normalizeAssets = async (
 				return;
 			}
 
-			// Convert from relative to absolute path for the asset file and make sure it doesn't try to access files outside of the contract folder.
-			const contractDir = path.dirname(contractFilepath);
-			const assetRealPath = await fs.promises.realpath(
-				path.join(contractDir, asset.url),
-			);
-
-			if (!assetRealPath.startsWith(contractDir)) {
-				captureException(
-					new Error('Invalid contract asset URL'),
-					`Contract asset URL '${asset.url}' is invalid, excluding asset from contract`,
-				);
-				return;
-			}
-
 			try {
+				// Convert from relative to absolute path for the asset file and make sure it doesn't try to access files outside of the contract folder.
+				const contractDir = path.dirname(contractFilepath);
+				const assetRealPath = await fs.promises.realpath(
+					path.join(contractDir, asset.url),
+				);
+
+				if (!assetRealPath.startsWith(contractDir)) {
+					captureException(
+						new Error('Invalid contract asset URL'),
+						`Contract asset URL '${asset.url}' is invalid, excluding asset from contract`,
+					);
+					return;
+				}
+
 				normalizedAssets[key] = {
 					...asset,
 					url: await handleLocalAssetUrl(assetRealPath),
 				};
-			} catch (e) {
+			} catch (err) {
 				captureException(
-					new Error('Normalizing contract asset failed'),
-					`Failed to normalize contract asset for url ${assetRealPath}, excluding asset`,
+					err,
+					`Failed to normalize contract asset for url ${asset.url}, excluding asset`,
 				);
 			}
 		}),


### PR DESCRIPTION
This will prevent syncing only the contracts that have an issue when normalizing their path, otherwise, all contract syncing for the device types would have failed.

Change-type: patch
Signed-off-by: Stevche Radevski <stevche@balena.io>