### PR TITLE
Optimize the unique commit per successful release per app rule

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -735,7 +735,7 @@ Fact type: config has description (Auth)
 Rule: It is necessary that each device1 that is managed by a device2, belongs to an application1 that depends on an application2 that owns the device2.
 Rule: It is necessary that each release that has a release version1 and has a status that is equal to "success" and is not invalidated, belongs to an application that owns exactly one release that has a release version2 that is equal to the release version1 and has a status that is equal to "success" and is not invalidated.
 Rule: It is necessary that each image that has a status that is equal to "success", has a push timestamp.
-Rule: It is necessary that each release1 that has a status that is equal to "success" and has a commit1, belongs to an application that owns exactly one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.
+Rule: It is necessary that each application that owns a release1 that has a status that is equal to "success" and has a commit1, owns at most one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.
 Rule: It is necessary that each release that should be running on a device, has a status that is equal to "success" and belongs to an application1 that the device belongs to.
 Rule: It is necessary that each release that should be running on an application, has a status that is equal to "success" and belongs to the application.
 Rule: It is necessary that each release that contains at least 2 images, belongs to an application that has an application type that supports multicontainer.

--- a/test/07_versioned-releases.ts
+++ b/test/07_versioned-releases.ts
@@ -55,7 +55,7 @@ describe('releases', () => {
 			.send(newRelease)
 			.expect(400);
 		expect(body).that.equals(
-			'It is necessary that each release1 that has a status that is equal to "success" and has a commit1, belongs to an application that owns exactly one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.',
+			'It is necessary that each application that owns a release1 that has a status that is equal to "success" and has a commit1, owns at most one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.',
 		);
 	});
 


### PR DESCRIPTION
Makes unique commit per successful release per app rule 25% faster, going from 4.8s to 3.6s.

Current rule:
Rule: It is necessary that each release1 that has a status that is equal to "success" and has a commit1, belongs to an application that owns exactly one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.
```sql
-- (cost=7.07..7.08 rows=1 width=1) (actual time=4809.263..4809.265 rows=1 loops=1)
SET jit = 0; EXPLAIN ANALYZE SELECT NOT EXISTS (
	SELECT 1
	FROM "release" AS "release.0"
	WHERE "release.0"."status" = 'success'
	AND "release.0"."status" IS NOT NULL
	AND "release.0"."commit" IS NOT NULL 
	AND NOT EXISTS (
		SELECT 1
		FROM "application" AS "application.3"
		WHERE (
			SELECT COUNT(*)
			FROM "release" AS "release.4"
			WHERE "release.4"."status" = 'success'
			AND "release.4"."status" IS NOT NULL
			AND "release.4"."commit" = "release.0"."commit"
			AND "release.4"."commit" IS NOT NULL
			AND "release.4"."belongs to-application" = "application.3"."id"
		) = 1
		AND "release.0"."belongs to-application" = "application.3"."id"
	)
) AS "result";
```

Updated rule:
Rule: It is necessary that each application that owns a release1 that has a status that is equal to "success" and has a commit1, owns at most one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.
```sql
-- (cost=10.34..10.35 rows=1 width=1) (actual time=3602.427..3602.428 rows=1 loops=1)
SET jit = 0; EXPLAIN ANALYZE SELECT NOT EXISTS (
	SELECT 1
	FROM "application" AS "application.0",
		"release" AS "release.1"
	WHERE "release.1"."status" = 'success'
	AND "release.1"."status" IS NOT NULL 
	AND "release.1"."commit" IS NOT NULL
	AND "release.1"."belongs to-application" = "application.0"."id"
	AND ( 
		SELECT COUNT(*)
		FROM "release" AS "release.4"
		WHERE "release.4"."status" = 'success'
		AND "release.4"."status" IS NOT NULL 
		AND "release.4"."commit" = "release.1"."commit"
		AND "release.4"."commit" IS NOT NULL
		AND "release.4"."belongs to-application" = "application.0"."id"
	) >= 2
) AS "result";
```

Change-type: minor
See: https://www.flowdock.com/app/rulemotion/resin-devops/threads/pltS7zNp3oKdJ7TKUymKfRXE1Nq
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>