### PR TITLE
Add an early check to quickly deny deleted devices access to the VPN

### DIFF
--- a/src/features/vpn/index.ts
+++ b/src/features/vpn/index.ts
@@ -3,10 +3,20 @@ import {
 	apiKeyMiddleware,
 	permissionRequiredMiddleware,
 } from '../../infra/auth';
-import { authDevice, clientConnect, clientDisconnect } from './services';
+import {
+	authDevice,
+	clientConnect,
+	clientDisconnect,
+	denyDeletedDevices,
+} from './services';
 
 export const setup = (app: Application) => {
-	app.get('/services/vpn/auth/:device_uuid', apiKeyMiddleware, authDevice);
+	app.get(
+		'/services/vpn/auth/:uuid',
+		denyDeletedDevices,
+		apiKeyMiddleware,
+		authDevice,
+	);
 	app.post(
 		'/services/vpn/client-connect',
 		apiKeyMiddleware,


### PR DESCRIPTION
This avoids unnecessary work when checking for a device that has
already been deleted and will allow legitimate VPN auth requests to be
served more quickly

Change-type: minor