### PR TITLE
Revert "Expose the RPi family config vars to raspberrypi3-unipi-neuron"

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -111,7 +111,6 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 			'raspberry-pi',
 			'raspberry-pi2',
 			'raspberrypi3',
-			'raspberrypi3-unipi-neuron',
 			'raspberrypi3-64',
 			'raspberrypi4-64',
 			'raspberrypi400-64',


### PR DESCRIPTION
This reverts commit db990479be2611f24b6262e12e1dfa092473cea0.

OpenBalena is not the place to do the config vars change for the private
device types such as the UniPi Neuron so we revert this commit here.

Change-type: minor