### PR TITLE
release versioning: Drop the release type field from the DB

### DIFF
--- a/src/migrations/00055-drop-release-type-field.sql
+++ b/src/migrations/00055-drop-release-type-field.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "release"
+DROP COLUMN IF EXISTS "release type";


### PR DESCRIPTION
Release plan:
* step 1:
  See: https://github.com/balena-io/open-balena-api/pull/722
  See: https://github.com/balena-io/balena-api/pull/3248
  * add the new field
  * have the API set both the release_type & revision but only read the release_type field
* step 2:
  See: https://github.com/balena-io/open-balena-api/pull/723
  See: https://github.com/balena-io/balena-api/pull/3249
  * run a migration that aligns the new field values based on the old one
  * have the API set both the release_type & revision but only read the revision field
* step 3:
  See: https://github.com/balena-io/open-balena-api/pull/724
  See: https://github.com/balena-io/balena-api/pull/3250
  * stop setting the release_type field & add a translation for it
  * remove the release_type field from the sbvr
* step 4:
  See: https://github.com/balena-io/open-balena-api/pull/725 **WEW ARE HERE**
  See: https://github.com/balena-io/balena-api/pull/3251
  * remove the release_type field from the DB

Change-type: minor
HQ: https://jel.ly.fish/8ea1c390-9a85-402d-978c-4d31dcb0d235
See: https://www.flowdock.com/app/rulemotion/r-supervisor/threads/JN2-gnspQ-v6WaeWCvm9T8NYDY1
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>