### PR TITLE
Add Build Stat to Release

### DIFF
--- a/src/balena-model.ts
+++ b/src/balena-model.ts
@@ -375,10 +375,22 @@ export interface DeviceTag {
 	value: string;
 }
 
+export interface BuildStat {
+	created_at: DateString;
+	modified_at: DateString;
+	id: number;
+	peak_memory_usage: number;
+	peak_cpu_usage: number;
+	average_memory_usage: number;
+	average_cpu_usage: number;
+	run_time: number;
+}
+
 export interface Release {
 	created_at: DateString;
 	modified_at: DateString;
 	id: number;
+	build_stat: { __id: number } | [BuildStat?] | null;
 	belongs_to__application: { __id: number } | [Application];
 	commit: string;
 	composition: {};

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -87,6 +87,12 @@ Term: api secret
 Term: app name
 	Concept Type: Text (Type)
 
+Term: average cpu usage
+	Concept Type: Integer (Type)
+
+Term: average memory usage
+	Concept Type: Integer (Type)
+
 Term: build log
 	Concept Type: Text (Type)
 
@@ -207,6 +213,12 @@ Term: os version range
 Term: os variant
 	Concept Type: Short Text (Type)
 
+Term: peak cpu usage
+	Concept Type: Integer (Type)
+
+Term: peak memory usage
+	Concept Type: Integer (Type)
+
 Term: project type
 	Concept Type: Short Text (Type)
 
@@ -230,6 +242,9 @@ Term: release version
 
 Term: release type
 	Concept Type: Short Text (Type)
+
+Term: run time
+	Concept Type: Integer (Type)
 
 Term: scope
 	Concept Type: Short Text (Type)
@@ -351,6 +366,19 @@ Term: device
 		Database Table Name: device tag
 		Necessity: each device tag has a tag key that has a Length (Type) that is greater than 0.
 
+Term: build stat
+
+Fact type: build stat has peak memory usage
+	Necessity: each build stat has exactly one peak memory usage
+Fact type: build stat has peak cpu usage
+	Necessity: each build stat has exactly one peak cpu usage
+Fact type: build stat has average memory usage
+	Necessity: each build stat has exactly one average memory usage
+Fact type: build stat has average cpu usage
+	Necessity: each build stat has exactly one average cpu usage
+Fact type: build stat has run time
+	Necessity: each build stat has exactly one run time
+
 Term: release
 
 Fact type: release has tag key
@@ -380,6 +408,8 @@ Fact type: user (Auth) is member of organization
 	Database Table Name: organization membership
 	Term Form: organization membership
 
+Fact type: release has build stat
+	Necessity: each release has at most one build stat.
 
 -- organization
 


### PR DESCRIPTION
This change is part of the larger change to add build statistics from the Builder to Releases.

Signed-off-by: Paul Jonathan Zoulin <pj@balena.io>
Change-type: minor
See:  https://www.flowdock.com/app/rulemotion/resin-tech/threads/4dsc0_Fec2ZZ3xxnZT3hkG7UMHM