### PR TITLE
release versioning 1: Add and start setting the semver & revision fields

### DIFF
--- a/src/balena-init.sql
+++ b/src/balena-init.sql
@@ -13,8 +13,11 @@ ALTER TABLE "device"
 ALTER COLUMN "api heartbeat state" SET DEFAULT 'unknown';
 
 ALTER TABLE "release"
-ALTER COLUMN "release type" SET DEFAULT 'final',
-ALTER COLUMN "is passing tests" SET DEFAULT 1;
+ALTER COLUMN "release type" SET DEFAULT 'final',-- TODO: Drop after the release versioning migration
+ALTER COLUMN "is passing tests" SET DEFAULT 1,
+ALTER COLUMN "semver major" SET DEFAULT 0,
+ALTER COLUMN "semver minor" SET DEFAULT 0,
+ALTER COLUMN "semver patch" SET DEFAULT 0;
 
 -------------------------------
 -- Start foreign key indexes --
@@ -163,3 +166,7 @@ ON "image" USING GIN ("is stored at-image location" gin_trgm_ops);
 -- Optimization for device state query
 CREATE INDEX IF NOT EXISTS "release_id_belongs_to_app_idx"
 ON "release" ("id", "belongs to-application");
+
+-- Optimization for the app-semver-revision uniqueness rule and for computing the next revision
+CREATE INDEX IF NOT EXISTS "release_belongs_to_app_revision_semver_idx"
+ON "release" ("belongs to-application", "revision", "semver major", "semver minor", "semver patch");

