### PR TITLE
Optimize the "device operated by same device type hostApp" rule

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -825,7 +825,7 @@ Rule: It is necessary that each release that should be running on a device, has 
 Rule: It is necessary that each release that should be running on an application, has a status that is equal to "success" and belongs to the application.
 Rule: It is necessary that each release that contains at least 2 images, belongs to an application that has an application type that supports multicontainer.
 Rule: It is necessary that each release that should operate a device, has a status that is equal to "success".
-Rule: It is necessary that each release that should operate a device, belongs to an application that is host and is for a device type that describes the device.
+Rule: It is necessary that each release that should operate a device that is of a device type, belongs to an application that is host and is for the device type.
 -- native supervisor release rules, separated for legibility
 Rule: It is necessary that each release that should manage a device, has a status that is equal to "success" and has a semver major that is greater than 0 or has a semver minor that is greater than 0 or has a semver patch that is greater than 0.
 Rule: It is necessary that each release that should manage a device, belongs to an application that is public and is not host.

--- a/test/15_target-hostapp.ts
+++ b/test/15_target-hostapp.ts
@@ -152,7 +152,7 @@ describe('target hostapps', () => {
 			.send({ should_be_operated_by__release: raspberryPiHostappReleaseId })
 			.expect(
 				400,
-				'"It is necessary that each release that should operate a device, belongs to an application that is host and is for a device type that describes the device."',
+				'"It is necessary that each release that should operate a device that is of a device type, belongs to an application that is host and is for the device type."',
 			);
 	});
 


### PR DESCRIPTION
Gets us from
```sql
-- 1304 (cost=5.75..5.76 rows=1 width=1) (actual time=1304.733..1304.736 rows=1 loops=1)
SET jit = 0; EXPLAIN ANALYZE SELECT NOT EXISTS (
	SELECT 1
	FROM "release" AS "release.0",
		"device" AS "device.1"
	WHERE "device.1"."should be operated by-release" = "release.0"."id"
	AND NOT EXISTS (
		SELECT 1
		FROM "application" AS "application.2",
			"device type" AS "device type.3"
		WHERE "device.1"."is of-device type" = "device type.3"."id"
		AND "application.2"."is for-device type" = "device type.3"."id"
		AND "application.2"."is host" = 1
		AND "release.0"."belongs to-application" = "application.2"."id"
	)
) AS "result";
```
to
```sql
-- 981 (cost=5.38..5.39 rows=1 width=1) (actual time=981.286..981.288 rows=1 loops=1)
SET jit = 0; EXPLAIN ANALYZE SELECT NOT EXISTS (
	SELECT 1
	FROM "release" AS "release.0",
		"device" AS "device.1",
		"device type" AS "device type.2"
	WHERE "device.1"."is of-device type" = "device type.2"."id"
	AND "device.1"."should be operated by-release" = "release.0"."id"
	AND NOT EXISTS (
		SELECT 1
		FROM "application" AS "application.3"
		WHERE "application.3"."is host" = 1
		AND "application.3"."is for-device type" = "device type.2"."id"
		AND "release.0"."belongs to-application" = "application.3"."id"
	)
) AS "result";
```

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/autohat/threads/mtagl6-CmM9f0DBHJ_twQ-kD496
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>