### PR TITLE
cache/multi-level-store: Fix not using the store cacheKey

### DIFF
--- a/src/infra/cache/multi-level-store.ts
+++ b/src/infra/cache/multi-level-store.ts
@@ -46,7 +46,7 @@ export function createMultiLevelStore<T extends Defined>(
 		// We include the version so that we get automatic invalidation on updates which might change the memoized fn behavior,
 		// we also calculate the keyPrefix lazily so that the version has a chance to be set as otherwise the memoized function
 		// creation can happen before the version has been initialized
-		keyPrefix ??= `cache$${version}$${key}$`;
+		keyPrefix ??= `cache$${version}$${cacheKey}$`;
 		return `${keyPrefix}${key}`;
 	};
 


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-io/open-balena-api/pull/831/files
See: https://www.flowdock.com/app/rulemotion/p-billing/threads/3z1OUmB627sBGtZhGRPzn-yOXq0
See: https://app.circleci.com/pipelines/github/balena-io/balena-api/30340/workflows/f9c9df89-d18a-42b6-a703-3f4a4ba73f89/jobs/69968
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>