### PR TITLE
multiCache: Fix using the preFetch option as ms instead of seconds

### DIFF
--- a/src/infra/cache/index.ts
+++ b/src/infra/cache/index.ts
@@ -85,17 +85,15 @@ export function multiCacheMemoizee<
 
 	const multiCacheOpts = [opts, { ...opts, ...sharedCacheOpts }].map(
 		(options): MultiCacheOpt => {
-			let refreshThreshold;
-			if (options.preFetch != null) {
-				refreshThreshold =
-					options.maxAge *
-					(options.preFetch === true ? 0.333 : options.preFetch);
-			}
+			// ttl is in seconds, so we need to divide by 1000
+			const ttl = options.maxAge / SECONDS;
 			return {
-				// ttl is in seconds, so we need to divide by 1000
-				ttl: options.maxAge / SECONDS,
+				ttl,
 				max: options.max,
-				refreshThreshold,
+				refreshThreshold:
+					options.preFetch != null
+						? ttl * (options.preFetch === true ? 0.333 : options.preFetch)
+						: undefined,
 				// Treat everything as cacheable, including `undefined` - the same as memoizee
 				isCacheableValue: () => true,
 			};


### PR DESCRIPTION
~~On top of https://github.com/balena-io/open-balena-api/pull/792~~
Also fixes using the preFetch option as ms instead of seconds

As found in cache-manager's docs:
If the remaining TTL is less than refreshThreshold,
the system will spawn a background worker to
update the value...

Change-type: patch
See: https://github.com/balena-io/open-balena-api/pull/761
See: https://github.com/BryanDonovan/node-cache-manager#refresh-cache-keys-in-background
See: https://github.com/BryanDonovan/node-cache-manager/blob/b3aa1d59885d5a011fd02f8c197c78f4f6235dde/test/multi_caching.unit.js#L1133
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/d3SVFlAr20-rnIZM1ChWR4QGMGI
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>