### PR TITLE
Use a hash tag for redis logs keys

### DIFF
--- a/src/features/device-logs/lib/backends/redis.ts
+++ b/src/features/device-logs/lib/backends/redis.ts
@@ -155,7 +155,7 @@ export class RedisBackend implements DeviceLogsBackend {
 	}
 
 	private getKey(ctx: LogContext, suffix = 'logs') {
-		return `device:${ctx.id}:${suffix}`;
+		return `{device:${ctx.id}}:${suffix}`;
 	}
 
 	private handleMessage(key: string, payload: string) {


### PR DESCRIPTION
This allows specifying the part of the key to use for redis hashing to
ensure that related logs keys are grouped together

Change-type: minor