### PR TITLE
Add an option to input expiry date for provisioning key

### DIFF
--- a/src/balena-model.ts
+++ b/src/balena-model.ts
@@ -74,6 +74,7 @@ export interface ApiKey {
 	modified_at: DateString;
 	id: number;
 	key: string;
+	expiry_date: DateString | null;
 	is_of__actor: { __id: number } | [Actor];
 	name: string | null;
 	description: string | null;

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -60,6 +60,8 @@ Term: api key
 Fact type: api key has key
 	Necessity: each api key has exactly one key
 	Necessity: each key is of exactly one api key
+Fact type: api key has expiry date
+	Necessity: each api key has at most one expiry date.
 Fact type: api key has role
 	Note: An 'api key' will inherit all the 'permissions' that the 'role' has.
 Fact type: api key has permission

--- a/src/features/device-config/device-config.ts
+++ b/src/features/device-config/device-config.ts
@@ -67,6 +67,11 @@ export const generateConfig = async (
 			req.query.provisioningKeyDescription ??
 			'Automatically generated for an image download or config file generation';
 
+		apiKeyOptions.expiryDate =
+			req.body.provisioningKeyExpiryDate ??
+			req.query.provisioningKeyExpiryDate ??
+			undefined;
+
 		return await createProvisioningApiKey(req, app.id, apiKeyOptions);
 	})();
 

--- a/test/fixtures/08-create-device-apikey/applications.json
+++ b/test/fixtures/08-create-device-apikey/applications.json
@@ -3,5 +3,10 @@
 		"user": "admin",
 		"app_name": "test_create_device_env_var",
 		"device_type": "raspberry-pi"
+	},
+	"app2": {
+		"user": "admin",
+		"app_name": "test_provisioning_key_expiry",
+		"device_type": "intel-nuc"
 	}
 }


### PR DESCRIPTION
Change-Type: minor
Signed-off-by: Nitish Agarwal <1592163+nitishagar@users.noreply.github.com>
Depends-on: https://github.com/balena-io/pinejs/pull/538
See: https://jel.ly.fish/product-improvement-provisioning-api-key-management-4c86a2c3-8899-4764-9019-8c9b932e57f5