### PR TITLE
var-schema: Add custom DTB support for TX2 NX variants

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -230,6 +230,8 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 			'jetson-nano-emmc',
 			'jn30b-nano',
 			'photon-nano',
+			'jetson-tx2-nx-devkit',
+			'photon-tx2-nx',
 		],
 		properties: {
 			RESIN_HOST_EXTLINUX_fdt: {


### PR DESCRIPTION
We now added support for the TX2 NX, let's also add
support for custom device tree loading for it as well as
for the Photon TX2 NX which is a community device type
that's in progress of being added to the supported
devices list.

Change-type: Patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>