### PR TITLE
supervisor-apps: allow provisioning directly to a logstream edition

### DIFF
--- a/src/features/supervisor-app/hooks/supervisor-app.ts
+++ b/src/features/supervisor-app/hooks/supervisor-app.ts
@@ -135,8 +135,15 @@ async function getSupervisorReleaseResource(
 		resource: 'release',
 		options: {
 			$select: ['id', 'release_version'],
+			// technically this is in violation of semver, but is required until logstreams go away
+			$orderby: { release_version: 'desc' },
+			$top: 1,
 			$filter: {
-				release_version: `v${supervisorVersion}`,
+				$or: [
+					{ release_version: `v${supervisorVersion}` },
+					{ release_version: `v${supervisorVersion}_logstream` },
+					{ release_version: `v${supervisorVersion}_logstream2` },
+				],
 				status: 'success',
 				belongs_to__application: {
 					$any: {

--- a/test/16_supervisor_releases.ts
+++ b/test/16_supervisor_releases.ts
@@ -9,6 +9,7 @@ describe('Devices running supervisor releases', () => {
 	let device: fakeDevice.Device;
 	let device2: fakeDevice.Device;
 	let device3: fakeDevice.Device;
+	let device4: fakeDevice.Device;
 
 	before(async () => {
 		const fx = await fixtures.load('16-supervisor-app');
@@ -22,10 +23,11 @@ describe('Devices running supervisor releases', () => {
 		device = await fakeDevice.provisionDevice(ctx.admin, ctx.deviceApp.id);
 		device2 = await fakeDevice.provisionDevice(ctx.admin, ctx.deviceApp.id);
 		device3 = await fakeDevice.provisionDevice(ctx.admin, ctx.deviceApp.id);
+		device4 = await fakeDevice.provisionDevice(ctx.admin, ctx.deviceApp.id);
 	});
 
 	after(async () => {
-		await fixtures.clean({ devices: [device, device2, device3] });
+		await fixtures.clean({ devices: [device, device2, device3, device4] });
 		await fixtures.clean(ctx.fixtures);
 	});
 
@@ -90,6 +92,32 @@ describe('Devices running supervisor releases', () => {
 				.expect(200);
 			const res = await supertest(ctx.admin).get(
 				`/${version}/device(${device.id})`,
+			);
+			expect(res.body)
+				.to.have.nested.property('d[0].should_be_managed_by__release.__id')
+				.that.equals(ctx.supervisorReleases['6.0.1_logstream'].id);
+		});
+
+		it('should provision to a _logstream supervisor edition', async () => {
+			await device4.patchStateV2({
+				local: {
+					api_port: 48484,
+					api_secret: 'somesecret',
+					os_version: '2.38.0+rev1',
+					os_variant: 'dev',
+					supervisor_version: '6.0.1',
+					provisioning_progress: null,
+					provisioning_state: '',
+					status: 'Idle',
+					logs_channel: null,
+					update_failed: false,
+					update_pending: false,
+					update_downloaded: false,
+				},
+			});
+
+			const res = await supertest(ctx.admin).get(
+				`/${version}/device(${device4.id})`,
 			);
 			expect(res.body)
 				.to.have.nested.property('d[0].should_be_managed_by__release.__id')

--- a/test/fixtures/16-supervisor-app/releases.json
+++ b/test/fixtures/16-supervisor-app/releases.json
@@ -13,6 +13,20 @@
 			}
 		}
 	},
+	"6.0.1": {
+		"user": "admin",
+		"application": "public_app",
+		"release_version": "v6.0.1",
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image2": {
+					"build": "./image2/"
+				}
+			}
+		}
+	},
 	"6.0.1_logstream": {
 		"user": "admin",
 		"application": "public_app",


### PR DESCRIPTION
Change-type: patch
Connects-to: https://github.com/balena-io/open-balena-api/issues/665
Signed-off-by: Matthew McGinn <matthew@balena.io>