### PR TITLE
Test updating device supervisor to a release with different service name

### DIFF
--- a/test/fixtures/16-supervisor-app/images.json
+++ b/test/fixtures/16-supervisor-app/images.json
@@ -1,28 +1,28 @@
 {
 	"image1": {
 		"user": "admin",
-		"service": "service1",
+		"service": "amd64_supervisor_app_service1",
 		"releases": [ "5.0.1" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
 	"image2": {
 		"user": "admin",
-		"service": "service1",
+		"service": "amd64_supervisor_app_service1",
 		"releases": [ "6.0.1_logstream" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
 	"image3": {
 		"user": "admin",
-		"service": "service1",
+		"service": "amd64_supervisor_app_service1",
 		"releases": [ "7.0.1" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
 	"image4": {
 		"user": "admin",
-		"service": "service1",
+		"service": "amd64_supervisor_app_service1",
 		"releases": [ "8.0.1" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
@@ -43,29 +43,43 @@
 	},
 	"image7": {
 		"user": "admin",
-		"service": "service1",
+		"service": "amd64_supervisor_app_service1",
 		"releases": [ "8.1.1" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
 	"image8": {
 		"user": "admin",
-		"service": "service1",
+		"service": "amd64_supervisor_app_service1",
 		"releases": [ "8.1.2" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
 	"image9": {
 		"user": "admin",
-		"service": "service4",
+		"service": "armv7hf_supervisor_app_service1",
 		"releases": [ "12.1.1_armv7hf" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
 	"image10": {
 		"user": "admin",
-		"service": "service4",
+		"service": "amd64_supervisor_app_service1",
 		"releases": [ "12.1.1_amd64" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"image11": {
+		"user": "admin",
+		"service": "amd64_supervisor_app_service2",
+		"releases": [ "12.10.15_amd64" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"image12": {
+		"user": "admin",
+		"service": "amd64_supervisor_app_service2",
+		"releases": [ "12.11.0_amd64" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	}

--- a/test/fixtures/16-supervisor-app/releases.json
+++ b/test/fixtures/16-supervisor-app/releases.json
@@ -136,6 +136,34 @@
 			}
 		}
 	},
+	"12.10.15_amd64": {
+		"user": "admin",
+		"application": "amd64_supervisor_app",
+		"semver": "12.10.15",
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image11": {
+					"build": "./image11/"
+				}
+			}
+		}
+	},
+	"12.11.0_amd64": {
+		"user": "admin",
+		"application": "amd64_supervisor_app",
+		"semver": "12.11.0",
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image12": {
+					"build": "./image12/"
+				}
+			}
+		}
+	},
 	"no_version": {
 		"user": "admin",
 		"application": "armv7hf_supervisor_app",

--- a/test/fixtures/16-supervisor-app/services.json
+++ b/test/fixtures/16-supervisor-app/services.json
@@ -1,6 +1,6 @@
 {
-	"service1": {
-		"service_name": "service1",
+	"amd64_supervisor_app_service1": {
+		"service_name": "main",
 		"application": "amd64_supervisor_app",
 		"user": "admin"
 	},
@@ -10,13 +10,18 @@
 		"user": "admin"
 	},
 	"service3": {
-		"service_name": "service3",
+		"service_name": "main",
 		"application": "host_app",
 		"user": "admin"
 	},
-	"service4": {
-		"service_name": "service4",
+	"armv7hf_supervisor_app_service1": {
+		"service_name": "main",
 		"application": "armv7hf_supervisor_app",
+		"user": "admin"
+	},
+	"amd64_supervisor_app_service2": {
+		"service_name": "balena-supervisor",
+		"application": "amd64_supervisor_app",
 		"user": "admin"
 	}
 }


### PR DESCRIPTION
This was already fixed as a side-effect of #874.

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-devices/threads/Ic1T-Faru_yiO6nahG6XlOlZ8eQ
Depends-on: https://github.com/balena-io/open-balena-api/pull/874
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>