### PR TITLE
target-hostapp: Add support for detecting unified OS releases

### DIFF
--- a/src/features/hostapp/hooks/target-hostapp.ts
+++ b/src/features/hostapp/hooks/target-hostapp.ts
@@ -230,17 +230,35 @@ async function getOSReleaseResource(
 						},
 					},
 					{
-						release_tag: {
-							$any: {
-								$alias: 'rt',
-								$expr: {
-									rt: {
-										value: normalizeVariant(osVariant),
-										tag_key: 'variant',
+						$or: [
+							{
+								release_tag: {
+									$any: {
+										$alias: 'rt',
+										$expr: {
+											rt: {
+												value: normalizeVariant(osVariant),
+												tag_key: 'variant',
+											},
+										},
 									},
 								},
 							},
-						},
+							{
+								$not: {
+									release_tag: {
+										$any: {
+											$alias: 'rt',
+											$expr: {
+												rt: {
+													tag_key: 'variant',
+												},
+											},
+										},
+									},
+								},
+							},
+						],
 					},
 				],
 			},

--- a/test/fixtures/15-target-hostapps/release_tags.json
+++ b/test/fixtures/15-target-hostapps/release_tags.json
@@ -82,5 +82,11 @@
 		"release": "release6",
 		"tag_key": "version",
 		"value": "2.53.0+rev1"
+	},
+	"unifiedReleaseTag-version": {
+		"user": "admin",
+		"release": "unifiedRelease",
+		"tag_key": "version",
+		"value": "2.88.4"
 	}
 }

--- a/test/fixtures/15-target-hostapps/releases.json
+++ b/test/fixtures/15-target-hostapps/releases.json
@@ -49,5 +49,13 @@
 		"status": "success",
 		"is_invalidated": true,
 		"user": "admin"
+	},
+	"unifiedRelease": {
+		"application": "intel-nuc",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"is_invalidated": true,
+		"user": "admin"
 	}
 }


### PR DESCRIPTION
Change-type: minor
See: https://jel.ly.fish/improvement-combine-os-variants-0d96399a-660b-4d38-adca-f661378cb86e
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>