### PR TITLE
Restrict supervisor release population to releases of the balena_os org

### DIFF
--- a/src/features/supervisor-app/hooks/supervisor-app.ts
+++ b/src/features/supervisor-app/hooks/supervisor-app.ts
@@ -149,6 +149,10 @@ async function getSupervisorReleaseResource(
 					$any: {
 						$alias: 'a',
 						$expr: {
+							$and: [
+								{ a: { slug: { $startswith: 'balena_os/' } } },
+								{ a: { slug: { $endswith: '-supervisor' } } },
+							],
 							a: {
 								is_public: true,
 								is_host: false,

--- a/test/fixtures/00-balena_os/organizations.json
+++ b/test/fixtures/00-balena_os/organizations.json
@@ -1,0 +1,6 @@
+{
+	"balena_os": {
+		"handle":"balena_os",
+		"name":"balena_os"
+	}
+}

--- a/test/fixtures/16-supervisor-app/applications.json
+++ b/test/fixtures/16-supervisor-app/applications.json
@@ -12,14 +12,14 @@
 		"app_name": "test-device-type",
 		"organization": "balena_os"
 	},
-	"public_pi_app": {
+	"armv7hf_supervisor_app": {
 		"user": "admin",
 		"device_type": "raspberrypi3",
 		"is_public": true,
 		"app_name": "armv7hf-supervisor",
 		"organization": "balena_os"
 	},
-	"public_app": {
+	"amd64_supervisor_app": {
 		"user": "admin",
 		"device_type": "intel-nuc",
 		"is_public": true,

--- a/test/fixtures/16-supervisor-app/releases.json
+++ b/test/fixtures/16-supervisor-app/releases.json
@@ -1,8 +1,9 @@
 {
 	"5.0.1": {
 		"user": "admin",
-		"application": "public_app",
+		"application": "amd64_supervisor_app",
 		"release_version": "v5.0.1",
+		"semver": "5.0.1",
 		"status": "success",
 		"source": "cloud",
 		"composition": {
@@ -15,8 +16,9 @@
 	},
 	"6.0.1": {
 		"user": "admin",
-		"application": "public_app",
+		"application": "amd64_supervisor_app",
 		"release_version": "v6.0.1",
+		"semver": "6.0.1",
 		"status": "success",
 		"source": "cloud",
 		"composition": {
@@ -29,8 +31,9 @@
 	},
 	"6.0.1_logstream": {
 		"user": "admin",
-		"application": "public_app",
+		"application": "amd64_supervisor_app",
 		"release_version": "v6.0.1_logstream",
+		"semver": "6.0.1",
 		"status": "success",
 		"source": "cloud",
 		"composition": {
@@ -43,8 +46,9 @@
 	},
 	"7.0.1": {
 		"user": "admin",
-		"application": "public_app",
+		"application": "amd64_supervisor_app",
 		"release_version": "v7.0.1",
+		"semver": "7.0.1",
 		"status": "success",
 		"source": "cloud",
 		"composition": {
@@ -57,8 +61,9 @@
 	},
 	"8.0.1": {
 		"user": "admin",
-		"application": "public_app",
+		"application": "amd64_supervisor_app",
 		"release_version": "v8.0.1",
+		"semver": "8.0.1",
 		"status": "success",
 		"source": "cloud",
 		"composition": {
@@ -71,8 +76,9 @@
 	},
 	"8.1.1": {
 		"user": "admin",
-		"application": "public_app",
+		"application": "amd64_supervisor_app",
 		"release_version": "v8.1.1",
+		"semver": "8.1.1",
 		"status": "success",
 		"source": "cloud",
 		"is_invalidated": true,
@@ -86,8 +92,9 @@
 	},
 	"12.1.1": {
 		"user": "admin",
-		"application": "public_pi_app",
+		"application": "armv7hf_supervisor_app",
 		"release_version": "v12.1.1",
+		"semver": "12.1.1",
 		"status": "success",
 		"source": "cloud",
 		"is_invalidated": false,
@@ -101,7 +108,7 @@
 	},
 	"no_version": {
 		"user": "admin",
-		"application": "public_pi_app",
+		"application": "armv7hf_supervisor_app",
 		"status": "success",
 		"source": "cloud",
 		"is_invalidated": false,

--- a/test/fixtures/16-supervisor-app/services.json
+++ b/test/fixtures/16-supervisor-app/services.json
@@ -1,7 +1,7 @@
 {
 	"service1": {
 		"service_name": "service1",
-		"application": "public_app",
+		"application": "amd64_supervisor_app",
 		"user": "admin"
 	},
 	"service2": {
@@ -16,7 +16,7 @@
 	},
 	"service4": {
 		"service_name": "service4",
-		"application": "public_pi_app",
+		"application": "armv7hf_supervisor_app",
 		"user": "admin"
 	}
 }

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -64,9 +64,10 @@ const loaders: Dictionary<LoaderFunc> = {
 		if (user == null) {
 			logErrorAndThrow(`Could not find user: ${jsonData.user}`);
 		}
-		const org = await fixtures.organizations['admin'];
+		const targetOrgHandle = jsonData.organization ?? 'admin';
+		const org = await fixtures.organizations[targetOrgHandle];
 		if (org == null) {
-			logErrorAndThrow('Could not find admin org');
+			logErrorAndThrow(`Could not find ${targetOrgHandle} org`);
 		}
 
 		if (jsonData.depends_on__application != null) {
@@ -124,6 +125,13 @@ const loaders: Dictionary<LoaderFunc> = {
 			user,
 		});
 	},
+	organizations: async (jsonData) => {
+		return await api.resin.post({
+			resource: 'organization',
+			passthrough: { req: permissions.root },
+			body: jsonData,
+		});
+	},
 	service_environment_variables: async (jsonData, fixtures) => {
 		const user = await fixtures.users[jsonData.user];
 		if (user == null) {
@@ -173,6 +181,7 @@ const loaders: Dictionary<LoaderFunc> = {
 					'composition',
 					'source',
 					'release_version',
+					'semver',
 					'is_invalidated',
 					'is_final',
 					'is_passing_tests',

--- a/test/test-lib/init-tests.ts
+++ b/test/test-lib/init-tests.ts
@@ -63,7 +63,16 @@ export const postInit = async () => {
 	await import('./device-type');
 
 	const { user, org } = await loadAdminUserAndOrganization();
+	const balenaOsFx = await fixtures.load('00-balena_os');
 	fixtures.setDefaultFixtures('users', { admin: Promise.resolve(user) });
-	fixtures.setDefaultFixtures('organizations', { admin: Promise.resolve(org) });
+	fixtures.setDefaultFixtures('organizations', {
+		admin: Promise.resolve(org),
+		...Object.fromEntries(
+			Object.entries(balenaOsFx.organizations).map(([key, value]) => [
+				key,
+				Promise.resolve(value),
+			]),
+		),
+	});
 	await import('../00_init');
 };


### PR DESCRIPTION
The cloud API has a rule which enforces this
restriction, which means that a PATCH of a device's
supervisor_version could fail if this code returned
a release of a different public app that has the same
release_version.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>