### PR TITLE
auth: Limit password length to 64 characters

### DIFF
--- a/src/infra/auth/auth.ts
+++ b/src/infra/auth/auth.ts
@@ -57,6 +57,10 @@ export const validatePassword = (password?: string) => {
 	if (password.length < 8) {
 		throw new BadRequestError('Password must be at least 8 characters.');
 	}
+	if (64 < password.length) {
+		// OWASP: Avoid long password DoS attacks
+		throw new BadRequestError('Password must be at most 64 characters.');
+	}
 };
 
 // Think twice before using this function as it *unconditionally* sets the


### PR DESCRIPTION
Connects-to: #1050
Change-type: minor
See: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>