### PR TITLE
Allow composition of a release to be initially `null`

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -619,7 +619,7 @@ Fact type: release belongs to application
 Fact type: release has commit
 	Necessity: each release has exactly one commit.
 Fact type: release has composition
-	Necessity: each release has exactly one composition.
+	Necessity: each release has at most one composition.
 Fact type: release has status
 	Necessity: each release has exactly one status.
 Fact type: release has source
@@ -773,6 +773,7 @@ Fact type: config has description (Auth)
 
 Rule: It is necessary that each device1 that is managed by a device2, belongs to an application1 that depends on an application2 that owns the device2.
 Rule: It is necessary that each release that has a release version1 and has a status that is equal to "success" and is not invalidated, belongs to an application that owns exactly one release that has a release version2 that is equal to the release version1 and has a status that is equal to "success" and is not invalidated.
+Rule: It is necessary that each release that has a status that is equal to "success", has a composition.
 Rule: It is necessary that each image that has a status that is equal to "success", has a push timestamp.
 Rule: It is necessary that each application that owns a release1 that has a status that is equal to "success" and has a commit1, owns at most one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.
 Rule: It is necessary that each release that should be running on a device, has a status that is equal to "success" and belongs to an application1 that the device belongs to.

--- a/src/migrations/00046-nullable-composition.sql
+++ b/src/migrations/00046-nullable-composition.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "release" ALTER COLUMN composition DROP NOT NULL;


### PR DESCRIPTION
This permits clients to create the release resource far earlier then currently possible — before even inspecting it — which in turn allows it to be monitored sooner.

Change-type: minor