### PR TITLE
registry: Avoid fetching unused fields in the image access check

### DIFF
--- a/src/features/registry/registry.ts
+++ b/src/features/registry/registry.ts
@@ -107,6 +107,9 @@ const resolveReadAccess = async (
 		resource: 'image',
 		id: imageId,
 		passthrough: { req },
+		options: {
+			$select: 'id',
+		},
 	});
 	return image != null;
 };


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>