### PR TITLE
Use `true = false` rather than `1 = 2` for generating a false result

### DIFF
--- a/src/features/devices/models/device-additions.ts
+++ b/src/features/devices/models/device-additions.ts
@@ -37,7 +37,7 @@ export const addToModel = (
 	// false), otherwise it'll generate a case that looks into the actual model
 	// field.
 	const isInactive: EqualsNode = addShims
-		? ['Equals', ['Number', 1], ['Number', 2]]
+		? ['Equals', ['Boolean', true], ['Boolean', false]]
 		: [
 				'Equals',
 				['ReferencedField', 'device', 'is active'],


### PR DESCRIPTION
Change-type: patch