### PR TITLE
Add index to optimize hostApp app rule

### DIFF
--- a/src/balena-init.sql
+++ b/src/balena-init.sql
@@ -70,8 +70,8 @@ ON "device" ("is running-release");
 -- Also optimizes should be running succesful release rule
 CREATE INDEX IF NOT EXISTS "device_should_be_running_release_application_idx"
 ON "device" ("should be running-release", "belongs to-application");
-CREATE INDEX IF NOT EXISTS "device_should_be_operated_by_release_idx"
-ON "device" ("should be operated by-release");
+CREATE INDEX IF NOT EXISTS "device_should_be_operated_by__release_device_type_idx"
+ON "device" ("should be operated by-release", "is of-device type");
 -- Also optimizes the supervisor cpu arch should match device cpu arch rule
 CREATE INDEX IF NOT EXISTS "device_should_be_managed_by__release_device_type_idx"
 ON "device" ("should be managed by-release", "is of-device type");

--- a/src/migrations/0074-device-operated-by-release-index.sql
+++ b/src/migrations/0074-device-operated-by-release-index.sql
@@ -1,0 +1,4 @@
+CREATE INDEX IF NOT EXISTS "device_should_be_operated_by__release_device_type_idx"
+ON "device" ("should be operated by-release", "is of-device type");
+
+DROP INDEX IF EXISTS "device_should_be_operated_by_release_idx";


### PR DESCRIPTION
This should improve the "device should be operated by hostApp release of the same DT" rule.
It already is using an index on "operated by release" but since that's the most costly part of the plan, it should help making it an index only scan.
See: https://explain.dalibo.com/plan/1YE#raw (current plan)
PS: Moreover it will be consistent with the "managed by release" index as well :)

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>