### PR TITLE
release versioning 3: Drop the release type property from the model

### DIFF
--- a/src/balena-init.sql
+++ b/src/balena-init.sql
@@ -13,7 +13,6 @@ ALTER TABLE "device"
 ALTER COLUMN "api heartbeat state" SET DEFAULT 'unknown';
 
 ALTER TABLE "release"
-ALTER COLUMN "release type" SET DEFAULT 'final',-- TODO: Drop after the release versioning migration
 ALTER COLUMN "is passing tests" SET DEFAULT 1,
 ALTER COLUMN "semver major" SET DEFAULT 0,
 ALTER COLUMN "semver minor" SET DEFAULT 0,

--- a/src/balena-model.ts
+++ b/src/balena-model.ts
@@ -392,7 +392,6 @@ export interface Release {
 	release_version: string | null;
 	contract: {} | null;
 	is_passing_tests: boolean;
-	release_type: 'final' | 'draft';
 	is_finalized_at__date: DateString | null;
 	semver_major: number;
 	semver_minor: number;

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -228,9 +228,6 @@ Term: push timestamp
 Term: release version
 	Concept Type: Short Text (Type)
 
-Term: release type
-	Concept Type: Short Text (Type)
-
 Term: revision
 	Concept Type: Integer (Type)
 
@@ -657,10 +654,6 @@ Fact type: release has release version
 Fact type: release has contract
 	Necessity: each release has at most one contract
 Fact type: release is passing tests
--- TODO: Drop after the release versioning migration
-Fact type: release has release type
-	Necessity: each release has exactly one release type.
-	Definition: "final" or "draft"
 Fact type: release is finalized at date
 	Necessity: each release is finalized at at most one date.
 Fact type: release has semver major

--- a/src/features/ci-cd/hooks/release-versioning.ts
+++ b/src/features/ci-cd/hooks/release-versioning.ts
@@ -77,11 +77,6 @@ const getNextRevision = async (
 		: 0;
 };
 
-const releaseTypeToFinalMap = {
-	draft: false,
-	final: true,
-};
-
 const PLAIN_SEMVER_REGEX = /^([0-9]+)\.([0-9]+)\.([0-9]+)$/;
 
 interface CustomObjectBase {
@@ -92,25 +87,6 @@ interface CustomObjectBase {
 const parseReleaseVersioningFields: (args: sbvrUtils.HookArgs) => void = ({
 	request,
 }) => {
-	const { is_final, release_type } = request.values;
-	if (typeof is_final === 'boolean') {
-		// TODO[release versioning next step]: Drop this once we move the release_type to a translation
-		const inferredReleaseType = is_final ? 'final' : 'draft';
-		if (release_type != null && release_type !== inferredReleaseType) {
-			throw new errors.BadRequestError(
-				'Conflict between the provided is_final and release_type values',
-			);
-		}
-		request.values.release_type = inferredReleaseType;
-	} else if (
-		typeof release_type === 'string' &&
-		release_type in releaseTypeToFinalMap
-	) {
-		// TODO[release versioning next step]: Drop this once we move the release_type to a translation
-		request.values.is_final =
-			releaseTypeToFinalMap[release_type as keyof typeof releaseTypeToFinalMap];
-	}
-
 	if (request.values.semver != null) {
 		const semverMatches = PLAIN_SEMVER_REGEX.exec(request.values.semver);
 		if (semverMatches == null) {

--- a/test/14_release-pinning.ts
+++ b/test/14_release-pinning.ts
@@ -68,16 +68,6 @@ describe(`Tracking latest release`, () => {
 			.expect(200);
 	});
 
-	it('Should not allow unexpected values for the release type', async () => {
-		const expectedLatest = fx.releases.release2;
-		await supertest(admin)
-			.patch(`/${version}/release(${expectedLatest.id})`)
-			.send({
-				release_type: 'randomtype',
-			})
-			.expect(400, '"Check constraint violated"');
-	});
-
 	it('Should update latest release to a newly-marked final release', async () => {
 		const expectedLatest = fx.releases.release2;
 		await supertest(admin)


### PR DESCRIPTION
Release plan:
* step 1:
  See: https://github.com/balena-io/open-balena-api/pull/722
  See: https://github.com/balena-io/balena-api/pull/3248
  * add the new field
  * have the API set both the release_type & revision but only read the release_type field
* step 2:
  See: https://github.com/balena-io/open-balena-api/pull/723
  See: https://github.com/balena-io/balena-api/pull/3249
  * run a migration that aligns the new field values based on the old one
  * have the API set both the release_type & revision but only read the revision field
* step 3:
  See: https://github.com/balena-io/open-balena-api/pull/724 **WEW ARE HERE**
  See: https://github.com/balena-io/balena-api/pull/3250
  * stop setting the release_type field & add a translation for it
  * remove the release_type field from the sbvr
* step 4:
  See: https://github.com/balena-io/open-balena-api/pull/725
  See: https://github.com/balena-io/balena-api/pull/3251
  * remove the release_type field from the DB

Change-type: minor
HQ: https://jel.ly.fish/8ea1c390-9a85-402d-978c-4d31dcb0d235
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>