### PR TITLE
Separate application delete hook components into individual hooks

### DIFF
--- a/src/features/applications/hooks/backwards-compatible-delete-error.ts
+++ b/src/features/applications/hooks/backwards-compatible-delete-error.ts
@@ -1,0 +1,15 @@
+import { sbvrUtils, hooks, errors } from '@balena/pinejs';
+
+hooks.addPureHook('DELETE', 'resin', 'application', {
+	PRERUN: async (args) => {
+		const appIds = await sbvrUtils.getAffectedIds(args);
+		if (appIds.length === 0) {
+			const { odataQuery } = args.request;
+			if (odataQuery != null && odataQuery.key != null) {
+				// If there's a specific app targeted we make sure we give a 404 for backwards compatibility
+				throw new errors.NotFoundError('Application(s) not found.');
+			}
+			return;
+		}
+	},
+});

--- a/src/features/applications/hooks/check-device-releases-before-delete.ts
+++ b/src/features/applications/hooks/check-device-releases-before-delete.ts
@@ -4,11 +4,6 @@ hooks.addPureHook('DELETE', 'resin', 'application', {
 	PRERUN: async (args) => {
 		const appIds = await sbvrUtils.getAffectedIds(args);
 		if (appIds.length === 0) {
-			const { odataQuery } = args.request;
-			if (odataQuery != null && odataQuery.key != null) {
-				// If there's a specific app targeted we make sure we give a 404 for backwards compatibility
-				throw new errors.NotFoundError('Application(s) not found.');
-			}
 			return;
 		}
 		// find devices which are
@@ -56,16 +51,5 @@ hooks.addPureHook('DELETE', 'resin', 'application', {
 				uuids,
 			});
 		}
-		// We need to null `should_be_running__release` or otherwise we have a circular dependency and cannot delete either
-		await args.api.patch({
-			resource: 'application',
-			options: {
-				$filter: {
-					id: { $in: appIds },
-					should_be_running__release: { $ne: null },
-				},
-			},
-			body: { should_be_running__release: null },
-		});
 	},
 });

--- a/src/features/applications/hooks/index.ts
+++ b/src/features/applications/hooks/index.ts
@@ -1,3 +1,5 @@
+import './backwards-compatible-delete-error';
 import './defaults';
-import './delete-checks';
+import './check-device-releases-before-delete';
+import './unpin-release-before-delete';
 import './rename';

--- a/src/features/applications/hooks/unpin-release-before-delete.ts
+++ b/src/features/applications/hooks/unpin-release-before-delete.ts
@@ -1,0 +1,21 @@
+import { sbvrUtils, hooks } from '@balena/pinejs';
+
+hooks.addPureHook('DELETE', 'resin', 'application', {
+	PRERUN: async (args) => {
+		const appIds = await sbvrUtils.getAffectedIds(args);
+		if (appIds.length === 0) {
+			return;
+		}
+		// We need to null `should_be_running__release` or otherwise we have a circular dependency and cannot delete either
+		await args.api.patch({
+			resource: 'application',
+			options: {
+				$filter: {
+					id: { $in: appIds },
+					should_be_running__release: { $ne: null },
+				},
+			},
+			body: { should_be_running__release: null },
+		});
+	},
+});


### PR DESCRIPTION
This allows them to be isolated from each other and also allows them to
be executed in parallel

Change-type: patch