### PR TITLE
vars-schema: Add HOST_CONFIG HDMI config definitions for the RPi family

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -141,6 +141,35 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 				description: 'Define device GPU memory in megabytes.',
 				default: 16,
 			},
+			BALENA_HOST_CONFIG_hdmi_cvt: {
+				type: 'string',
+				description: 'Define a custom CVT mode for the HDMI',
+				examples: ['480 360 60 1 0 0 0'],
+			},
+			BALENA_HOST_CONFIG_hdmi_force_hotplug: {
+				type: 'integer',
+				enum: [0, 1],
+				description: 'Force the HDMI hotplug signal',
+				default: 0,
+			},
+			BALENA_HOST_CONFIG_hdmi_group: {
+				type: 'integer',
+				description: 'Define the HDMI output group',
+				examples: [2],
+				default: 0,
+			},
+			BALENA_HOST_CONFIG_hdmi_mode: {
+				type: 'integer',
+				description: 'Define the HDMI output format',
+				examples: [87],
+				default: 1,
+			},
+			BALENA_HOST_CONFIG_display_rotate: {
+				type: 'string',
+				description: 'Define the rotation or flip of the display',
+				examples: ['1', '0x10000'],
+				default: '0',
+			},
 		},
 	},
 	{

--- a/test/01_basic.ts
+++ b/test/01_basic.ts
@@ -110,6 +110,11 @@ describe('Basic', () => {
 			{
 				deviceType: 'fincm3',
 				extraConfigVarSchemaProperties: [
+					'BALENA_HOST_CONFIG_display_rotate',
+					'BALENA_HOST_CONFIG_hdmi_cvt',
+					'BALENA_HOST_CONFIG_hdmi_force_hotplug',
+					'BALENA_HOST_CONFIG_hdmi_group',
+					'BALENA_HOST_CONFIG_hdmi_mode',
 					'RESIN_HOST_CONFIG_disable_splash',
 					'RESIN_HOST_CONFIG_dtparam',
 					'RESIN_HOST_CONFIG_dtoverlay',


### PR DESCRIPTION
Change-type: minor
See: https://www.flowdock.com/app/rulemotion/balenalabs/threads/Zp0NS-1iY28vO0lJNih-lW4U_Ag
See: https://www.raspberrypi.org/documentation/configuration/config-txt/video.md
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>