### PR TITLE
Fixed JSON serialization of device type contracts in database

### DIFF
--- a/src/features/contracts/index.ts
+++ b/src/features/contracts/index.ts
@@ -93,7 +93,7 @@ const mapModel = async (
 ) => {
 	const mappedModel: { [k: string]: any } = {};
 	if (includeRawContract) {
-		mappedModel['contract'] = JSON.stringify(contractEntry);
+		mappedModel['contract'] = contractEntry;
 	}
 	for (const key of Object.keys(map) as Array<keyof typeof map>) {
 		const mapper = map[key];
@@ -135,6 +135,10 @@ const upsertEntries = async (
 	await Bluebird.map(
 		newData,
 		async (entry: any) => {
+			const entryQuery =
+				'contract' in entry && entry.contract != null
+					? { ...entry, contract: JSON.stringify(entry.contract) }
+					: entry;
 			try {
 				if (existingData.has(entry[uniqueField])) {
 					return await rootApi.patch({
@@ -143,7 +147,7 @@ const upsertEntries = async (
 						options: {
 							$filter: {
 								[uniqueField]: entry[uniqueField],
-								$not: entry,
+								$not: entryQuery,
 							},
 						},
 					});

--- a/test/09_contracts.ts
+++ b/test/09_contracts.ts
@@ -179,7 +179,10 @@ describe('contracts', () => {
 			expect(dbDeviceTypes).to.have.length(14);
 			expect(newDt).to.not.be.undefined;
 			expect(finDt).to.have.property('name', 'Fin');
-			expect(finDt).to.have.property('contract', JSON.stringify(finDtContract));
+			expect(finDt).to.have.deep.property(
+				'contract',
+				JSON.parse(JSON.stringify(finDtContract)),
+			);
 		});
 	});
 });


### PR DESCRIPTION
PineJS serializes and deserializes JSON fields automatically and serializing before pushing contracts to the database breaks this. This fixes the issue and lets PineJS handle the serialization.