### PR TITLE
Rename the exported deviceTypes.getDeviceTypeIdBySlug() to getDeviceTypeBySlug() & the DeviceType type to DeviceTypeJson

### DIFF
--- a/src/features/device-config/device-config.ts
+++ b/src/features/device-config/device-config.ts
@@ -15,7 +15,7 @@ import {
 	createProvisioningApiKey,
 	createUserApiKey,
 } from '../api-keys/lib';
-import type { DeviceType } from '../device-types/device-types';
+import type { DeviceTypeJson } from '../device-types/device-types';
 
 const { BadRequestError } = errors;
 
@@ -34,7 +34,7 @@ import {
 export const generateConfig = async (
 	req: Request,
 	app: deviceConfig.GenerateOptions['application'],
-	deviceType: DeviceType,
+	deviceType: DeviceTypeJson,
 	osVersion?: string,
 ) => {
 	const userPromise = getUser(req);

--- a/src/features/device-config/download.ts
+++ b/src/features/device-config/download.ts
@@ -61,11 +61,11 @@ export const downloadImageConfig: RequestHandler = async (req, res) => {
 		const resinApi = api.resin.clone({ passthrough: { req } });
 
 		const app = await getApp(req);
-		const deviceType = await findBySlug(
+		const deviceTypeJson = await findBySlug(
 			resinApi,
 			deviceTypeSlug || app.is_for__device_type[0].slug,
 		);
-		const config = await generateConfig(req, app, deviceType, osVersion);
+		const config = await generateConfig(req, app, deviceTypeJson, osVersion);
 
 		res.json(config);
 	} catch (err) {

--- a/src/features/device-types/build-info-facade.ts
+++ b/src/features/device-types/build-info-facade.ts
@@ -1,7 +1,7 @@
 import * as memoizee from 'memoizee';
 import { multiCacheMemoizee } from '../../infra/cache';
 
-import * as deviceTypesLib from '@resin.io/device-types';
+import type { DeviceType as DeviceTypeJson } from '@resin.io/device-types';
 
 import {
 	BUILD_COMPRESSED_SIZE_CACHE_TIMEOUT,
@@ -9,8 +9,6 @@ import {
 	FILES_HOST,
 } from '../../lib/config';
 import { fileExists, getFile, getFolderSize, getImageKey } from './storage';
-
-export type DeviceType = deviceTypesLib.DeviceType;
 
 export const getLogoUrl = multiCacheMemoizee(
 	async (
@@ -52,7 +50,7 @@ export const getDeviceTypeJson = memoizee(
 	async (
 		normalizedSlug: string,
 		buildId: string,
-	): Promise<deviceTypesLib.DeviceType | undefined> => {
+	): Promise<DeviceTypeJson | undefined> => {
 		const isIgnored = await fileExists(
 			getImageKey(normalizedSlug, buildId, 'IGNORE'),
 		);
@@ -64,7 +62,7 @@ export const getDeviceTypeJson = memoizee(
 		);
 		const deviceType =
 			response && response.Body
-				? (JSON.parse(response.Body.toString()) as DeviceType)
+				? (JSON.parse(response.Body.toString()) as DeviceTypeJson)
 				: undefined;
 		if (deviceType) {
 			deviceType.buildId = buildId;

--- a/src/features/device-types/device-types.ts
+++ b/src/features/device-types/device-types.ts
@@ -292,7 +292,7 @@ export interface ImageVersions {
 	latest: string;
 }
 
-export const getDeviceTypeIdBySlug = async (
+export const getDeviceTypeBySlug = async (
 	resinApi: sbvrUtils.PinejsClient,
 	slug: string,
 ): Promise<{ id: number; slug: string } | undefined> => {

--- a/src/features/device-types/device-types.ts
+++ b/src/features/device-types/device-types.ts
@@ -33,10 +33,10 @@ export class UnknownVersionError extends NotFoundError {
 	}
 }
 
-export type DeviceType = deviceTypesLib.DeviceType;
+export type DeviceTypeJson = deviceTypesLib.DeviceType;
 
 interface DeviceTypeInfo {
-	latest: DeviceType;
+	latest: DeviceTypeJson;
 	versions: string[];
 }
 
@@ -55,9 +55,9 @@ function sortBuildIds(ids: string[]): string[] {
 const getFirstValidBuild = async (
 	slug: string,
 	versions: string[],
-): Promise<DeviceType | undefined> => {
+): Promise<DeviceTypeJson | undefined> => {
 	for (const buildId of versions) {
-		let deviceType: DeviceType | undefined;
+		let deviceType: DeviceTypeJson | undefined;
 		try {
 			deviceType = await getDeviceTypeJson(slug, buildId);
 		} catch (err) {
@@ -229,7 +229,7 @@ const getAllDeviceTypes = async () => {
 
 export const getAccessibleDeviceTypes = async (
 	resinApi: sbvrUtils.PinejsClient,
-): Promise<DeviceType[]> => {
+): Promise<DeviceTypeJson[]> => {
 	const [deviceTypes, accessibleDeviceTypes] = await Promise.all([
 		getAllDeviceTypes(),
 		getAccessibleSlugs(resinApi),
@@ -244,7 +244,7 @@ export const getAccessibleDeviceTypes = async (
 export const findBySlug = async (
 	resinApi: sbvrUtils.PinejsClient,
 	slug: string,
-): Promise<DeviceType> => {
+): Promise<DeviceTypeJson> => {
 	const deviceTypes = await getAccessibleDeviceTypes(resinApi);
 	const deviceType = await deviceTypesLib.findBySlug(deviceTypes, slug);
 	if (deviceType == null) {

--- a/src/features/device-types/hooks.ts
+++ b/src/features/device-types/hooks.ts
@@ -1,6 +1,6 @@
 import { sbvrUtils, hooks, errors } from '@balena/pinejs';
 import { captureException } from '../../infra/error-handling';
-import { getDeviceTypeIdBySlug, UnknownDeviceTypeError } from './device-types';
+import { getDeviceTypeBySlug, UnknownDeviceTypeError } from './device-types';
 
 const { BadRequestError, ConflictError } = errors;
 
@@ -11,10 +11,7 @@ export const resolveDeviceType = async (
 ): Promise<void> => {
 	if (request.values.device_type != null && request.values[fkValue] == null) {
 		// translate device_type to is_for__device_type
-		const dtBySlug = await getDeviceTypeIdBySlug(
-			api,
-			request.values.device_type,
-		);
+		const dtBySlug = await getDeviceTypeBySlug(api, request.values.device_type);
 		if (!dtBySlug) {
 			throw new UnknownDeviceTypeError(request.values.device_type);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ export * as tags from './features/tags/validation';
 export type { Creds, User } from './infra/auth/jwt-passport';
 export type { Access } from './features/registry/registry';
 export type { ApplicationType } from './features/application-types/application-types';
-export type { DeviceType } from './features/device-types/device-types';
+export type { DeviceTypeJson } from './features/device-types/device-types';
 
 export { DefaultApplicationType } from './features/application-types/application-types';
 export * as request from './infra/request-promise';

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ import {
 import {
 	getAccessibleDeviceTypes,
 	findBySlug,
-	getDeviceTypeIdBySlug,
+	getDeviceTypeBySlug,
 } from './features/device-types/device-types';
 import { proxy as supervisorProxy } from './features/device-proxy/device-proxy';
 import { generateConfig } from './features/device-config/device-config';
@@ -244,7 +244,7 @@ export const release = {
 export const deviceTypes = {
 	getAccessibleDeviceTypes,
 	findBySlug,
-	getDeviceTypeIdBySlug,
+	getDeviceTypeBySlug,
 };
 export const contracts = {
 	setSyncSettings,


### PR DESCRIPTION
The getDeviceTypeIdBySlug name was
misleading, since the helper was returning an
object.

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>