### PR TITLE
Fix Husky hooks not being installed on fresh repo clones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update \
 	&& pip3 install --no-cache-dir pgsanity
 
 COPY package.json package-lock.json /usr/src/app/
-RUN npm ci --unsafe-perm --production && npm cache clean --force
+RUN HUSKY=0 npm ci --unsafe-perm --production && npm cache clean --force
 
 COPY . /usr/src/app
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "prettify": "balena-lint --fix src/ test/ typings/ init.ts index.js",
     "prepack": "npm run build",
     "test": "IMAGE_NAME=test-open-balena-api ./automation/test.sh",
-    "posttest": "docker rmi test-open-balena-api"
+    "posttest": "docker rmi test-open-balena-api",
+    "prepare": "[ \"$HUSKY\" = 0 ] || husky install"
   },
   "dependencies": {
     "@balena/abstract-sql-compiler": "^7.20.0",


### PR DESCRIPTION
Change-type: patch
See: https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v8
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>