### PR TITLE
Fix release tracking using the new CI/CD metadata fields

### DIFF
--- a/src/features/ci-cd/hooks/track-latest-release.ts
+++ b/src/features/ci-cd/hooks/track-latest-release.ts
@@ -1,52 +1,65 @@
 import * as _ from 'lodash';
+import { sbvrUtils, hooks } from '@balena/pinejs';
 
-import { hooks } from '@balena/pinejs';
 const releaseStateFields = [
 	'status',
 	'is_passing_tests',
 	'release_type',
 	'is_invalidated',
 ];
-const updateLatestRelease = async ({ request, api }: hooks.HookArgs) => {
-	if (
-		// we avoid short-circuiting for POSTs since the db can provide defaults that we later use to filter on.
-		request.method !== 'POST' &&
-		!releaseStateFields.some((field) => field in request.values)
-	) {
+
+const updateLatestRelease = async (
+	api: sbvrUtils.PinejsClient,
+	releaseIds: number[],
+) => {
+	if (!releaseIds.length) {
 		return;
 	}
-	const [release] = await api.get({
-		resource: 'release',
+
+	const appsToUpdate = await api.get({
+		resource: 'application',
 		options: {
 			$select: 'id',
-			$top: 1,
-			// the most recently started build should be the latest, to ignore variable build times
-			$orderby: { start_timestamp: 'desc' },
-			$filter: {
-				// We only track releases that are successful, final, not invalid, and passing tests
-				release_type: 'final',
-				is_passing_tests: true,
-				is_invalidated: false,
-				status: 'success',
-			},
 			$expand: {
-				belongs_to__application: {
+				owns__device: {
 					$select: ['id'],
+				},
+				owns__release: {
+					$select: 'id',
+					$top: 1,
+					// the most recently started build should be the latest, to ignore variable build times
+					$orderby: { start_timestamp: 'desc' },
+					$filter: {
+						// We only track releases that are successful, final, not invalid, and passing tests
+						release_type: 'final',
+						is_passing_tests: true,
+						is_invalidated: false,
+						status: 'success',
+					},
 					$expand: {
-						owns__device: {
+						contains__image: {
 							$select: ['id'],
+							$expand: {
+								image: {
+									$select: ['id'],
+									$expand: {
+										is_a_build_of__service: {
+											$select: ['id'],
+										},
+									},
+								},
+							},
 						},
 					},
 				},
-				contains__image: {
-					$select: ['id'],
-					$expand: {
-						image: {
-							$select: ['id'],
-							$expand: {
-								is_a_build_of__service: {
-									$select: ['id'],
-								},
+			},
+			$filter: {
+				owns__release: {
+					$any: {
+						$alias: 'r',
+						$expr: {
+							r: {
+								id: { $in: releaseIds },
 							},
 						},
 					},
@@ -54,64 +67,74 @@ const updateLatestRelease = async ({ request, api }: hooks.HookArgs) => {
 			},
 		},
 	});
-	if (release == null) {
+	if (!appsToUpdate.length) {
 		return;
 	}
-	await api.patch({
-		resource: 'application',
-		id: release.belongs_to__application[0].id,
-		options: {
-			$filter: {
-				should_track_latest_release: true,
-			},
-		},
-		body: {
-			should_be_running__release: release.id,
-		},
-	});
 
-	const deviceIds: number[] = _.map(
-		release.belongs_to__application[0].owns__device,
-		(device) => device.id,
-	);
-	const serviceIds: number[] = _.map(
-		release.contains__image,
-		(ipr) => ipr.image[0].is_a_build_of__service[0].id,
-	);
-	if (deviceIds.length === 0 || serviceIds.length === 0) {
-		return;
-	}
-	const serviceInstalls = await api.get({
-		resource: 'service_install',
-		options: {
-			$select: ['device', 'installs__service'],
-			$filter: {
-				device: { $in: deviceIds },
-				installs__service: { $in: serviceIds },
-			},
-		},
-	});
-	const serviceInstallsByDevice = _.groupBy(
-		serviceInstalls,
-		(si) => si.device.__id as number,
-	);
 	await Promise.all(
-		deviceIds.map(async (deviceId) => {
-			const existingServiceIds: number[] = _.map(
-				serviceInstallsByDevice[deviceId],
-				(si) => si.installs__service.__id,
+		appsToUpdate.map(async (app) => {
+			const [release] = app.owns__release;
+			if (release == null) {
+				return;
+			}
+
+			await api.patch({
+				resource: 'application',
+				id: app.id,
+				options: {
+					$filter: {
+						should_track_latest_release: true,
+					},
+				},
+				body: {
+					should_be_running__release: release.id,
+				},
+			});
+
+			const deviceIds: number[] = _.map(
+				app.owns__device,
+				(device) => device.id,
 			);
-			const deviceServiceIds = _.difference(serviceIds, existingServiceIds);
+			const serviceIds: number[] = _.map(
+				release.contains__image,
+				(ipr) => ipr.image[0].is_a_build_of__service[0].id,
+			);
+			if (deviceIds.length === 0 || serviceIds.length === 0) {
+				return;
+			}
+			const serviceInstalls = await api.get({
+				resource: 'service_install',
+				options: {
+					$select: ['device', 'installs__service'],
+					$filter: {
+						device: { $in: deviceIds },
+						installs__service: { $in: serviceIds },
+					},
+				},
+			});
+			const serviceInstallsByDevice = _.groupBy(
+				serviceInstalls,
+				(si) => si.device.__id as number,
+			);
 			await Promise.all(
-				deviceServiceIds.map(async (serviceId) => {
-					await api.post({
-						resource: 'service_install',
-						body: {
-							device: deviceId,
-							installs__service: serviceId,
-						},
-						options: { returnResource: false },
-					});
+				deviceIds.map(async (deviceId) => {
+					const existingServiceIds: number[] = _.map(
+						serviceInstallsByDevice[deviceId],
+						(si) => si.installs__service.__id,
+					);
+					const deviceServiceIds = _.difference(serviceIds, existingServiceIds);
+					await Promise.all(
+						deviceServiceIds.map(async (serviceId) => {
+							await api.post({
+								resource: 'service_install',
+								body: {
+									device: deviceId,
+									installs__service: serviceId,
+								},
+								options: { returnResource: false },
+							});
+						}),
+					);
 				}),
 			);
 		}),
@@ -119,20 +142,24 @@ const updateLatestRelease = async ({ request, api }: hooks.HookArgs) => {
 };
 
 hooks.addPureHook('PATCH', 'resin', 'release', {
-	POSTRUN: async (args) => {
-		const { request } = args;
-		// If we're updating a release by id and setting it successful then we update the application to this build
-		if (request.affectedIds && request.affectedIds.length > 0) {
-			await updateLatestRelease(args);
+	POSTRUN: async ({ api, request }) => {
+		// If we're updating the ci/cd fields of any release (eg marking them as successful) then we update the application to track this release
+		if (
+			request.affectedIds &&
+			request.affectedIds.length > 0 &&
+			releaseStateFields.some((field) => field in request.values)
+		) {
+			await updateLatestRelease(api, request.affectedIds);
 		}
 	},
 });
 
 hooks.addPureHook('POST', 'resin', 'release', {
-	POSTRUN: async (args) => {
-		// If we successfully created a release then check if the latest release needs to be updated
-		if (args.result != null) {
-			await updateLatestRelease(args);
+	POSTRUN: async ({ api, result: releaseId }) => {
+		// If we successfully created a release then check if the latest release needs to be updated.
+		// We avoid checking specific fields & short-circuiting since the db can provide defaults that we later use to filter on.
+		if (releaseId != null) {
+			await updateLatestRelease(api, [releaseId]);
 		}
 	},
 });

--- a/test/14_release-pinning.ts
+++ b/test/14_release-pinning.ts
@@ -5,21 +5,31 @@ import { supertest, UserObjectParam } from './test-lib/supertest';
 import { version } from './test-lib/versions';
 
 import * as fixtures from './test-lib/fixtures';
+import {
+	addReleaseToApp,
+	addImageToService,
+	addServiceToApp,
+	addImageToRelease,
+} from './test-lib/api-helpers';
 
 describe(`Tracking latest release`, () => {
 	let fx: fixtures.Fixtures;
 	let admin: UserObjectParam;
 	let applicationId: number;
+	let application2Id: number;
 	let device: fakeDevice.Device;
+	let device2: fakeDevice.Device;
 
 	before(async () => {
 		fx = await fixtures.load('13-release-pinning');
 
 		admin = fx.users.admin;
 		applicationId = fx.applications.app1.id;
+		application2Id = fx.applications.app2.id;
 
 		// create a new device in this test application...
 		device = await fakeDevice.provisionDevice(admin, applicationId);
+		device2 = await fakeDevice.provisionDevice(admin, application2Id);
 	});
 
 	after(async () => {
@@ -96,5 +106,94 @@ describe(`Tracking latest release`, () => {
 		expect(state.local.apps[applicationId].releaseId).to.equal(
 			expectedLatest.id,
 		);
+	});
+
+	describe('given two releases of two applications building in parallel', function () {
+		// used to create uqniue commits for each set of releases
+		let testRunsCount = 0;
+		let app1ReleaseId: number;
+		let app2ReleaseId: number;
+
+		beforeEach(async function () {
+			testRunsCount++;
+
+			const app1Release = await addReleaseToApp(admin, {
+				belongs_to__application: applicationId,
+				is_created_by__user: admin.id!,
+				build_log: '',
+				commit: `deadbeef${testRunsCount}`,
+				composition: '',
+				source: '',
+				status: 'running',
+				start_timestamp: Date.now(),
+			});
+			app1ReleaseId = app1Release.id;
+
+			const app2Release = await addReleaseToApp(admin, {
+				belongs_to__application: application2Id,
+				is_created_by__user: admin.id!,
+				build_log: '',
+				commit: `deadbeef${testRunsCount}`,
+				composition: '',
+				source: '',
+				status: 'running',
+				start_timestamp: Date.now(),
+			});
+			app2ReleaseId = app2Release.id;
+		});
+
+		it('should update the target release of both apps when the releases complete in order', async function () {
+			await supertest(admin)
+				.patch(`/${version}/release(${app1ReleaseId})`)
+				.send({
+					status: 'success',
+					end_timestamp: Date.now(),
+				})
+				.expect(200);
+
+			await supertest(admin)
+				.patch(`/${version}/release(${app2ReleaseId})`)
+				.send({
+					status: 'success',
+					end_timestamp: Date.now(),
+				})
+				.expect(200);
+
+			const device1state = await device.getStateV2();
+			expect(device1state.local.apps[applicationId].releaseId).to.equal(
+				app1ReleaseId,
+			);
+			const device2state = await device2.getStateV2();
+			expect(device2state.local.apps[application2Id].releaseId).to.equal(
+				app2ReleaseId,
+			);
+		});
+
+		it('should update the target release of both apps when the the later release finishes before the first one', async function () {
+			await supertest(admin)
+				.patch(`/${version}/release(${app2ReleaseId})`)
+				.send({
+					status: 'success',
+					end_timestamp: Date.now(),
+				})
+				.expect(200);
+
+			await supertest(admin)
+				.patch(`/${version}/release(${app1ReleaseId})`)
+				.send({
+					status: 'success',
+					end_timestamp: Date.now(),
+				})
+				.expect(200);
+
+			const device1state = await device.getStateV2();
+			expect(device1state.local.apps[applicationId].releaseId).to.equal(
+				app1ReleaseId,
+			);
+			const device2state = await device2.getStateV2();
+			expect(device2state.local.apps[application2Id].releaseId).to.equal(
+				app2ReleaseId,
+			);
+		});
 	});
 });

--- a/test/fixtures/13-release-pinning/applications.json
+++ b/test/fixtures/13-release-pinning/applications.json
@@ -8,5 +8,10 @@
         "user": "admin",
         "device_type": "intel-nuc",
         "app_name": "test-app-2"
+    },
+    "app3": {
+        "user": "admin",
+        "device_type": "intel-nuc",
+        "app_name": "test-app-3"
     }
 }

--- a/test/fixtures/13-release-pinning/applications.json
+++ b/test/fixtures/13-release-pinning/applications.json
@@ -3,5 +3,10 @@
         "user": "admin",
         "device_type": "intel-nuc",
         "app_name": "test-app-1"
+    },
+    "app2": {
+        "user": "admin",
+        "device_type": "intel-nuc",
+        "app_name": "test-app-2"
     }
 }

--- a/test/fixtures/13-release-pinning/releases.json
+++ b/test/fixtures/13-release-pinning/releases.json
@@ -42,5 +42,16 @@
 		"source": "cloud",
 		"status": "success",
 		"user": "admin"
+	},
+	"app2release1": {
+		"application": "app2",
+		"commit": "de2dc0de",
+		"composition": {},
+		"is_passing_tests": true,
+		"release_type": "final",
+		"release_version": "v0.0.1",
+		"source": "cloud",
+		"status": "success",
+		"user": "admin"
 	}
 }

--- a/test/fixtures/13-release-pinning/releases.json
+++ b/test/fixtures/13-release-pinning/releases.json
@@ -53,5 +53,16 @@
 		"source": "cloud",
 		"status": "success",
 		"user": "admin"
+	},
+	"app3release1": {
+		"application": "app3",
+		"commit": "de2dc0de",
+		"composition": {},
+		"is_passing_tests": true,
+		"release_type": "final",
+		"release_version": "v0.0.1",
+		"source": "cloud",
+		"status": "success",
+		"user": "admin"
 	}
 }

--- a/test/scenarios/unpin-device-after-release.ts
+++ b/test/scenarios/unpin-device-after-release.ts
@@ -6,81 +6,12 @@ import { supertest, UserObjectParam } from '../test-lib/supertest';
 import { version } from '../test-lib/versions';
 
 import * as fixtures from '../test-lib/fixtures';
-
-interface MockReleaseParams {
-	belongs_to__application: number;
-	is_created_by__user: number;
-	commit: string;
-	composition: string;
-	status: string;
-	source: string;
-	build_log: string;
-	start_timestamp: number;
-	end_timestamp?: number;
-	update_timestamp?: number;
-}
-interface MockImageParams {
-	is_a_build_of__service: number;
-	start_timestamp: number;
-	end_timestamp: number;
-	push_timestamp: number;
-	status: string;
-	image_size: number;
-	project_type?: string;
-	error_message?: string;
-	build_log: string;
-}
-interface MockServiceParams {
-	application: number;
-	service_name: string;
-}
-
-type MockRelease = MockReleaseParams & { id: number };
-type MockImage = MockImageParams & { id: number };
-type MockService = MockServiceParams & { id: number };
-
-const addReleaseToApp = async (
-	auth: UserObjectParam,
-	release: MockReleaseParams,
-): Promise<MockRelease> =>
-	(await supertest(auth).post(`/${version}/release`).send(release).expect(201))
-		.body;
-
-const addImageToService = async (
-	auth: UserObjectParam,
-	image: MockImageParams,
-): Promise<MockImage> =>
-	(await supertest(auth).post(`/${version}/image`).send(image).expect(201))
-		.body;
-
-const addServiceToApp = async (
-	auth: UserObjectParam,
-	serviceName: string,
-	application: number,
-): Promise<MockService> =>
-	(
-		await supertest(auth)
-			.post(`/${version}/service`)
-			.send({
-				application,
-				service_name: serviceName,
-			})
-			.expect(201)
-	).body;
-
-const addImageToRelease = async (
-	auth: UserObjectParam,
-	imageId: number,
-	releaseId: number,
-): Promise<void> => {
-	await supertest(auth)
-		.post(`/${version}/image__is_part_of__release`)
-		.send({
-			image: imageId,
-			is_part_of__release: releaseId,
-		})
-		.expect(201);
-};
+import {
+	addReleaseToApp,
+	addImageToService,
+	addServiceToApp,
+	addImageToRelease,
+} from '../test-lib/api-helpers';
 
 describe('Device with missing service installs', () => {
 	let fx: fixtures.Fixtures;

--- a/test/test-lib/api-helpers.ts
+++ b/test/test-lib/api-helpers.ts
@@ -1,0 +1,79 @@
+import { supertest, UserObjectParam } from '../test-lib/supertest';
+import { version } from '../test-lib/versions';
+
+interface MockReleaseParams {
+	belongs_to__application: number;
+	is_created_by__user: number;
+	commit: string;
+	composition: string;
+	status: string;
+	source: string;
+	build_log: string;
+	start_timestamp: number;
+	end_timestamp?: number;
+	update_timestamp?: number;
+}
+
+interface MockImageParams {
+	is_a_build_of__service: number;
+	start_timestamp: number;
+	end_timestamp: number;
+	push_timestamp: number;
+	status: string;
+	image_size: number;
+	project_type?: string;
+	error_message?: string;
+	build_log: string;
+}
+
+interface MockServiceParams {
+	application: number;
+	service_name: string;
+}
+
+type MockRelease = MockReleaseParams & { id: number };
+type MockImage = MockImageParams & { id: number };
+type MockService = MockServiceParams & { id: number };
+
+export const addReleaseToApp = async (
+	auth: UserObjectParam,
+	release: MockReleaseParams,
+): Promise<MockRelease> =>
+	(await supertest(auth).post(`/${version}/release`).send(release).expect(201))
+		.body;
+
+export const addImageToService = async (
+	auth: UserObjectParam,
+	image: MockImageParams,
+): Promise<MockImage> =>
+	(await supertest(auth).post(`/${version}/image`).send(image).expect(201))
+		.body;
+
+export const addServiceToApp = async (
+	auth: UserObjectParam,
+	serviceName: string,
+	application: number,
+): Promise<MockService> =>
+	(
+		await supertest(auth)
+			.post(`/${version}/service`)
+			.send({
+				application,
+				service_name: serviceName,
+			})
+			.expect(201)
+	).body;
+
+export const addImageToRelease = async (
+	auth: UserObjectParam,
+	imageId: number,
+	releaseId: number,
+): Promise<void> => {
+	await supertest(auth)
+		.post(`/${version}/image__is_part_of__release`)
+		.send({
+			image: imageId,
+			is_part_of__release: releaseId,
+		})
+		.expect(201);
+};


### PR DESCRIPTION
It looks like we previously were updating the release of the app that had the latest start_timestamp.
Draft so that I can collect some thoughts on this while I write some tests.

Resolves: #591
Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/L_kD9edlawU6l8f8wvHT0FBUPG_
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>