### PR TITLE
env-vars: Remove check for reserved namespaces

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -282,14 +282,6 @@ export const checkConfigVarNameValidity = (name: string) => {
 
 export const checkEnvVarNameValidity = (name: string) => {
 	checkVarName('Environment variable', name);
-
-	if (startsWithAny(RESERVED_NAMESPACES, name)) {
-		throw new BadRequestError(
-			`Environment variables beginning with ${RESERVED_NAMESPACES.join(
-				', ',
-			)} are reserved.`,
-		);
-	}
 };
 
 export const checkEnvVarValueValidity = (value: string) => {


### PR DESCRIPTION
This was leftover legacy behaviour from when config vars
were handled the same way as env vars.

See: https://jel.ly.fish/8b4c23c9-705a-46bd-b446-707aeba29d45
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>