### PR TITLE
var-schema: Extend custom DTB support to include Jetson Nano 2GB Devkit

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -233,6 +233,8 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 			'srd3-tx2',
 			'jetson-nano',
 			'jetson-nano-emmc',
+			'jetson-nano-2gb-devkit',
+			'floyd-nano',
 			'jn30b-nano',
 			'photon-nano',
 			'jetson-tx2-nx-devkit',


### PR DESCRIPTION
... and the community supported Floyd Nano.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Connects-to: https://github.com/balena-os/balena-supervisor/pull/1822