--- a/src/balena-model.ts
+++ b/src/balena-model.ts
@@ -393,6 +393,13 @@ export interface Release {
 	contract: {} | null;
 	is_passing_tests: boolean;
 	release_type: 'final' | 'draft';
+	is_finalized_at__date: DateString | null;
+	semver_major: number;
+	semver_minor: number;
+	semver_patch: number;
+	revision: number | null;
+	is_final: boolean;
+	semver: string;
 }
 
 export interface ReleaseTag {

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -231,6 +231,9 @@ Term: release version
 Term: release type
 	Concept Type: Short Text (Type)
 
+Term: revision
+	Concept Type: Integer (Type)
+
 Term: scope
 	Concept Type: Short Text (Type)
 
@@ -251,6 +254,15 @@ Term: start timestamp
 
 Term: status
 	Concept Type: Short Text (Type)
+
+Term: semver major
+	Concept Type: Integer (Type)
+
+Term: semver minor
+	Concept Type: Integer (Type)
+
+Term: semver patch
+	Concept Type: Integer (Type)
 
 Term: supervisor version
 	Concept Type: Short Text (Type)
@@ -645,9 +657,21 @@ Fact type: release has release version
 Fact type: release has contract
 	Necessity: each release has at most one contract
 Fact type: release is passing tests
+-- TODO: Drop after the release versioning migration
 Fact type: release has release type
 	Necessity: each release has exactly one release type.
 	Definition: "final" or "draft"
+Fact type: release is finalized at date
+	Necessity: each release is finalized at at most one date.
+Fact type: release has semver major
+	Necessity: each release has exactly one semver major.
+Fact type: release has semver minor
+	Necessity: each release has exactly one semver minor.
+Fact type: release has semver patch
+	Necessity: each release has exactly one semver patch.
+Fact type: release has revision
+	Necessity: each release has at most one revision.
+	Necessity: each release that has a revision, has a revision that is greater than or equal to 0.
 
 
 -- service environment variable

--- a/src/balena.ts
+++ b/src/balena.ts
@@ -7,6 +7,7 @@ import {
 
 import * as userHasDirectAccessToApplication from './features/applications/models/user__has_direct_access_to__application';
 import * as deviceAdditions from './features/devices/models/device-additions';
+import * as releaseAdditions from './features/ci-cd/models/release-additions';
 
 export const apiRoot = 'resin';
 export const modelName = 'balena';
@@ -23,5 +24,6 @@ renameEnvVarName(abstractSql);
 
 userHasDirectAccessToApplication.addToModel(abstractSql);
 deviceAdditions.addToModel(abstractSql);
+releaseAdditions.addToModel(abstractSql);
 
 optimizeSchema(abstractSql);

--- a/src/features/ci-cd/hooks/release-versioning.ts
+++ b/src/features/ci-cd/hooks/release-versioning.ts
@@ -1,4 +1,9 @@
-import { sbvrUtils, hooks, errors } from '@balena/pinejs';
+import { sbvrUtils, hooks, errors, permissions } from '@balena/pinejs';
+import type { FilterObj } from 'pinejs-client-core';
+import * as _ from 'lodash';
+import { ADVISORY_LOCK_NAMESPACES } from '../../../lib/config';
+import { groupByMap } from '../../../lib/utils';
+import type { PickDeferred, Release } from '../../../balena-model';
 
 const { BadRequestError } = errors;
 
@@ -27,5 +32,327 @@ hooks.addPureHook('PATCH', 'resin', 'release', {
 				);
 			}
 		}
+	},
+});
+
+const getAdvisoryLockForApp = async (tx: Tx, appId: number) => {
+	if (!Number.isInteger(appId)) {
+		// This should never happen, since Pine has already validated the value,
+		// but double-check it just to be sure what we are passing to the advisory lock.
+		throw new errors.BadRequestError(
+			'Invalid belongs_to__application parameter',
+		);
+	}
+	await tx.executeSql(`SELECT pg_advisory_xact_lock($1, $2);`, [
+		ADVISORY_LOCK_NAMESPACES.release__revision__belongs_to__application,
+		appId,
+	]);
+};
+
+const getNextRevision = async (
+	api: sbvrUtils.PinejsClient,
+	applicationId: number,
+	semver: string,
+) => {
+	const [releaseWithLatestRevision] = (await api.get({
+		resource: 'release',
+		options: {
+			$top: 1,
+			$select: 'revision',
+			$filter: {
+				belongs_to__application: applicationId,
+				semver,
+				// Check both fields, so that instances of this deploy step, can work with instances of the next step.
+				revision: { $ne: null },
+				// TODO[release versioning next step]: Drop this after re-migrating all data on step 2:
+				release_type: 'final',
+			},
+			$orderby: {
+				revision: 'desc',
+			},
+		},
+	})) as Array<NonNullableField<Pick<Release, 'revision'>, 'revision'>>;
+
+	return releaseWithLatestRevision != null
+		? releaseWithLatestRevision.revision + 1
+		: 0;
+};
+
+const releaseTypeToFinalMap = {
+	draft: false,
+	final: true,
+};
+
+const PLAIN_SEMVER_REGEX = /^([0-9]+)\.([0-9]+)\.([0-9]+)$/;
+
+interface CustomObjectBase {
+	is_final?: boolean;
+	semver?: string;
+}
+
+const parseReleaseVersioningFields: (args: sbvrUtils.HookArgs) => void = ({
+	request,
+}) => {
+	const { is_final, release_type } = request.values;
+	if (typeof is_final === 'boolean') {
+		// TODO[release versioning next step]: Drop this once we move the release_type to a translation
+		const inferredReleaseType = is_final ? 'final' : 'draft';
+		if (release_type != null && release_type !== inferredReleaseType) {
+			throw new errors.BadRequestError(
+				'Conflict between the provided is_final and release_type values',
+			);
+		}
+		request.values.release_type = inferredReleaseType;
+	} else if (
+		typeof release_type === 'string' &&
+		release_type in releaseTypeToFinalMap
+	) {
+		// TODO[release versioning next step]: Drop this once we move the release_type to a translation
+		request.values.is_final =
+			releaseTypeToFinalMap[release_type as keyof typeof releaseTypeToFinalMap];
+	}
+
+	if (request.values.semver != null) {
+		const semverMatches = PLAIN_SEMVER_REGEX.exec(request.values.semver);
+		if (semverMatches == null) {
+			throw new errors.BadRequestError('Invalid semver format');
+		}
+		request.values.semver_major = parseInt(semverMatches[1], 10);
+		request.values.semver_minor = parseInt(semverMatches[2], 10);
+		request.values.semver_patch = parseInt(semverMatches[3], 10);
+	} else {
+		// the semver part fields are only settable through the computed term
+		['semver_major', 'semver_minor', 'semver_patch'].forEach((semverPart) => {
+			if (request.values[semverPart] != null) {
+				delete request.values[semverPart];
+			}
+		});
+	}
+
+	// Keep computed terms as custom values and remove them from the body,
+	// since they do not exist in the DB.
+	const custom = request.custom as CustomObjectBase;
+	custom.is_final = request.values.is_final;
+	custom.semver = request.values.semver;
+	delete request.values.is_final;
+	delete request.values.semver;
+};
+
+const DEFAULT_SEMVER = '0.0.0';
+
+hooks.addPureHook('POST', 'resin', 'release', {
+	POSTPARSE: async (args) => {
+		parseReleaseVersioningFields(args);
+
+		const { request } = args;
+		const custom = request.custom as CustomObjectBase;
+		// Releases are by final by default
+		custom.is_final ??= true;
+	},
+	POSTRUN: async ({ api, request, result: releaseId, tx }) => {
+		const custom = request.custom as CustomObjectBase;
+		if (releaseId == null || !custom.is_final) {
+			return;
+		}
+		await getAdvisoryLockForApp(tx, request.values.belongs_to__application);
+		const revision = await getNextRevision(
+			api,
+			request.values.belongs_to__application,
+			custom.semver ?? DEFAULT_SEMVER,
+		);
+		const finalizedAt = new Date();
+		await api.patch({
+			resource: 'release',
+			// Needs root because revision is not settable.
+			passthrough: { req: permissions.root },
+			id: releaseId,
+			body: {
+				revision,
+				is_finalized_at__date: finalizedAt,
+			},
+		});
+	},
+});
+
+interface PatchCustomObject extends CustomObjectBase {
+	releasesToSetRevision?: Array<
+		Pick<Release, 'id' | 'semver' | 'is_finalized_at__date'> &
+			PickDeferred<Release, 'belongs_to__application'>
+	>;
+}
+
+hooks.addPureHook('PATCH', 'resin', 'release', {
+	POSTPARSE: parseReleaseVersioningFields,
+	PRERUN: async (args) => {
+		const { api, request } = args;
+		const custom = request.custom as PatchCustomObject;
+		const filters: FilterObj[] = [];
+		if (custom.is_final) {
+			filters.push({
+				$or: {
+					// Check both fields, so that instances of this deploy step, can work with instances of the next step.
+					revision: { $eq: null },
+					// TODO[release versioning next step]: Drop this after re-migrating all data on step 2:
+					release_type: 'draft',
+				},
+			});
+		}
+		if (custom.semver != null) {
+			filters.push({
+				$or: {
+					// Check both fields, so that instances of this deploy step, can work with instances of the next step.
+					revision: { $ne: null },
+					// TODO[release versioning next step]: Drop this after re-migrating all data on step 2:
+					release_type: 'final',
+				},
+				semver: { $ne: custom.semver },
+			});
+		}
+		if (request.values.belongs_to__application != null) {
+			filters.push({
+				$or: {
+					// Check both fields, so that instances of this deploy step, can work with instances of the next step.
+					revision: { $ne: null },
+					// TODO[release versioning next step]: Drop this after re-migrating all data on step 2:
+					release_type: 'final',
+				},
+				belongs_to__application: {
+					$ne: request.values.belongs_to__application,
+				},
+			});
+		}
+		if (filters.length === 0) {
+			// no field of interest was PATCHed
+			return;
+		}
+		const releaseIds = await sbvrUtils.getAffectedIds(args);
+		if (!releaseIds.length) {
+			return;
+		}
+		const releasesToSetRevision = (await api.get({
+			resource: 'release',
+			options: {
+				$select: [
+					'id',
+					'semver',
+					'is_finalized_at__date',
+					'belongs_to__application',
+				],
+				$filter: {
+					id: { $in: releaseIds },
+					...(filters.length === 1
+						? filters[0]
+						: {
+								$or: filters,
+						  }),
+				},
+				$orderby: [
+					// order first by application, so that the advisory locks are picked
+					// in a consistent order across requests so that we can avoid deadlocks
+					{ belongs_to__application: 'asc' },
+					// order by finalization date & id in order to have predictable revision ordering
+					{ is_finalized_at__date: 'asc' },
+					{ id: 'asc' },
+				],
+			},
+		})) as NonNullable<PatchCustomObject['releasesToSetRevision']>;
+		if (!releasesToSetRevision.length) {
+			return;
+		}
+		custom.releasesToSetRevision = releasesToSetRevision;
+
+		if (custom.semver == null) {
+			return;
+		}
+		// When changing the semver, set the revision to null so that
+		// we don't end up with duplicate revisions.
+		// We will set the correct value in PRERESPOND
+		await api.patch({
+			resource: 'release',
+			// Needs root because revision is not settable.
+			passthrough: { req: permissions.root },
+			options: {
+				$filter: {
+					id: { $in: releasesToSetRevision.map((r) => r.id) },
+					revision: { $ne: null },
+				},
+			},
+			body: {
+				revision: null,
+			},
+		});
+	},
+	POSTRUN: async ({ api, request, tx }) => {
+		const { is_final, releasesToSetRevision, semver } =
+			request.custom as PatchCustomObject;
+		if (releasesToSetRevision == null) {
+			return;
+		}
+		const patchedAppId = request.values.belongs_to__application;
+		let releasesByApp: Map<number, typeof releasesToSetRevision>;
+		if (patchedAppId != null) {
+			releasesByApp = new Map([
+				[parseInt(patchedAppId, 10), releasesToSetRevision],
+			]);
+		} else {
+			releasesByApp = groupByMap(
+				releasesToSetRevision,
+				(r) => r.belongs_to__application.__id,
+			);
+		}
+
+		const entries = Array.from(releasesByApp.entries());
+		// lift all locks upfront
+		for (const [appId] of entries) {
+			await getAdvisoryLockForApp(tx, appId);
+		}
+
+		await Promise.all(
+			entries.map(async ([appId, releases]) => {
+				if (semver != null) {
+					const nextRevision = await getNextRevision(api, appId, semver);
+					await Promise.all(
+						releases.map(async (release, index) => {
+							await api.patch({
+								resource: 'release',
+								// Needs root because revision is not settable.
+								passthrough: { req: permissions.root },
+								id: release.id,
+								body: {
+									...(is_final &&
+										release.is_finalized_at__date == null && {
+											is_finalized_at__date: new Date(),
+										}),
+									revision: nextRevision + index,
+								},
+							});
+						}),
+					);
+				} else {
+					// needs to be done one by one, since otherwise more than one releases might already
+					// be in the same semver and they could end up with the same revision as well.
+					for (const release of releases) {
+						const nextRevision = await getNextRevision(
+							api,
+							appId,
+							release.semver,
+						);
+						await api.patch({
+							resource: 'release',
+							// Needs root because revision is not settable.
+							passthrough: { req: permissions.root },
+							id: release.id,
+							body: {
+								...(is_final &&
+									release.is_finalized_at__date == null && {
+										is_finalized_at__date: new Date(),
+									}),
+								revision: nextRevision,
+							},
+						});
+					}
+				}
+			}),
+		);
 	},
 });

