### PR TITLE
Augment provisioning API key permissions for Post Hostapp hook

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -8,7 +8,8 @@ export = {
 			username: 'guest',
 			password: ' ',
 			permissions: [
-				'resin.device_type.read',
+				// The "1 eq 1" is necessary so that we can do "device_type/canAccess()"
+				'resin.device_type.read?1 eq 1',
 				'resin.device_type_alias.read',
 				'resin.cpu_architecture.read',
 				'resin.device_family.read',

--- a/src/features/device-provisioning/register.ts
+++ b/src/features/device-provisioning/register.ts
@@ -53,11 +53,18 @@ export const register: RequestHandler = async (req, res) => {
 		} = req.body;
 		const deviceApiKey = req.body.api_key ?? randomstring.generate();
 
-		// Temporarily augment the api key with the ability to fetch the device we create and create an api key for it
+		/**
+		 * Temporarily augment the api key with the ability to:
+		 * - Fetch the device we create & create an api key for it
+		 * - Read the hostApp releases that should be operating the device
+		 */
 		req = augmentReqApiKeyPermissions(
 			req,
 			'resin.device.read',
 			'resin.device.create-device-api-key',
+			`resin.application.read?is_public eq true and is_host eq true and is_for__device_type/canAccess()`,
+			'resin.release.read?belongs_to__application/canAccess()',
+			`resin.release_tag.read?release/canAccess()`,
 		);
 
 		const response = await sbvrUtils.db.transaction(async (tx) => {


### PR DESCRIPTION
When provisioning a device, a [postHostappHook](https://github.com/balena-io/open-balena-api/blob/master/src/features/hostapp/hooks/target-hostapp.ts#L82-L119) is being run since commit https://github.com/balena-io/open-balena-api/commit/0eca892c689acf33c3d18b7f25b16ab1d90f4731 (v0.139.1).

This hook gets the OS release resource, which queries the [release, application and release tag tables](https://github.com/balena-io/open-balena-api/blob/master/src/features/hostapp/hooks/target-hostapp.ts#L193-L267). 
This is why the provisioning fails when running an openBalena instance. With those permissions added, it works fine.

Hopefully you guys will merge this!