### PR TITLE
Only cache the device id for `checkDeviceExists` rather than an object

### DIFF
--- a/src/features/device-state/middleware.ts
+++ b/src/features/device-state/middleware.ts
@@ -22,10 +22,11 @@ const checkDeviceExistsQuery = _.once(() =>
 	}),
 );
 export const checkDeviceExists = multiCacheMemoizee(
-	async (uuid: string) => {
-		return (await checkDeviceExistsQuery()({ uuid })) as
+	async (uuid: string): Promise<number | undefined> => {
+		const device = (await checkDeviceExistsQuery()({ uuid })) as
 			| Pick<Device, typeof $select>
 			| undefined;
+		return device?.id;
 	},
 	{
 		cacheKey: 'checkDeviceExists',
@@ -37,7 +38,7 @@ export const checkDeviceExists = multiCacheMemoizee(
 );
 
 export interface ResolveDeviceInfoCustomObject {
-	resolvedDevice: Pick<Device, typeof $select>;
+	resolvedDevice: Device['id'];
 }
 
 export const resolveOrGracefullyDenyDevices: RequestHandler = async (

--- a/src/features/device-state/routes/state-patch-v2.ts
+++ b/src/features/device-state/routes/state-patch-v2.ts
@@ -186,9 +186,9 @@ export const statePatchV2: RequestHandler = async (req, res) => {
 	if (!uuid) {
 		return res.status(400).end();
 	}
-	const { resolvedDevice: device } =
+	const { resolvedDevice: deviceId } =
 		req.custom as ResolveDeviceInfoCustomObject;
-	if (device == null) {
+	if (deviceId == null) {
 		// We are supposed to have already checked this.
 		throw new UnauthorizedError();
 	}
@@ -254,7 +254,7 @@ export const statePatchV2: RequestHandler = async (req, res) => {
 					deviceBody = { ...deviceBody, ...metricsBody };
 					await resinApiTx.patch({
 						resource: 'device',
-						id: device.id,
+						id: deviceId,
 						options: {
 							$filter: { $not: deviceBody },
 						},
@@ -297,7 +297,7 @@ export const statePatchV2: RequestHandler = async (req, res) => {
 						options: {
 							$select: ['id', 'installs__image'],
 							$filter: {
-								device: device.id,
+								device: deviceId,
 								installs__image: { $in: imageIds },
 							},
 						},
@@ -313,13 +313,13 @@ export const statePatchV2: RequestHandler = async (req, res) => {
 								resinApiTx,
 								existingImgInstallsByImage[imgInstall.imageId],
 								imgInstall,
-								device.id,
+								deviceId,
 							);
 						}),
 					);
 				}
 
-				await deleteOldImageInstalls(resinApiTx, device.id, imageIds);
+				await deleteOldImageInstalls(resinApiTx, deviceId, imageIds);
 			});
 		}
 	}
@@ -349,7 +349,7 @@ export const statePatchV2: RequestHandler = async (req, res) => {
 					options: {
 						$select: ['id', 'image'],
 						$filter: {
-							is_downloaded_by__device: device.id,
+							is_downloaded_by__device: deviceId,
 							image: { $in: imageIds },
 						},
 					},
@@ -364,14 +364,14 @@ export const statePatchV2: RequestHandler = async (req, res) => {
 						await upsertGatewayDownload(
 							resinApiTx,
 							existingGatewayDownloadsByImage[gatewayDownload.imageId],
-							device.id,
+							deviceId,
 							gatewayDownload,
 						);
 					}),
 				);
 			}
 
-			await deleteOldGatewayDownloads(resinApiTx, device.id, imageIds);
+			await deleteOldGatewayDownloads(resinApiTx, deviceId, imageIds);
 		});
 	}
 


### PR DESCRIPTION
The object is unnecessary as we only care about the id and only serves
to increases the cache memory usage

Change-type: patch