### PR TITLE
Stop using docker layer caching on circleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
           version: 19.03.8
       - run:
           name: Build


### PR DESCRIPTION
Resolves: #
Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/rksMXFxgAs7JqhltZz7Cvh-i5id
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>