--- a/src/features/ci-cd/models/release-additions.ts
+++ b/src/features/ci-cd/models/release-additions.ts
@@ -1,0 +1,28 @@
+import type { AbstractSqlModel } from '@balena/abstract-sql-compiler';
+
+export const addToModel = (abstractSql: AbstractSqlModel) => {
+	abstractSql.tables['release'].fields.push({
+		fieldName: 'is final',
+		dataType: 'Boolean',
+		required: true,
+		computed: [
+			'Equals',
+			['ReferencedField', 'release', 'release type'],
+			['EmbeddedText', 'final'],
+		],
+	});
+
+	abstractSql.tables['release'].fields.push({
+		fieldName: 'semver',
+		dataType: 'Short Text',
+		required: true,
+		computed: [
+			'Concatenate',
+			['ReferencedField', 'release', 'semver major'],
+			['EmbeddedText', '.'],
+			['ReferencedField', 'release', 'semver minor'],
+			['EmbeddedText', '.'],
+			['ReferencedField', 'release', 'semver patch'],
+		],
+	});
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,7 @@ import {
 import { addToModel as addUserHasDirectAccessToApplicationToModel } from './features/applications/models/user__has_direct_access_to__application';
 import { getApplicationSlug } from './features/applications';
 import * as deviceAdditions from './features/devices/models/device-additions';
+import { addToModel as addReleaseAdditionsToModel } from './features/ci-cd/models/release-additions';
 
 export * as tags from './features/tags/validation';
 
@@ -242,6 +243,9 @@ export const device = {
 	getPollInterval,
 	DeviceOnlineStates,
 	getDeviceOnlineStateManager,
+};
+export const release = {
+	addVirtualFieldsToModel: addReleaseAdditionsToModel,
 };
 export const deviceTypes = {
 	getAccessibleDeviceTypes,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -101,6 +101,10 @@ export function boolVar<R>(varName: string, defaultValue?: R): boolean | R {
 	);
 }
 
+export const ADVISORY_LOCK_NAMESPACES = {
+	release__revision__belongs_to__application: 1,
+};
+
 export const API_HOST = requiredVar('API_HOST');
 export const API_HEARTBEAT_STATE_ENABLED = intVar(
 	'API_HEARTBEAT_STATE_ENABLED',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -101,3 +101,21 @@ export const withRetries = async <T>(
 		return await withRetries(func, delayDuration, retries - 1);
 	}
 };
+
+/**
+ * Useful when you want to avoid having to manually parse the key
+ * or when need order guarantees while iterating the keys.
+ */
+export const groupByMap = <K, V>(entries: V[], iteratee: (item: V) => K) => {
+	const result = new Map<K, V[]>();
+	for (const entry of entries) {
+		const key = iteratee(entry);
+		let keyGroup = result.get(key);
+		if (keyGroup == null) {
+			keyGroup = [];
+			result.set(key, keyGroup);
+		}
+		keyGroup.push(entry);
+	}
+	return result;
+};

--- a/src/migrations/00053-add-release-versioning-fields.sql
+++ b/src/migrations/00053-add-release-versioning-fields.sql
@@ -1,0 +1,37 @@
+ALTER TABLE "release"
+ADD COLUMN IF NOT EXISTS "is finalized at-date" TIMESTAMP NULL,
+ADD COLUMN IF NOT EXISTS "semver major" INTEGER DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS "semver minor" INTEGER DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS "semver patch" INTEGER DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS "revision" INTEGER NULL;
+
+UPDATE "release"
+SET "is finalized at-date" = "release"."created at"
+WHERE "release type" = 'final';
+
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM information_schema.table_constraints tc
+		WHERE tc.CONSTRAINT_TYPE = 'CHECK'
+			AND tc.table_schema = CURRENT_SCHEMA()
+			AND tc.table_name = 'release'
+			AND tc.constraint_name = 'release$69zgYrVSJaN1avGiEeipPlJ9/lMKzOIt3iMPF6u/6WY='
+	) THEN
+		ALTER TABLE "release"
+			-- It is necessary that each release that has a revision, has a revision that is greater than or equal to 0.
+			ADD CONSTRAINT "release$69zgYrVSJaN1avGiEeipPlJ9/lMKzOIt3iMPF6u/6WY=" CHECK (NOT (
+				"revision" IS NOT NULL
+				AND NOT (
+					0 <= "revision"
+					AND "revision" IS NOT NULL
+				)
+			))
+		;
+	END IF;
+END;
+$$;
+
+CREATE INDEX IF NOT EXISTS "release_belongs_to_app_revision_semver_idx"
+ON "release" ("belongs to-application", "revision", "semver major", "semver minor", "semver patch");

--- a/test/07_versioned-releases.ts
+++ b/test/07_versioned-releases.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from 'crypto';
+import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
+import type { Release } from '../src/balena-model';
 import * as fixtures from './test-lib/fixtures';
 import { expect } from './test-lib/chai';
-
 import { supertest, UserObjectParam } from './test-lib/supertest';
 import { version } from './test-lib/versions';
 import { pineTest } from './test-lib/pinetest';
@@ -75,19 +77,61 @@ describe('releases', () => {
 	});
 });
 
