### PR TITLE
Simplify ignored device types handling

### DIFF
--- a/src/features/device-types/build-info-facade.ts
+++ b/src/features/device-types/build-info-facade.ts
@@ -10,18 +10,6 @@ export type DeviceType = deviceTypesLib.DeviceType;
 const BUILD_PROPERTY_CACHE_EXPIRATION = 10 * 60 * 1000; // 10 mins
 const BUILD_COMPRESSED_SIZE_CACHE_EXPIRATION = 20 * 60 * 1000; // 20 mins
 
-export const getIsIgnored = memoizee(
-	async (normalizedSlug: string, buildId: string): Promise<boolean> => {
-		return await fileExists(getImageKey(normalizedSlug, buildId, 'IGNORE'));
-	},
-	{
-		promise: true,
-		primitive: true,
-		preFetch: true,
-		maxAge: BUILD_PROPERTY_CACHE_EXPIRATION,
-	},
-);
-
 export const getLogoUrl = memoizee(
 	async (
 		normalizedSlug: string,
@@ -60,6 +48,12 @@ export const getDeviceTypeJson = memoizee(
 		normalizedSlug: string,
 		buildId: string,
 	): Promise<deviceTypesLib.DeviceType | undefined> => {
+		const isIgnored = await fileExists(
+			getImageKey(normalizedSlug, buildId, 'IGNORE'),
+		);
+		if (isIgnored) {
+			return undefined;
+		}
 		const response = await getFile(
 			getImageKey(normalizedSlug, buildId, 'device-type.json'),
 		);


### PR DESCRIPTION
By handling ignored device types transparently at the point of fetching
it allows us to avoid duplicating that code and guarantees the ignoring
is always applied

Change-type: patch