### PR TITLE
Fix supervisor & hostApp being set on device outside of the transaction

### DIFF
--- a/src/features/hostapp/hooks/target-hostapp.ts
+++ b/src/features/hostapp/hooks/target-hostapp.ts
@@ -154,6 +154,7 @@ async function setOSReleaseResource(
 	const rootApi = api.clone({
 		passthrough: {
 			req: permissions.root,
+			tx: api.passthrough.tx,
 		},
 	});
 

--- a/src/features/supervisor-app/hooks/supervisor-app.ts
+++ b/src/features/supervisor-app/hooks/supervisor-app.ts
@@ -217,6 +217,7 @@ async function setSupervisorReleaseResource(
 	const rootApi = api.clone({
 		passthrough: {
 			req: permissions.root,
+			tx: api.passthrough.tx,
 		},
 	});
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>