### PR TITLE
supervisor-releases: copy across all relevant modeling from closed API

### DIFF
--- a/src/balena-init.sql
+++ b/src/balena-init.sql
@@ -63,6 +63,8 @@ CREATE INDEX IF NOT EXISTS "device_should_be_running_release_idx"
 ON "device" ("should be running-release");
 CREATE INDEX IF NOT EXISTS "device_should_be_operated_by_release_idx"
 ON "device" ("should be operated by-release");
+CREATE INDEX IF NOT EXISTS "device_should_be_managed_by__release_idx"
+ON "device" ("should be managed by-release");
 
 -- "device config variable"."device" is the first part of an automated unique index
 

--- a/src/balena-model.ts
+++ b/src/balena-model.ts
@@ -313,6 +313,7 @@ export interface Device {
 	should_be_running__release: { __id: number } | [Release?] | null;
 	should_be_operated_by__release: { __id: number } | [Release?] | null;
 	is_managed_by__device: { __id: number } | [Device?] | null;
+	should_be_managed_by__release: { __id: number } | [Release?] | null;
 	is_web_accessible: boolean | null;
 	overall_status: string | null;
 	overall_progress: number | null;

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -552,6 +552,9 @@ Fact type: device should be operated by release
 Fact type: device1 is managed by device2
 	Synonymous Form: device2 manages device1
 	Necessity: each device1 is managed by at most one device2.
+Fact type: device should be managed by release
+	Synonymous Form: release should manage device
+	Necessity: each device should be managed by at most one release
 
 
 -- application config variable
@@ -784,3 +787,8 @@ Rule: It is necessary that each release that should be running on an application
 Rule: It is necessary that each release that contains at least 2 images, belongs to an application that has an application type that supports multicontainer.
 Rule: It is necessary that each release that should operate a device, has a status that is equal to "success".
 Rule: It is necessary that each release that should operate a device, belongs to an application that is host and is for a device type that describes the device.
+-- native supervisor release rules, separated for legibility
+Rule: It is necessary that each release that should manage a device, has a status that is equal to "success" and has exactly one release version.
+-- this rule is meant to prevent accidentally setting a host extension as a supervisor (i.e., another public + non-host app)
+Rule: It is necessary that each release that should manage a device, belongs to an application that is public and is not host and has a slug that is equal to "balena_os/aarch64-supervisor" or "balena_os/amd64-supervisor" or "balena_os/armv7hf-supervisor" or "balena_os/i386-supervisor" or "balena_os/i386-nlp-supervisor" or "balena_os/rpi-supervisor".
+Rule: It is necessary that each release that should manage a device that is of a device type1, belongs to an application that is for a device type2 that is of a cpu architecture that is supported by the device type1.

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -789,6 +789,5 @@ Rule: It is necessary that each release that should operate a device, has a stat
 Rule: It is necessary that each release that should operate a device, belongs to an application that is host and is for a device type that describes the device.
 -- native supervisor release rules, separated for legibility
 Rule: It is necessary that each release that should manage a device, has a status that is equal to "success" and has exactly one release version.
--- this rule is meant to prevent accidentally setting a host extension as a supervisor (i.e., another public + non-host app)
-Rule: It is necessary that each release that should manage a device, belongs to an application that is public and is not host and has a slug that is equal to "balena_os/aarch64-supervisor" or "balena_os/amd64-supervisor" or "balena_os/armv7hf-supervisor" or "balena_os/i386-supervisor" or "balena_os/i386-nlp-supervisor" or "balena_os/rpi-supervisor".
+Rule: It is necessary that each release that should manage a device, belongs to an application that is public and is not host.
 Rule: It is necessary that each release that should manage a device that is of a device type1, belongs to an application that is for a device type2 that is of a cpu architecture that is supported by the device type1.

--- a/src/features/supervisor-app/hooks/index.ts
+++ b/src/features/supervisor-app/hooks/index.ts
@@ -1,0 +1,1 @@
+import './supervisor-app';

--- a/src/features/supervisor-app/hooks/supervisor-app.ts
+++ b/src/features/supervisor-app/hooks/supervisor-app.ts
@@ -17,13 +17,12 @@ hooks.addPureHook('PATCH', 'resin', 'device', {
 	 */
 	async PRERUN(args) {
 		if (args.request.values.supervisor_version != null) {
-			await sbvrUtils.getAffectedIds(args).then(async (ids) => {
-				await setSupervisorReleaseResource(
-					args.api,
-					ids,
-					args.request.values.supervisor_version,
-				);
-			});
+			const ids = await sbvrUtils.getAffectedIds(args);
+			await setSupervisorReleaseResource(
+				args.api,
+				ids,
+				args.request.values.supervisor_version,
+			);
 		}
 	},
 });
@@ -48,15 +47,12 @@ hooks.addPureHook('PATCH', 'resin', 'device', {
 
 			// Ensure that we don't ever downgrade the supervisor
 			// from its current version
-			await sbvrUtils
-				.getAffectedIds(args)
-				.then((ids) =>
-					checkSupervisorReleaseUpgrades(
-						args.api,
-						ids,
-						args.request.custom.supervisorRelease,
-					),
-				);
+			const ids = await sbvrUtils.getAffectedIds(args);
+			await checkSupervisorReleaseUpgrades(
+				args.api,
+				ids,
+				args.request.custom.supervisorRelease,
+			);
 		}
 	},
 });

