### PR TITLE
Stop exporting the deviceTypes.getDeviceTypes() request handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,6 @@ import {
 	findBySlug,
 	getDeviceTypeIdBySlug,
 } from './features/device-types/device-types';
-import { getDeviceTypes as getDeviceTypesRoute } from './features/device-types/routes';
 import { proxy as supervisorProxy } from './features/device-proxy/device-proxy';
 import { generateConfig } from './features/device-config/device-config';
 import {
@@ -251,7 +250,6 @@ export const deviceTypes = {
 	getAccessibleDeviceTypes,
 	findBySlug,
 	getDeviceTypeIdBySlug,
-	getDeviceTypes: getDeviceTypesRoute,
 };
 export const contracts = {
 	setSyncSettings,


### PR DESCRIPTION
Change-type: minor
See: https://github.com/balena-io/balena-api/pull/3304
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/h53eF4Ud-6Zq3Vklp1M0D6RSIUZ
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>