### PR TITLE
Extend the supervisor application rule to also check the slug

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -828,5 +828,6 @@ Rule: It is necessary that each release that should operate a device, has a stat
 Rule: It is necessary that each release that should operate a device that is of a device type, belongs to an application that is host and is for the device type.
 -- native supervisor release rules, separated for legibility
 Rule: It is necessary that each release that should manage a device, has a status that is equal to "success" and has a semver major that is greater than 0 or has a semver minor that is greater than 0 or has a semver patch that is greater than 0.
-Rule: It is necessary that each release that should manage a device, belongs to an application that is public and is not host.
+-- this rule is meant to prevent accidentally setting a host extension as a supervisor (i.e., another public + non-host app)
+Rule: It is necessary that each release that should manage a device, belongs to an application that is public and is not host and has a slug that is equal to "balena_os/aarch64-supervisor" or "balena_os/amd64-supervisor" or "balena_os/armv7hf-supervisor" or "balena_os/i386-supervisor" or "balena_os/i386-nlp-supervisor" or "balena_os/rpi-supervisor".
 Rule: It is necessary that each release that should manage a device that is of a device type1, belongs to an application that is for a device type2 that is of a cpu architecture that is supported by the device type1.

--- a/src/migrations/00066-supervisor-release-application-slug-rule.sql
+++ b/src/migrations/00066-supervisor-release-application-slug-rule.sql
@@ -1,0 +1,28 @@
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM "release" AS "release.0",
+			"device" AS "device.1"
+		WHERE "device.1"."should be managed by-release" = "release.0"."id"
+		AND NOT EXISTS (
+			SELECT 1
+			FROM "application" AS "application.2"
+			WHERE "application.2"."is public" = 1
+			AND "application.2"."is host" = 0
+			AND "application.2"."slug" IN (
+				'balena_os/aarch64-supervisor',
+				'balena_os/amd64-supervisor',
+				'balena_os/armv7hf-supervisor',
+				'balena_os/i386-supervisor',
+				'balena_os/i386-nlp-supervisor',
+				'balena_os/rpi-supervisor'
+			)
+			AND "application.2"."slug" IS NOT NULL
+			AND "release.0"."belongs to-application" = "application.2"."id"
+		)
+	)
+	THEN
+		RAISE EXCEPTION 'migration failed: It is necessary that each release that should manage a device, belongs to an application that is public and is not host and has a slug that is equal to "balena_os/aarch64-supervisor" or "balena_os/amd64-supervisor" or "balena_os/armv7hf-supervisor" or "balena_os/i386-supervisor" or "balena_os/i386-nlp-supervisor" or "balena_os/rpi-supervisor".';
+	END IF;
+END $$;


### PR DESCRIPTION
The Cloud API already had this rule and the
supervisor release inference code already
uses the same filter.

From:
```sql
-- 1409 (cost=2.28..2.29 rows=1 width=1) (actual time=1409.593..1409.595 rows=1 loops=1)
-- Rule: It is necessary that each release that should manage a device, belongs to an application that is public and is not host.
SET jit = 0; EXPLAIN ANALYZE SELECT NOT EXISTS (
	SELECT 1
	FROM "release" AS "release.0",
		"device" AS "device.1"
	WHERE "device.1"."should be managed by-release" = "release.0"."id"
	AND NOT EXISTS (
		SELECT 1
		FROM "application" AS "application.2"
		WHERE "application.2"."is public" = 1
		AND "application.2"."is host" = 0
		AND "release.0"."belongs to-application" = "application.2"."id"
	)
) AS "result";

-- 879 (cost=1.91..1.92 rows=1 width=1) (actual time=879.328..879.331 rows=1 loops=1)
-- Rule: It is necessary that each release that should manage a device, belongs to an application that has a slug that is equal to "balena_os/aarch64-supervisor" or "balena_os/amd64-supervisor" or "balena_os/armv7hf-supervisor" or "balena_os/i386-supervisor" or "balena_os/i386-nlp-supervisor" or "balena_os/rpi-supervisor".
SET jit = 0; EXPLAIN ANALYZE SELECT NOT EXISTS (
	SELECT 1
	FROM "release" AS "release.0",
		"device" AS "device.1"
	WHERE "device.1"."should be managed by-release" = "release.0"."id"
	AND NOT EXISTS (
		SELECT 1
		FROM "application" AS "application.2"
		WHERE "application.2"."slug" IN (
			'balena_os/aarch64-supervisor',
			'balena_os/amd64-supervisor',
			'balena_os/armv7hf-supervisor',
			'balena_os/i386-supervisor',
			'balena_os/i386-nlp-supervisor',
			'balena_os/rpi-supervisor'
		)
		AND "application.2"."slug" IS NOT NULL
		AND "release.0"."belongs to-application" = "application.2"."id"
	)
) AS "result";
```

To:
```sql
-- 1443 (cost=2.25..2.26 rows=1 width=1) (actual time=1443.471..1443.473 rows=1 loops=1)
-- Rule: It is necessary that each release that should manage a device, belongs to an application that is public and is not host and has a slug that is equal to "balena_os/aarch64-supervisor" or "balena_os/amd64-supervisor" or "balena_os/armv7hf-supervisor" or "balena_os/i386-supervisor" or "balena_os/i386-nlp-supervisor" or "balena_os/rpi-supervisor".
SET jit = 0; EXPLAIN ANALYZE SELECT NOT EXISTS (
	SELECT 1
	FROM "release" AS "release.0",
		"device" AS "device.1"
	WHERE "device.1"."should be managed by-release" = "release.0"."id"
	AND NOT EXISTS (
		SELECT 1
		FROM "application" AS "application.2"
		WHERE "application.2"."is public" = 1
		AND "application.2"."is host" = 0
		AND "application.2"."slug" IN (
			'balena_os/aarch64-supervisor',
			'balena_os/amd64-supervisor',
			'balena_os/armv7hf-supervisor',
			'balena_os/i386-supervisor',
			'balena_os/i386-nlp-supervisor',
			'balena_os/rpi-supervisor'
		)
		AND "application.2"."slug" IS NOT NULL
		AND "release.0"."belongs to-application" = "application.2"."id"
	)
) AS "result";
```
The speed improvements on POSTs & DELETEs should be way important than the slowdown of PATCHes to `application.is_public`.
I'm expecting this to become even better in case we also add an `application_is_public_is_host_idx`.



Change-type: minor
See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/61KC8Lpk8aCuOIclIsFhlUeC-RU
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>