+const getTopRevision = async (
+	pineTestInstance: typeof pineTest,
+	appId: number,
+	semver: string,
+) => {
+	const {
+		body: [topRevisionRelease],
+	} = await pineTestInstance
+		.get<Array<Pick<Release, 'revision'>>>({
+			resource: 'release',
+			options: {
+				$select: 'revision',
+				$filter: {
+					belongs_to__application: appId,
+					semver,
+					revision: { $ne: null },
+				},
+				$orderby: {
+					revision: 'desc',
+				},
+			},
+		})
+		.expect(200);
+	expect(topRevisionRelease.revision).to.be.a('number');
+	return topRevisionRelease.revision!;
+};
+
+/** must be more than 3 */
+const RELEASE_FINALIZATION_TEST_CONCURENCY = 10;
+expect(RELEASE_FINALIZATION_TEST_CONCURENCY).to.be.greaterThanOrEqual(
+	3,
+	'Please define a RELEASE_FINALIZATION_TEST_CONCURENCY >= 3',
+);
+const RELEASE_FINALIZATION_CONCURENCY_DELAY_FACTOR =
+	2 * RELEASE_FINALIZATION_TEST_CONCURENCY;
+
 describe('versioning releases', () => {
 	let fx: fixtures.Fixtures;
 	let user: UserObjectParam;
 	let release1: AnyObject;
 	let release2: AnyObject;
 	let newRelease: AnyObject;
+	let newReleaseBody: AnyObject;
+	let pineUser: typeof pineTest;
+	let topRevision: number;
 
 	before(async () => {
 		fx = await fixtures.load('07-releases');
 		user = fx.users.admin;
+		pineUser = pineTest.clone({
+			passthrough: { user },
+		});
 		release1 = fx.releases.release1;
 		release2 = fx.releases.release2;
-		newRelease = {
+		newReleaseBody = {
 			belongs_to__application: fx.applications.app1.id,
 			commit: 'test-commit',
 			status: 'success',
@@ -157,16 +201,69 @@ describe('versioning releases', () => {
 	});
 
 	it('should confirm that a new release can be created with version', async () => {
-		await supertest(user)
+		topRevision = await getTopRevision(
+			pineUser,
+			fx.applications.app1.id,
+			'0.0.0',
+		);
+		const { body } = await supertest(user)
 			.post(`/${version}/release`)
-			.send(newRelease)
+			.send(newReleaseBody)
 			.expect(201);
+		expect(body).to.have.property(
+			'release_version',
+			newReleaseBody.release_version,
+		);
+		newRelease = body;
+	});
+
+	it('should mark it as final, assign the default semver and the next availale revision', async () => {
+		const revision = topRevision + 1;
+		expect(newRelease).to.have.property('semver', '0.0.0');
+		expect(newRelease).to.have.property('semver_major', 0);
+		expect(newRelease).to.have.property('semver_minor', 0);
+		expect(newRelease).to.have.property('semver_patch', 0);
+		expect(newRelease).to.have.property('revision', revision);
+		expect(newRelease).to.have.property('is_final', true);
+		expect(newRelease)
+			.to.have.property('is_finalized_at__date')
+			.that.is.a('string');
+
+		const { body: freshlyGetRelease } = await pineUser
+			.get({
+				resource: 'release',
+				id: newRelease.id,
+				options: {
+					$select: [
+						'semver',
+						'semver_major',
+						'semver_minor',
+						'semver_patch',
+						'revision',
+						'is_final',
+						'is_finalized_at__date',
+					],
+				},
+			})
+			.expect(200);
+		expect(freshlyGetRelease).to.have.property('semver', '0.0.0');
+		expect(freshlyGetRelease).to.have.property('semver_major', 0);
+		expect(freshlyGetRelease).to.have.property('semver_minor', 0);
+		expect(freshlyGetRelease).to.have.property('semver_patch', 0);
+		expect(freshlyGetRelease).to.have.property('revision', revision);
+		expect(freshlyGetRelease).to.have.property('is_final', true);
+		expect(freshlyGetRelease)
+			.to.have.property('is_finalized_at__date')
+			.that.is.a('string');
+		expect(newRelease.is_finalized_at__date).to.equal(
+			freshlyGetRelease.is_finalized_at__date,
+		);
 	});
 
 	it('should disallow creating a new release with used version', async () => {
 		await supertest(user)
 			.post(`/${version}/release`)
-			.send(newRelease)
+			.send(newReleaseBody)
 			.expect(400);
 	});
 
@@ -184,6 +281,292 @@ describe('versioning releases', () => {
 			})
 			.expect(200);
 	});
+
+	it('should start assigning new revisions per semver per app starting from 0', async () => {
+		const newReleases: Release[] = [];
+		// Add them in order so that they get predictable revisions.
+		for (let i = 0; i < RELEASE_FINALIZATION_TEST_CONCURENCY; i++) {
+			newReleases.push(
+				(
+					await pineUser
+						.post({
+							resource: 'release',
+							body: {
+								...newReleaseBody,
+								commit: randomUUID(),
+								release_version: undefined,
+								semver: '0.2.0',
+							},
+						})
+						.expect(201)
+				).body as Release,
+			);
+		}
+
+		newReleases.forEach((r) => expect(r).to.have.property('semver', '0.2.0'));
+		newReleases.forEach((r) => expect(r).to.have.property('is_final', true));
+		const newRevisions = newReleases.map((r) => r.revision);
+		expect(newRevisions).to.deep.equal(_.range(0, newRevisions.length));
+	});
+
+	it('should assign unique revisions when multiple releases are created concurrently', async () => {
+		topRevision = await getTopRevision(
+			pineUser,
+			fx.applications.app1.id,
+			'0.0.0',
+		);
+		const newReleases = await Promise.all(
+			_.times(RELEASE_FINALIZATION_TEST_CONCURENCY).map(async () => {
+				await Bluebird.delay(
+					Math.random() * RELEASE_FINALIZATION_CONCURENCY_DELAY_FACTOR,
+				);
+				return (
+					await pineUser
+						.post({
+							resource: 'release',
+							body: {
+								...newReleaseBody,
+								commit: randomUUID(),
+								release_version: undefined,
+								semver: '0.0.0',
+							},
+						})
+						.expect(201)
+				).body as Release;
+			}),
+		);
+
+		newReleases.forEach((r) => {
+			expect(r).to.have.property('semver', '0.0.0');
+			expect(r).to.have.property('is_final', true);
+		});
+		const newRevisions = _.sortBy(
+			newReleases.map((r) => r.revision),
+			(rev) => rev,
+		);
+		expect(newRevisions).to.deep.equal(
+			_.range(topRevision + 1, topRevision + 1 + newRevisions.length),
+		);
+	});
+
+	const makeMarkAsFinalTest = (
+		titlePart: string,
+		updateFn: (newDraftReleases: Release[]) => Promise<void>,
+	) => {
+		it(`should assign unique revisions when multiple draft releases are marked as final ${titlePart}`, async () => {
+			topRevision = await getTopRevision(
+				pineUser,
+				fx.applications.app1.id,
+				'0.0.0',
+			);
+			const newDraftReleases = await Promise.all(
+				_.times(RELEASE_FINALIZATION_TEST_CONCURENCY).map(async () => {
+					return (
+						await pineUser
+							.post({
+								resource: 'release',
+								body: {
+									...newReleaseBody,
+									commit: randomUUID(),
+									release_version: undefined,
+									semver: '0.0.0',
+									is_final: false,
+								},
+							})
+							.expect(201)
+					).body as Release;
+				}),
+			);
+			newDraftReleases.forEach((r) =>
+				expect(r).to.have.property('revision', null),
+			);
+
+			await updateFn(newDraftReleases);
+
+			const { body: newFinalReleases } = await pineUser
+				.get<Array<Pick<Release, 'revision'>>>({
+					resource: 'release',
+					options: {
+						$select: 'revision',
+						$filter: { id: { $in: newDraftReleases.map((r) => r.id) } },
+					},
+				})
+				.expect(200);
+
+			const newRevisions = _.sortBy(
+				newFinalReleases.map((r) => r.revision),
+				(rev) => rev,
+			);
+			expect(newRevisions).to.deep.equal(
+				_.range(topRevision + 1, topRevision + 1 + newRevisions.length),
+			);
+		});
+	};
+
+	makeMarkAsFinalTest('with a single request', async (newDraftReleases) => {
+		await pineUser
+			.patch({
+				resource: 'release',
+				options: {
+					$filter: { id: { $in: newDraftReleases.map((r) => r.id) } },
+				},
+				body: {
+					is_final: true,
+				},
+			})
+			.expect(200);
+	});
+
+	makeMarkAsFinalTest('concurrently', async (newDraftReleases) => {
+		await Promise.all(
+			newDraftReleases.map(async (r) => {
+				await Bluebird.delay(
+					Math.random() * RELEASE_FINALIZATION_CONCURENCY_DELAY_FACTOR,
+				);
+				await pineUser
+					.patch({
+						resource: 'release',
+						id: r.id,
+						body: {
+							is_final: true,
+						},
+					})
+					.expect(200);
+			}),
+		);
+	});
+
+	const makeUpdateSemverTest = (
+		titlePart: string,
+		[SEMVER_A, SEMVER_B]: [string, string],
+		updateFn: (versionAReleasesToChangeSemver: Release[]) => Promise<void>,
+	) => {
+		it(`should assign the correct revisions when changing the semver of a release ${titlePart}`, async () => {
+			const [v1Releases, v2Releases] = await Promise.all(
+				[SEMVER_A, SEMVER_B].map(async (semver) => {
+					const newReleases: Release[] = [];
+					// Add them in order so that they get predictable revisions.
+					for (let i = 0; i < RELEASE_FINALIZATION_TEST_CONCURENCY; i++) {
+						newReleases.push(
+							(
+								await pineUser
+									.post({
+										resource: 'release',
+										body: {
+											...newReleaseBody,
+											commit: randomUUID(),
+											release_version: undefined,
+											semver,
+										},
+									})
+									.expect(201)
+							).body as Release,
+						);
+					}
+
+					const revisions = _.sortBy(
+						newReleases.map((r) => r.revision),
+						(rev) => rev,
+					);
+					expect(revisions).to.deep.equal(_.range(0, newReleases.length));
+					return newReleases;
+				}),
+			);
+			v1Releases
+				.concat(v2Releases)
+				.forEach((r) =>
+					expect(r).to.have.property('revision').that.is.a('number'),
+				);
+			const [versionAReleasesToChangeSemver, [leftBehindV1SemverRelease]] =
+				_.partition(
+					v1Releases,
+					(r) => v1Releases.indexOf(r) < v1Releases.length - 1,
+				);
+			const releaseIdsToChangeSemver = versionAReleasesToChangeSemver.map(
+				(r) => r.id,
+			);
+			const maxV2Revision = Math.max(...v2Releases.map((r) => r.revision!));
+
+			await updateFn(versionAReleasesToChangeSemver);
+
+			const { body: changedSemverReleases } = await pineUser
+				.get<Array<Pick<Release, 'revision'>>>({
+					resource: 'release',
+					options: {
+						$select: 'revision',
+						$filter: { id: { $in: releaseIdsToChangeSemver } },
+					},
+				})
+				.expect(200);
+
+			const newRevisions = _.sortBy(
+				changedSemverReleases.map((r) => r.revision),
+				(rev) => rev,
+			);
+			expect(newRevisions).to.deep.equal(
+				_.range(maxV2Revision + 1, maxV2Revision + 1 + newRevisions.length),
+			);
+
+			const { body: unchangedV1SemverRelease } = await pineUser
+				.get<Array<Pick<Release, 'revision'>>>({
+					resource: 'release',
+					id: leftBehindV1SemverRelease.id,
+					options: {
+						$select: ['semver', 'revision'],
+					},
+				})
+				.expect(200);
+
+			expect(unchangedV1SemverRelease).to.have.property('semver', SEMVER_A);
+			expect(unchangedV1SemverRelease)
+				.to.have.property('revision', leftBehindV1SemverRelease.revision)
+				.that.equals(RELEASE_FINALIZATION_TEST_CONCURENCY - 1);
+		});
+	};
+
+	makeUpdateSemverTest(
+		'with a single request',
+		['1.0.1', '2.0.1'],
+		async (versionAReleasesToChangeSemver) => {
+			const releaseIdsToChangeSemver = versionAReleasesToChangeSemver.map(
+				(r) => r.id,
+			);
+			await pineUser
+				.patch({
+					resource: 'release',
+					options: {
+						$filter: { id: { $in: releaseIdsToChangeSemver } },
+					},
+					body: {
+						semver: '2.0.1',
+					},
+				})
+				.expect(200);
+		},
+	);
+
+	makeUpdateSemverTest(
+		'concurrently',
+		['1.0.2', '2.0.2'],
+		async (versionAReleasesToChangeSemver) => {
+			await Promise.all(
+				versionAReleasesToChangeSemver.map(async (r) => {
+					await Bluebird.delay(
+						Math.random() * RELEASE_FINALIZATION_CONCURENCY_DELAY_FACTOR,
+					);
+					await pineUser
+						.patch({
+							resource: 'release',
+							id: r.id,
+							body: {
+								semver: '2.0.2',
+							},
+						})
+						.expect(200);
+				}),
+			);
+		},
+	);
 });
 
 describe('draft releases', () => {
@@ -223,6 +606,22 @@ describe('draft releases', () => {
 		newRelease = body;
 	});
 
+	it('should return the release as not final and with a default semver', async () => {
+		const { body } = await pineUser
+			.get({
+				resource: 'release',
+				id: newRelease.id,
+				options: {
+					$select: ['is_final', 'is_finalized_at__date', 'revision', 'semver'],
+				},
+			})
+			.expect(200);
+		expect(body).to.have.property('is_final', false);
+		expect(body).to.have.property('is_finalized_at__date', null);
+		expect(body).to.have.property('revision', null);
+		expect(body).to.have.property('semver', '0.0.0');
+	});
+
 	it('should be able to mark it as final', async () => {
 		await pineUser
 			.patch({
@@ -233,6 +632,20 @@ describe('draft releases', () => {
 				},
 			})
 			.expect(200);
+	});
+
+	it('should then return the release as final and increase the revision', async () => {
+		const { body } = await pineUser
+			.get({
+				resource: 'release',
+				id: newRelease.id,
+				options: {
+					$select: ['is_final', 'revision', 'semver'],
+				},
+			})
+			.expect(200);
+		expect(body).to.have.property('is_final', true);
+		expect(body).to.have.property('revision').that.is.greaterThanOrEqual(0);
 	});
 
 	it('should prevent changing a final relase back to draft', async () => {

--- a/typings/common.d.ts
+++ b/typings/common.d.ts
@@ -9,7 +9,14 @@ declare global {
 		[key: string]: T;
 	}
 
+	type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 	type Writable<T> = { -readonly [K in keyof T]: T[K] };
+	type NonNullableField<T, F extends keyof T> = Overwrite<
+		T,
+		{
+			[P in F]: NonNullable<T[P]>;
+		}
+	>;
 
 	type ResolvableReturnType<T extends (...args: any[]) => any> = T extends (
 		...args: any[]


### PR DESCRIPTION
Release plan:
* step 1:
  See: https://github.com/balena-io/open-balena-api/pull/722 **WEW ARE HERE**
  See: https://github.com/balena-io/balena-api/pull/3248
  * add the new field
  * have the API set both the release_type & revision but only read the release_type field
* step 2:
  See: https://github.com/balena-io/open-balena-api/pull/723
  See: https://github.com/balena-io/balena-api/pull/3249
  * run a migration that aligns the new field values based on the old one
  * have the API set both the release_type & revision but only read the revision field
* step 3:
  See: https://github.com/balena-io/open-balena-api/pull/724
  See: https://github.com/balena-io/balena-api/pull/3250
  * stop setting the release_type field & add a translation for it
  * remove the release_type field from the sbvr
* step 4:
  See: https://github.com/balena-io/open-balena-api/pull/725
  See: https://github.com/balena-io/balena-api/pull/3251
  * remove the release_type field from the DB


Change-type: minor
HQ: https://jel.ly.fish/8ea1c390-9a85-402d-978c-4d31dcb0d235
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>