### PR TITLE
Add a fasttest-stop npm script that stops the fasttest containers

### DIFF
--- a/automation/fasttest.sh
+++ b/automation/fasttest.sh
@@ -15,6 +15,7 @@ external=''
 test_versions=''
 test_files=''
 teardown=0
+stop=0
 extra_env=''
 extra_args=''
 
@@ -24,6 +25,9 @@ while [[ $# -gt 0 ]]; do
 	case $key in
 		--teardown)
 			teardown=1
+		;;
+		--stop)
+			stop=1
 		;;
 		--long-stack)
 			extra_env="${extra_env} --env BLUEBIRD_LONG_STACK_TRACES=1"
@@ -50,6 +54,12 @@ if [[ $teardown -eq 1 ]]; then
 	echo 'Tearing down test environment...'
 	teardown $IMAGE_NAME $db_id $redis_id $loki_id $api_id
 	rm "$CONFIG_FILE" 2>/dev/null || true
+	exit 0
+fi
+
+if [[ $stop -eq 1 ]]; then
+	echo 'Stopping test environment containers...'
+	docker stop $api_id $db_id $redis_id $loki_id 2>/dev/null || true
 	exit 0
 fi
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "fasttest": "IMAGE_NAME=test-open-balena-api-fast ./automation/fasttest.sh",
+    "fasttest-stop": "IMAGE_NAME=test-open-balena-api-fast ./automation/fasttest.sh --stop",
     "fasttest-cleanup": "IMAGE_NAME=test-open-balena-api-fast ./automation/fasttest.sh --teardown",
     "materialize-config": "npm run fasttest -- --generate-config .materialized-config.json",
     "generate-model-schema": "npm run materialize-config && npx @balena/pinejs compile .materialized-config.json .materialized-schema.sql",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>