### PR TITLE
Added contract field to device type resources

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -57,6 +57,7 @@ async function onInitHooks() {
 		'hw.device-type': {
 			resource: 'device_type',
 			uniqueKey: 'slug',
+			includeRawContract: true,
 			map: {
 				slug: {
 					contractField: 'slug',

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -578,6 +578,9 @@ Fact type: device type is of cpu architecture
 Fact type: device type has logo
 	Necessity: each device type has at most one logo
 
+Fact type: device type has contract
+	Necessity: each device type has at most one contract
+
 Fact type: device type belongs to device family
 	Synonymous form: device family has device type
 	Necessity: each device type belongs to at most one device family

--- a/src/migrations/00044-add-contract-device-type.sql
+++ b/src/migrations/00044-add-contract-device-type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "device type" 
+ADD COLUMN IF NOT EXISTS "contract" TEXT NULL;

--- a/test/09_contracts.ts
+++ b/test/09_contracts.ts
@@ -159,6 +159,12 @@ describe('contracts', () => {
 			mockRepo('balena-io', 'contracts', 'updated-base-contracts');
 			await synchronizeContracts([{ owner: 'balena-io', name: 'contracts' }]);
 
+			const contracts = await getContracts('hw.device-type');
+
+			const finDtContract = contracts.find(
+				(dbDeviceType) => dbDeviceType.slug === 'fincm3',
+			);
+
 			const dbDeviceTypes: DeviceType[] = (
 				await supertest().get(`/${version}/device_type`).expect(200)
 			).body.d;
@@ -173,6 +179,7 @@ describe('contracts', () => {
 			expect(dbDeviceTypes).to.have.length(14);
 			expect(newDt).to.not.be.undefined;
 			expect(finDt).to.have.property('name', 'Fin');
+			expect(finDt).to.have.property('contract', JSON.stringify(finDtContract));
 		});
 	});
 });


### PR DESCRIPTION
One a previous Architecture call we discussed adding partials to the API for device types and releases. This adds the fields to those tables and adds a migration script.