### PR TITLE
Fix Husky not working after v4 to v8 update

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no lint-staged

--- a/package.json
+++ b/package.json
@@ -135,11 +135,6 @@
     "node": "^16.13.0",
     "npm": "^8.1.1"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "mocha": {
     "reporter": "spec",
     "sort": true,


### PR DESCRIPTION
Change-type: patch
See: https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v8
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>