### PR TITLE
Fix random name generator

### DIFF
--- a/src/infra/haiku-name/index.ts
+++ b/src/infra/haiku-name/index.ts
@@ -229,6 +229,8 @@ const nouns = [
 	'surf',
 	'table',
 	'tea',
+	'teapot',
+	'tent',
 	'thunder',
 	'tile',
 	'time',
@@ -254,7 +256,8 @@ const nounsCount = nouns.length;
 const bigNumber = Math.pow(2, 12);
 
 export const generate = () => {
-	const rnd = Math.floor(Math.random() * bigNumber);
+	const adjRnd = Math.floor(Math.random() * bigNumber);
+	const nounRnd = Math.floor(Math.random() * bigNumber);
 	// tslint:disable-next-line:no-bitwise
-	return `${adjs[(rnd >> 6) % adjsCount]}-${nouns[rnd % nounsCount]}`;
+	return `${adjs[adjRnd % adjsCount]}-${nouns[nounRnd % nounsCount]}`;
 };


### PR DESCRIPTION
Adjectives after 'mean' were not being selected.

Change-type: patch
Signed-off-by: Chris Crocker-White <chriscw@balena.io>