### PR TITLE
initial conversion of `should track latest release` int -> enum

### DIFF
--- a/src/balena-init.sql
+++ b/src/balena-init.sql
@@ -13,8 +13,8 @@ ALTER TABLE "device"
 ALTER COLUMN "api heartbeat state" SET DEFAULT 'unknown';
 
 ALTER TABLE "release"
-ALTER COLUMN "release type" SET DEFAULT 'final',
-ALTER COLUMN "is passing tests" SET DEFAULT 1;
+ALTER COLUMN "release type" SET DEFAULT 'draft',
+ALTER COLUMN "is passing tests" SET DEFAULT 0;
 
 -------------------------------
 -- Start foreign key indexes --

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -293,6 +293,7 @@ Term: application
 	Concept Type: actor (Auth)
 
 	Fact type: application [should track latest release]
+		Definition: "none" or "any" or "stable"
 
 	Fact type: application has env var name
 		Term Form: application environment variable

--- a/src/features/ci-cd/hooks/track-latest-release.ts
+++ b/src/features/ci-cd/hooks/track-latest-release.ts
@@ -16,10 +16,13 @@ const updateLatestRelease = async (
 		return;
 	}
 
+	// if should_track_latest_release === 'none', we never update
+	// if should_track_latest_release === 'any', we update regardless
+	// if should_track_latest_release === 'stable', we update to the most recent passing, valid, final release
 	const appsToUpdate = await api.get({
 		resource: 'application',
 		options: {
-			$select: 'id',
+			$select: ['id', 'should_track_latest_release'],
 			$expand: {
 				owns__release: {
 					$select: 'id',

--- a/src/migrations/00047-flip-release-logic.sql
+++ b/src/migrations/00047-flip-release-logic.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "release"
+ALTER COLUMN "release type" SET DEFAULT 'draft',
+ALTER COLUMN "is passing tests" SET DEFAULT 0;
+
+ALTER TABLE "application"
+ALTER COLUMN "should track latest release" TYPE TEXT USING "should track latest release"::TEXT;
+
+UPDATE "application"
+SET "should track latest release" = 'none'
+WHERE "should track latest release" = '0';
+
+UPDATE "application"
+SET "should track latest release" = 'any'
+WHERE "should track latest release" = '1';


### PR DESCRIPTION
related to
https://www.flowdock.com/app/rulemotion/resin-tech/threads/Odo2hTtX2f-dnzQkTKRu5mwYZIm,
this change will allow specifying that an application can track only the
latest _stable_ release, thus allowing draft + untested release status
as opt-in release controls

Change-type: minor
Signed-off-by: Matthew McGinn <matthew@balena.io>