--- a/src/features/supervisor-app/hooks/supervisor-app.ts
+++ b/src/features/supervisor-app/hooks/supervisor-app.ts
@@ -1,0 +1,248 @@
+import * as semver from 'balena-semver';
+import * as _ from 'lodash';
+
+import {
+	sbvrUtils,
+	hooks,
+	permissions,
+	errors as pinejsErrors,
+} from '@balena/pinejs';
+
+const { BadRequestError } = pinejsErrors;
+
+hooks.addPureHook('PATCH', 'resin', 'device', {
+	/**
+	 * When a device checks in with it's initial supervisor version, set the corresponding should_be_managed_by__release resource
+	 * using its current reported version.
+	 */
+	async PRERUN(args) {
+		if (args.request.values.supervisor_version != null) {
+			await sbvrUtils.getAffectedIds(args).then(async (ids) => {
+				await setSupervisorReleaseResource(
+					args.api,
+					ids,
+					args.request.values.supervisor_version,
+				);
+			});
+		}
+	},
+});
+
+hooks.addPureHook('PATCH', 'resin', 'device', {
+	/**
+	 * Disallow supervisor downgrades, using the related release resource
+	 */
+	async PRERUN(args) {
+		if (args.request.values.should_be_managed_by__release != null) {
+			// First try to coerce the value to an integer for
+			// moving forward
+			args.request.custom.supervisorRelease = parseInt(
+				args.request.values.should_be_managed_by__release,
+				10,
+			);
+			// But let's check we actually got a value
+			// representing an integer
+			if (!Number.isInteger(args.request.custom.supervisorRelease)) {
+				throw new BadRequestError('Expected an ID for the supervisor_release');
+			}
+
+			// Ensure that we don't ever downgrade the supervisor
+			// from its current version
+			await sbvrUtils
+				.getAffectedIds(args)
+				.then((ids) =>
+					checkSupervisorReleaseUpgrades(
+						args.api,
+						ids,
+						args.request.custom.supervisorRelease,
+					),
+				);
+		}
+	},
+});
+
+async function checkSupervisorReleaseUpgrades(
+	api: sbvrUtils.PinejsClient,
+	deviceIds: number[],
+	newSupervisorReleaseId: number,
+) {
+	if (deviceIds.length === 0) {
+		return;
+	}
+	const nullSupervisorCount = await api.get({
+		resource: 'device',
+		options: {
+			$count: { $filter: { id: { $in: deviceIds }, supervisor_version: null } },
+		},
+	});
+
+	if (nullSupervisorCount === deviceIds.length) {
+		return;
+	}
+
+	const newSupervisorRelease = await api.get({
+		resource: 'release',
+		id: newSupervisorReleaseId,
+		options: {
+			$select: 'release_version',
+			$filter: {
+				is_invalidated: false,
+			},
+		},
+	});
+
+	if (newSupervisorRelease == null) {
+		throw new BadRequestError(
+			`Could not find a supervisor release with this ID ${newSupervisorReleaseId}`,
+		);
+	}
+
+	const newSupervisorVersion = newSupervisorRelease.release_version;
+
+	const releases = await api.get({
+		resource: 'release',
+		options: {
+			$select: 'release_version',
+			$filter: {
+				should_manage__device: {
+					$any: {
+						$alias: 'd',
+						$expr: {
+							d: {
+								id: {
+									$in: deviceIds,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	});
+
+	for (const release of releases) {
+		const oldVersion = release.release_version;
+		if (semver.lt(newSupervisorVersion, oldVersion)) {
+			throw new BadRequestError(
+				`Attempt to downgrade supervisor, which is not allowed`,
+			);
+		}
+	}
+}
+
+async function getSupervisorReleaseResource(
+	api: sbvrUtils.PinejsClient,
+	supervisorVersion: string,
+	archId: string,
+) {
+	return await api.get({
+		resource: 'release',
+		options: {
+			$select: ['id', 'release_version'],
+			$filter: {
+				release_version: `v${supervisorVersion}`,
+				status: 'success',
+				belongs_to__application: {
+					$any: {
+						$alias: 'a',
+						$expr: {
+							a: {
+								is_public: true,
+								is_host: false,
+								is_for__device_type: {
+									$any: {
+										$alias: 'dt',
+										$expr: {
+											dt: {
+												is_of__cpu_architecture: {
+													$any: {
+														$alias: 'c',
+														$expr: {
+															c: {
+																id: archId,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	});
+}
+
+async function setSupervisorReleaseResource(
+	api: sbvrUtils.PinejsClient,
+	deviceIds: number[],
+	supervisorVersion: string,
+) {
+	if (deviceIds.length === 0) {
+		return;
+	}
+	const devices = await api.get({
+		resource: 'device',
+		options: {
+			// if the device already has a supervisor_version, just bail.
+			$filter: {
+				id: { $in: deviceIds },
+				supervisor_version: null,
+			},
+			$select: ['id'],
+			$expand: {
+				is_of__device_type: { $select: ['is_of__cpu_architecture', 'id'] },
+			},
+		},
+	});
+
+	if (devices.length === 0) {
+		return;
+	}
+
+	const devicesByDeviceTypeArch = _.groupBy(devices, (d) => {
+		return d.is_of__device_type[0].is_of__cpu_architecture.__id;
+	});
+
+	if (Object.keys(devicesByDeviceTypeArch).length === 0) {
+		return;
+	}
+
+	const rootApi = api.clone({
+		passthrough: {
+			req: permissions.root,
+		},
+	});
+
+	return Promise.all(
+		_.map(devicesByDeviceTypeArch, async (affectedDevices, deviceTypeArch) => {
+			const affectedDeviceIds = affectedDevices.map((d) => d.id);
+
+			const [supervisorRelease] = await getSupervisorReleaseResource(
+				api,
+				supervisorVersion,
+				deviceTypeArch,
+			);
+
+			if (supervisorRelease == null) {
+				return;
+			}
+
+			await rootApi.patch({
+				resource: 'device',
+				options: {
+					$filter: {
+						id: { $in: affectedDeviceIds },
+					},
+				},
+				body: {
+					should_be_managed_by__release: supervisorRelease.id,
+				},
+			});
+		}),
+	);
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -9,6 +9,7 @@ import './features/device-urls/hooks';
 import './features/device-types/hooks';
 import './features/hostapp/hooks';
 import './features/organizations/hooks';
+import './features/supervisor-app/hooks';
 import './features/tags/hooks';
 import './features/vars-schema/hooks';
 import './features/vpn/hooks';

--- a/src/migrations/00049-supervisor-app.sql
+++ b/src/migrations/00049-supervisor-app.sql
@@ -1,0 +1,6 @@
+-- migrate to add a should be managed by-release relationship to the devices...
+ALTER TABLE "device"
+ADD COLUMN IF NOT EXISTS "should be managed by-release" INT NULL;
+
+CREATE INDEX IF NOT EXISTS "device_should_be_managed_by__release_idx"
+ON "device" ("should be managed by-release");

--- a/test/16_supervisor_releases.ts
+++ b/test/16_supervisor_releases.ts
@@ -1,0 +1,231 @@
+import { expect } from './test-lib/chai';
+import * as fixtures from './test-lib/fixtures';
+import * as fakeDevice from './test-lib/fake-device';
+import { supertest } from './test-lib/supertest';
+import { version } from './test-lib/versions';
+
+describe('Devices running supervisor releases', () => {
+	const ctx: AnyObject = {};
+	let device: fakeDevice.Device;
+	let device2: fakeDevice.Device;
+	let device3: fakeDevice.Device;
+
+	before(async () => {
+		const fx = await fixtures.load('16-supervisor-app');
+		ctx.fixtures = fx;
+		ctx.admin = fx.users.admin;
+		ctx.public_app = fx.applications.public_app;
+		ctx.deviceApp = fx.applications.app1;
+		ctx.public_pi_app = fx.applications.public_pi_app;
+		ctx.host_app = fx.applications.host_app;
+		ctx.supervisorReleases = ctx.fixtures['releases'];
+		device = await fakeDevice.provisionDevice(ctx.admin, ctx.deviceApp.id);
+		device2 = await fakeDevice.provisionDevice(ctx.admin, ctx.deviceApp.id);
+		device3 = await fakeDevice.provisionDevice(ctx.admin, ctx.deviceApp.id);
+	});
+
+	after(async () => {
+		await fixtures.clean({ devices: [device, device2] });
+		await fixtures.clean(ctx.fixtures);
+	});
+
+	describe('Devices running supervisor releases', () => {
+		it('should be provisioned with a non-null supervisor release after device PATCH', async () => {
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send({
+					os_version: '2.38.0+rev1',
+					supervisor_version: '5.0.1',
+				})
+				.expect(200);
+
+			const res = await supertest(ctx.admin).get(
+				`/${version}/device(${device.id})`,
+			);
+			const nativeSupervisorRes = await supertest(ctx.admin).get(
+				`/${version}/release(${res.body.d[0].should_be_managed_by__release.__id})?$select=release_version`,
+			);
+			expect(nativeSupervisorRes.body)
+				.to.have.nested.property('d[0].release_version')
+				.that.equals(`v${res.body.d[0].supervisor_version}`);
+		});
+
+		it('should be set to a non-null supervisor release after state endpoint PATCH', async () => {
+			await device2.patchStateV2({
+				local: {
+					api_port: 48484,
+					api_secret: 'somesecret',
+					os_version: '2.38.0+rev1',
+					os_variant: 'dev',
+					supervisor_version: '5.0.1',
+					provisioning_progress: null,
+					provisioning_state: '',
+					status: 'Idle',
+					logs_channel: null,
+					update_failed: false,
+					update_pending: false,
+					update_downloaded: false,
+				},
+			});
+
+			const res = await supertest(ctx.admin).get(
+				`/${version}/device(${device2.id})`,
+			);
+			const nativeSupervisorRes = await supertest(ctx.admin).get(
+				`/${version}/release(${res.body.d[0].should_be_managed_by__release.__id})?$select=release_version`,
+			);
+			expect(nativeSupervisorRes.body)
+				.to.have.nested.property('d[0].release_version')
+				.that.equals(`v${res.body.d[0].supervisor_version}`);
+		});
+
+		it('should allow upgrading to a logstream version', async () => {
+			const patch = {
+				should_be_managed_by__release:
+					ctx.supervisorReleases['6.0.1_logstream'].id,
+			};
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send(patch)
+				.expect(200);
+			const res = await supertest(ctx.admin).get(
+				`/${version}/device(${device.id})`,
+			);
+			expect(res.body)
+				.to.have.nested.property('d[0].should_be_managed_by__release.__id')
+				.that.equals(ctx.supervisorReleases['6.0.1_logstream'].id);
+		});
+
+		it("should allow upgrading a device's supervisor release", async () => {
+			const patch = {
+				should_be_managed_by__release: ctx.supervisorReleases['7.0.1'].id,
+			};
+			const patch2 = {
+				should_be_managed_by__release: ctx.supervisorReleases['8.0.1'].id,
+			};
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send(patch)
+				.expect(200);
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send(patch2)
+				.expect(200);
+			const res = await supertest(ctx.admin).get(
+				`/${version}/device(${device.id})`,
+			);
+			expect(res.body)
+				.to.have.nested.property('d[0].should_be_managed_by__release.__id')
+				.that.equals(ctx.supervisorReleases['8.0.1'].id);
+		});
+
+		it('should provision to an invalidated release', async () => {
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send({
+					supervisor_version: null,
+					should_be_managed_by__release: null,
+				})
+				.expect(200);
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send({
+					supervisor_version: '8.1.1',
+				})
+				.expect(200);
+			const { body } = await supertest(ctx.admin)
+				.get(`/${version}/device(${device.id})`)
+				.expect(200);
+			expect(body).to.have.nested.property('d[0].should_be_managed_by__release')
+				.that.is.not.null;
+		});
+
+		it('should not allow upgrading to a release without a release version', async () => {
+			const patch = {
+				should_be_managed_by__release: ctx.supervisorReleases['no_version'].id,
+			};
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send(patch)
+				.expect(400);
+		});
+
+		it('should not allow upgrading to a different architecture', async () => {
+			const patch = {
+				should_be_managed_by__release: ctx.supervisorReleases['12.1.1'].id,
+			};
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send(patch)
+				.expect(400);
+		});
+
+		it('should not allow upgrading to an invalidated release', async () => {
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device3.id})`)
+				.send({
+					supervisor_version: '8.0.1',
+				})
+				.expect(200);
+			const patch = {
+				should_be_managed_by__release: ctx.supervisorReleases['8.1.1'].id,
+			};
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device3.id})`)
+				.send(patch)
+				.expect(400);
+		});
+
+		it('should not allow setting a supervisor native release to a non-public app', async () => {
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send({
+					should_be_managed_by__release:
+						ctx.supervisorReleases['user_release'].id,
+				})
+				.expect(400);
+		});
+
+		it('should not allow setting a supervisor native release to a hostapp', async () => {
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send({
+					should_be_managed_by__release:
+						ctx.supervisorReleases['hostapp_release'].id,
+				})
+				.expect(400);
+		});
+
+		it('should fail if supervisor release does not exist', async () => {
+			const fakeId = 999;
+			const patch = {
+				should_be_managed_by__release: fakeId,
+			};
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send(patch)
+				.expect(400);
+		});
+
+		it('should not allow downgrading a supervisor version', async () => {
+			const patch = {
+				should_be_managed_by__release: ctx.supervisorReleases['7.0.1'].id,
+			};
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send(patch)
+				.expect(400);
+		});
+
+		it('should correctly determine logstream values', async () => {
+			const patch = {
+				should_be_managed_by__release:
+					ctx.supervisorReleases['6.0.1_logstream'].id,
+			};
+			await supertest(ctx.admin)
+				.patch(`/${version}/device(${device.id})`)
+				.send(patch)
+				.expect(400);
+		});
+	});
+});

--- a/test/16_supervisor_releases.ts
+++ b/test/16_supervisor_releases.ts
@@ -25,7 +25,7 @@ describe('Devices running supervisor releases', () => {
 	});
 
 	after(async () => {
-		await fixtures.clean({ devices: [device, device2] });
+		await fixtures.clean({ devices: [device, device2, device3] });
 		await fixtures.clean(ctx.fixtures);
 	});
 

--- a/test/fixtures/16-supervisor-app/applications.json
+++ b/test/fixtures/16-supervisor-app/applications.json
@@ -1,0 +1,29 @@
+{
+	"app1": {
+		"user": "admin",
+		"device_type": "intel-nuc",
+		"app_name": "supervisor_release_test_app"
+	},
+	"host_app": {
+		"user": "admin",
+		"device_type": "intel-nuc",
+		"is_public": true,
+		"is_host": true,
+		"app_name": "test-device-type",
+		"organization": "balena_os"
+	},
+	"public_pi_app": {
+		"user": "admin",
+		"device_type": "raspberrypi3",
+		"is_public": true,
+		"app_name": "armv7hf-supervisor",
+		"organization": "balena_os"
+	},
+	"public_app": {
+		"user": "admin",
+		"device_type": "intel-nuc",
+		"is_public": true,
+		"app_name": "amd64-supervisor",
+		"organization": "balena_os"
+	}
+}

--- a/test/fixtures/16-supervisor-app/images.json
+++ b/test/fixtures/16-supervisor-app/images.json
@@ -1,0 +1,58 @@
+{
+	"image1": {
+		"user": "admin",
+		"service": "service1",
+		"releases": [ "5.0.1" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"image2": {
+		"user": "admin",
+		"service": "service1",
+		"releases": [ "6.0.1_logstream" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"image3": {
+		"user": "admin",
+		"service": "service1",
+		"releases": [ "7.0.1" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"image4": {
+		"user": "admin",
+		"service": "service1",
+		"releases": [ "8.0.1" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"image5": {
+		"user": "admin",
+		"service": "service2",
+		"releases": [ "user_release" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"image6": {
+		"user": "admin",
+		"service": "service3",
+		"releases": [ "hostapp_release" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"image7": {
+		"user": "admin",
+		"service": "service1",
+		"releases": [ "8.1.1" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"image8": {
+		"user": "admin",
+		"service": "service4",
+		"releases": [ "12.1.1" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	}
+}

--- a/test/fixtures/16-supervisor-app/releases.json
+++ b/test/fixtures/16-supervisor-app/releases.json
@@ -1,0 +1,130 @@
+{
+	"5.0.1": {
+		"user": "admin",
+		"application": "public_app",
+		"release_version": "v5.0.1",
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image1": {
+					"build": "./image1/"
+				}
+			}
+		}
+	},
+	"6.0.1_logstream": {
+		"user": "admin",
+		"application": "public_app",
+		"release_version": "v6.0.1_logstream",
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image2": {
+					"build": "./image2/"
+				}
+			}
+		}
+	},
+	"7.0.1": {
+		"user": "admin",
+		"application": "public_app",
+		"release_version": "v7.0.1",
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image3": {
+					"build": "./image3/"
+				}
+			}
+		}
+	},
+	"8.0.1": {
+		"user": "admin",
+		"application": "public_app",
+		"release_version": "v8.0.1",
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image4": {
+					"build": "./image4/"
+				}
+			}
+		}
+	},
+	"8.1.1": {
+		"user": "admin",
+		"application": "public_app",
+		"release_version": "v8.1.1",
+		"status": "success",
+		"source": "cloud",
+		"is_invalidated": true,
+		"composition": {
+			"services": {
+				"image7": {
+					"build": "./image7/"
+				}
+			}
+		}
+	},
+	"12.1.1": {
+		"user": "admin",
+		"application": "public_pi_app",
+		"release_version": "v12.1.1",
+		"status": "success",
+		"source": "cloud",
+		"is_invalidated": false,
+		"composition": {
+			"services": {
+				"image8": {
+					"build": "./image8/"
+				}
+			}
+		}
+	},
+	"no_version": {
+		"user": "admin",
+		"application": "public_pi_app",
+		"status": "success",
+		"source": "cloud",
+		"is_invalidated": false,
+		"composition": {
+			"services": {
+				"image8": {
+					"build": "./image8/"
+				}
+			}
+		}
+	},
+	"hostapp_release": {
+		"user": "admin",
+		"application": "host_app",
+		"release_version": "v9.0.1",
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image6": {
+					"build": "./image6/"
+				}
+			}
+		}
+	},
+	"user_release": {
+		"user": "admin",
+		"application": "app1",
+		"release_version": "v9.0.1",
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image5": {
+					"build": "./image5/"
+				}
+			}
+		}
+	}
+}

--- a/test/fixtures/16-supervisor-app/services.json
+++ b/test/fixtures/16-supervisor-app/services.json
@@ -1,0 +1,22 @@
+{
+	"service1": {
+		"service_name": "service1",
+		"application": "public_app",
+		"user": "admin"
+	},
+	"service2": {
+		"service_name": "service2",
+		"application": "app1",
+		"user": "admin"
+	},
+	"service3": {
+		"service_name": "service3",
+		"application": "host_app",
+		"user": "admin"
+	},
+	"service4": {
+		"service_name": "service4",
+		"application": "public_pi_app",
+		"user": "admin"
+	}
+}

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -172,6 +172,7 @@ const loaders: Dictionary<LoaderFunc> = {
 					'composition',
 					'source',
 					'release_version',
+					'is_invalidated',
 					'release_type',
 					'is_passing_tests',
 				),


### PR DESCRIPTION
supervisor-releases: copy across all relevant modeling from closed API
    
Connects-to: https://github.com/balena-io/open-balena-api/pull/504
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>
