### PR TITLE
Consider devices with heartbeats to be out of the pre-provisioning state

### DIFF
--- a/src/features/devices/models/device-additions.ts
+++ b/src/features/devices/models/device-additions.ts
@@ -59,8 +59,13 @@ export const addToModel = (
 	// so it's still provisioning.
 	const isPreProvisioning: AndNode = [
 		'And',
-		isOverallOffline,
+		['Equals', ['ReferencedField', 'device', 'is online'], ['Boolean', false]],
 		['NotExists', ['ReferencedField', 'device', 'last connectivity event']],
+		[
+			'Equals',
+			['ReferencedField', 'device', 'api heartbeat state'],
+			['EmbeddedText', 'unknown'],
+		],
 	];
 
 	const isPostProvisioning: EqualsNode = [


### PR DESCRIPTION
Change-type: minor
See: https://www.flowdock.com/app/rulemotion/r-resinos/threads/3cl3JBefZ2rV51CrrGpOz5T478d
See: https://jel.ly.fish/pattern-heartbeating-devices-without-vpn-connectivity-show-configuring-when-turned-off-f19c956
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>