### PR TITLE
Fix early exist check on service install creation from application PATCH

### DIFF
--- a/src/features/ci-cd/hooks/service-installs.ts
+++ b/src/features/ci-cd/hooks/service-installs.ts
@@ -24,7 +24,7 @@ const createReleaseServiceInstalls = async (
 					},
 				})) as Array<Pick<Device, 'id'>>
 		  ).map(({ id }) => id);
-	if (deviceFilterOrIds.length === 0) {
+	if (deviceIds.length === 0) {
 		return;
 	}
 


### PR DESCRIPTION
TS was unfortunately happy with this b/c FilterObject is a `Dictionary<FilterObj | FilterArray | FilterBaseType>`, so `.length` is a valid prop and comparing with numbers is a valid value as part of FilterBaseType...
Thankfully the check wasn't `!deviceFilterOrIds.length`, b/c that would have resulted invalid target states for devices.

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>