### PR TITLE
multiCache: Fix using milliseconds instead of seconds for the ttl

### DIFF
--- a/src/infra/cache/index.ts
+++ b/src/infra/cache/index.ts
@@ -2,7 +2,7 @@ import * as cacheManager from 'cache-manager';
 import redisStore = require('cache-manager-redis-store');
 import type { Options as MemoizeeOptions } from 'memoizee';
 import primitiveKey = require('memoizee/normalizers/primitive');
-import { REDIS_HOST, REDIS_PORT, version } from '../../lib/config';
+import { REDIS_HOST, REDIS_PORT, SECONDS, version } from '../../lib/config';
 
 export type Defined = string | number | boolean | symbol | bigint | object;
 
@@ -19,6 +19,7 @@ export function multiCacheMemoizee<
 		undefinedAs: Defined;
 		promise: true;
 		primitive: true;
+		/** In milliseconds like memoizee */
 		maxAge: number;
 	} & Pick<MemoizeeOptions<any>, 'preFetch' | 'max' | 'normalizer'>,
 ): T;
@@ -82,7 +83,8 @@ export function multiCacheMemoizee<
 		cacheKey,
 		normalizer,
 		{
-			ttl: maxAge,
+			// ttl is in seconds, so we need to divide by 1000
+			ttl: maxAge / SECONDS,
 			max,
 			refreshThreshold,
 			// Treat everything as cacheable, including `undefined` - the same as memoizee


### PR DESCRIPTION
Affects:
* src/features/device-types/build-info-facade.ts
  * getLogoUrl
  * getCompressedSize
* src/features/device-state/middleware.ts
  * checkDeviceExists
* src/features/registry/registry.ts
  * $getSubject

Change-type: patch
See: https://github.com/balena-io/balena-api/issues/3306
See: https://jel.ly.fish/pattern-api-s-state-endpoint-caches-state-endpoint-s-deleted-device-response-long-e4e61f5
See: https://github.com/BryanDonovan/node-cache-manager/blob/b3aa1d59885d5a011fd02f8c197c78f4f6235dde/test/caching.unit.js#L731
See: https://github.com/BryanDonovan/node-cache-manager/blob/b3aa1d59885d5a011fd02f8c197c78f4f6235dde/examples/redis_example/example.js#L9
See: https://github.com/BryanDonovan/node-cache-manager/blob/master/README.md#single-store
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>