### PR TITLE
Cache device existence check for 5 minutes

### DIFF
--- a/src/features/device-state/middleware.ts
+++ b/src/features/device-state/middleware.ts
@@ -1,7 +1,9 @@
 import type { RequestHandler } from 'express';
 import * as _ from 'lodash';
+import * as memoizee from 'memoizee';
 
 import { sbvrUtils, permissions } from '@balena/pinejs';
+import { MINUTES } from '../../lib/config';
 
 const { api } = sbvrUtils;
 
@@ -18,18 +20,21 @@ const checkDeviceExistsQuery = _.once(() =>
 		},
 	}),
 );
+export const checkDeviceExists = memoizee(
+	async (uuid: string): Promise<boolean> => {
+		const devices = await checkDeviceExistsQuery()({ uuid });
+		return devices === 0;
+	},
+	{ promise: true, maxAge: 5 * MINUTES },
+);
 
 export const gracefullyDenyDeletedDevices: RequestHandler = async (
 	req,
 	res,
 	next,
 ) => {
-	const { uuid } = req.params;
-
-	const returnCode = req.method === 'GET' ? 304 : 200;
-
-	const devices = await checkDeviceExistsQuery()({ uuid });
-	if (devices === 0) {
+	if (!checkDeviceExists(req.params.uuid)) {
+		const returnCode = req.method === 'GET' ? 304 : 200;
 		res.sendStatus(returnCode);
 		return;
 	}


### PR DESCRIPTION
This will reduce the load for the common case where active devices are
not regularly deleted with the potential to briefly respond with a 401
when a device is first deleted. There may also be a slight delay for
restored devices to be able to communicate again however again that is
a very rare case.

Change-type: patch