### PR TITLE
Refactor the state patch tests to use the expectResourceToMatch helper

### DIFF
--- a/test/test-lib/pinetest.ts
+++ b/test/test-lib/pinetest.ts
@@ -3,4 +3,5 @@ import { PineTest } from 'pinejs-client-supertest';
 import { app } from '../../init';
 import { version } from './versions';
 
+export type { PineTest };
 export const pineTest = new PineTest({ apiPrefix: `${version}/` }, { app });


### PR DESCRIPTION
Reduces the amount of code in the tests.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>