### PR TITLE
Expose the RPi family config vars to Pi Zero 2W

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -122,6 +122,7 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 		capableDeviceTypes: [
 			'fincm3',
 			'npe-x500-m3',
+			'raspberrypi0-2w-64',
 			'raspberry-pi',
 			'raspberry-pi2',
 			'raspberrypi3',


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Alexandru Costche <alexandru@balena.io>