### PR TITLE
device-proxy: Skip canAccess check for internal root operations

### DIFF
--- a/src/features/device-proxy/device-proxy.ts
+++ b/src/features/device-proxy/device-proxy.ts
@@ -155,22 +155,22 @@ interface RequestDevicesOpts extends FixedMethodRequestDevicesOpts {
 // the request will be used to get devices,
 // if it is not passed then("guest" permissions will be used to get the devices.
 // - method is the HTTP method for the request, defaults to 'POST'
-export async function requestDevices(
+async function requestDevices(
 	opts: RequestDevicesOpts & {
 		wait?: true;
 	},
 ): Promise<RequestResponse[]>;
-export async function requestDevices(
+async function requestDevices(
 	opts: RequestDevicesOpts & {
 		wait: false;
 	},
 ): Promise<void>;
 // This override is identical to the main form in order for `postDevices` to be able
 // to call it with the generic form
-export async function requestDevices(
+async function requestDevices(
 	opts: RequestDevicesOpts,
 ): Promise<void | RequestResponse[]>;
-export async function requestDevices({
+async function requestDevices({
 	url,
 	filter,
 	data,
@@ -212,7 +212,9 @@ export async function requestDevices({
 		}
 		throw new NotFoundError('No online device(s) found');
 	}
-	if (method !== 'GET') {
+	// Check for device update permission, except for
+	// internal operation of the platform.
+	if (method !== 'GET' && req !== permissions.root) {
 		await Promise.all(
 			deviceIds.map(async (deviceId) => {
 				const res = (await resinApi.post({

--- a/test/14_release-pinning.ts
+++ b/test/14_release-pinning.ts
@@ -1,5 +1,6 @@
 import { expect } from './test-lib/chai';
 
+import { connectDeviceAndWaitForUpdate } from './test-lib/connect-device-and-wait';
 import * as fakeDevice from './test-lib/fake-device';
 import { supertest, UserObjectParam } from './test-lib/supertest';
 import { version } from './test-lib/versions';
@@ -295,6 +296,17 @@ describe(`Tracking latest release`, () => {
 				(si: AnyObject) => si.installs__service[0].service_name,
 			);
 			expect(serviceNamesAfter).to.include('new-untracked-release-service');
+		});
+
+		it('should notify the supervisor when pinning the application to a release pinned', async function () {
+			await connectDeviceAndWaitForUpdate(device3.uuid, version, async () => {
+				await supertest(admin)
+					.patch(`/${version}/application(${application3Id})`)
+					.send({
+						should_be_running__release: app3ReleaseId,
+					})
+					.expect(200);
+			});
 		});
 	});
 });

--- a/test/test-lib/common.ts
+++ b/test/test-lib/common.ts
@@ -1,0 +1,38 @@
+import * as Bluebird from 'bluebird';
+import { TypedError } from 'typed-error';
+
+type PredicateFunction = () => Resolvable<boolean>;
+
+export class TimedOutError extends TypedError {}
+
+/**
+ * Loops `maxCount` times, calling the `checkFn` predicate. Returning `TRUE` from the
+ * predicate will cease the looping. If `FALSE` then we delay by `delayMs` milliseconds.
+ *
+ * If we haven't seen a `TRUE` when the loop finishes, we throw a {@link TimedOutError}
+ *
+ * @export
+ * @param {number} delayMs
+ * @param {number} maxCount
+ * @param {PredicateFunction} checkFn
+ */
+export async function waitFor({
+	delayMs = 100,
+	maxCount = 100,
+	checkFn,
+}: {
+	delayMs?: number;
+	maxCount?: number;
+	checkFn: PredicateFunction;
+}) {
+	for (let i = 1; i <= maxCount; i++) {
+		console.log(`⌚  Waiting (${i}/${maxCount})...`);
+		await Bluebird.delay(delayMs);
+
+		if (await checkFn()) {
+			return;
+		}
+	}
+
+	throw new TimedOutError();
+}

--- a/test/test-lib/connect-device-and-wait.ts
+++ b/test/test-lib/connect-device-and-wait.ts
@@ -1,0 +1,62 @@
+import { expect } from './chai';
+import * as nock from 'nock';
+import { supertest } from './supertest';
+
+import { VPN_SERVICE_API_KEY } from '../../src/lib/config';
+import { waitFor, TimedOutError } from './common';
+
+const registerService = async (version: string) => {
+	const res = await supertest()
+		.post(`/${version}/service_instance`)
+		.query({ apikey: VPN_SERVICE_API_KEY })
+		.expect(201);
+
+	expect(res.body).to.have.property('id').that.is.a('number');
+
+	return res.body.id;
+};
+
+export const connectDeviceAndWaitForUpdate = async (
+	uuid: string,
+	version: string,
+	promiseFn: () => PromiseLike<any>,
+) => {
+	let updateRequested = false;
+
+	const serviceId = await registerService(version);
+	await supertest()
+		.post('/services/vpn/client-connect')
+		.query({ apikey: VPN_SERVICE_API_KEY })
+		.send({
+			common_name: uuid,
+			virtual_address: '10.10.10.1',
+			service_id: serviceId,
+		})
+		.expect(200);
+
+	nock(`http://${uuid}.balena`)
+		.post(/\/v1\/update/)
+		.reply(() => {
+			updateRequested = true;
+			return [
+				{
+					statusCode: 200,
+					headers: { 'content-type': 'text/plain' },
+				},
+				'OK',
+			];
+		});
+	await promiseFn();
+
+	try {
+		await waitFor({
+			checkFn: () => updateRequested,
+		});
+	} catch (err) {
+		if (err instanceof TimedOutError) {
+			throw new Error('Request to update device never happened');
+		} else {
+			throw err;
+		}
+	}
+};


### PR DESCRIPTION
Atm
2 w/ root
* /v1/update on app.should_be_running__release
  https://github.com/balena-io/open-balena-api/blob/05adbc7c705e0fe138a3fdd34e846bd7e030d19f/src/features/ci-cd/hooks/app-update-trigger.ts#L12-L14
* /v1/update on device.should_be_running__release
  https://github.com/balena-io/open-balena-api/blob/05adbc7c705e0fe138a3fdd34e846bd7e030d19f/src/features/ci-cd/hooks/device-update-trigger.ts#L18-L20
1 w/o root
* /v1/update on env var change
https://github.com/balena-io/open-balena-api/blob/05adbc7c705e0fe138a3fdd34e846bd7e030d19f/src/features/vars-schema/hooks/vars-update-trigger.ts#L53-L55

Change-type: patch
See: https://github.com/balena-io/balena-api/issues/3339
See: https://www.flowdock.com/app/rulemotion/resin-devops/threads/7eWUlj4x8HU0fxhBOFmvOe3gxjw
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>