### PR TITLE
vars-update-trigger: Fix 42P01 error when the affected envs are too many

### DIFF
--- a/src/features/vars-schema/hooks/vars-update-trigger.ts
+++ b/src/features/vars-schema/hooks/vars-update-trigger.ts
@@ -1,5 +1,6 @@
 import { sbvrUtils, hooks } from '@balena/pinejs';
-import type { Filter } from 'pinejs-client-core';
+import * as _ from 'lodash';
+import type { FilterObj } from 'pinejs-client-core';
 
 import { captureException } from '../../../infra/error-handling';
 
@@ -9,6 +10,12 @@ interface CustomObject {
 	affectedDevices?: number[];
 }
 
+// Postgresql uses 16 bits to address the binds of sql commands. We use a number a bit below
+// that limit to chunk the binds, in order to have some extra room for other things like
+// computed terms/permissions.
+// See: https://www.postgresql.org/docs/13/protocol-message-formats.html#:~:text=The%20number%20of%20parameter%20values%20that%20follow
+const MAX_SAFE_SQL_BINDS = 2 ** 16 - 1 - 100;
+
 // Env vars hooks
 const addEnvHooks = (
 	resource: string,
@@ -16,7 +23,11 @@ const addEnvHooks = (
 		args: hooks.HookArgs & {
 			tx: Tx;
 		},
-	) => Promise<Filter | undefined>,
+	) => Promise<
+		| FilterObj
+		| [affectedIds: number[], filterBuilder: (ids: number[]) => FilterObj]
+		| undefined
+	>,
 ): void => {
 	const getAffectedDeviceIds = async (
 		args: hooks.HookArgs & {
@@ -28,14 +39,31 @@ const addEnvHooks = (
 			if (filter == null) {
 				return;
 			}
-			const devices = (await args.api.get({
-				resource: 'device',
-				options: {
-					$select: 'id',
-					$filter: filter,
-				},
-			})) as Array<{ id: number }>;
-			return devices.map(({ id }) => id);
+			const filters = Array.isArray(filter)
+				? (() => {
+						const [affectedIds, filterBuilder] = filter;
+						// Chunk the affected device retrieval, since a using $in errors with `code: '42P01'` for more than 66k IDs.
+						return _.chunk(affectedIds, MAX_SAFE_SQL_BINDS).map((ids) =>
+							filterBuilder(ids),
+						);
+				  })()
+				: [filter];
+			const deviceIds = (
+				await Promise.all(
+					filters.map(async ($filter) =>
+						(
+							(await args.api.get({
+								resource: 'device',
+								options: {
+									$select: 'id',
+									$filter,
+								},
+							})) as Array<{ id: number }>
+						).map(({ id }) => id),
+					),
+				)
+			).flat();
+			return deviceIds;
 		} catch (err) {
 			captureException(err, `Error building the ${resource} filter`, {
 				req: args.req,
@@ -101,23 +129,26 @@ const addAppEnvHooks = (resource: string) =>
 				return;
 			}
 
-			return {
-				belongs_to__application: {
-					$any: {
-						$alias: 'a',
-						$expr: {
-							a: {
-								[resource]: {
-									$any: {
-										$alias: 'e',
-										$expr: { e: { id: { $in: envVarIds } } },
+			return [
+				envVarIds,
+				(envVarIdsChunk) => ({
+					belongs_to__application: {
+						$any: {
+							$alias: 'a',
+							$expr: {
+								a: {
+									[resource]: {
+										$any: {
+											$alias: 'e',
+											$expr: { e: { id: { $in: envVarIdsChunk } } },
+										},
 									},
 								},
 							},
 						},
 					},
-				},
-			};
+				}),
+			];
 		},
 	);
 
@@ -141,16 +172,19 @@ const addDeviceEnvHooks = (resource: string) =>
 			if (envVarIds.length === 0) {
 				return;
 			}
-			return {
-				[resource]: {
-					$any: {
-						$alias: 'e',
-						$expr: {
-							e: { id: { $in: envVarIds } },
+			return [
+				envVarIds,
+				(envVarIdsChunk) => ({
+					[resource]: {
+						$any: {
+							$alias: 'e',
+							$expr: {
+								e: { id: { $in: envVarIdsChunk } },
+							},
 						},
 					},
-				},
-			};
+				}),
+			];
 		},
 	);
 
@@ -188,22 +222,25 @@ addEnvHooks(
 		if (envVarIds.length === 0) {
 			return;
 		}
-		return {
-			service_install: {
-				$any: {
-					$alias: 'si',
-					$expr: {
-						si: {
-							service: {
-								$any: {
-									$alias: 's',
-									$expr: {
-										s: {
-											service_environment_variable: {
-												$any: {
-													$alias: 'e',
-													$expr: {
-														e: { id: { $in: envVarIds } },
+		return [
+			envVarIds,
+			(envVarIdsChunk) => ({
+				service_install: {
+					$any: {
+						$alias: 'si',
+						$expr: {
+							si: {
+								service: {
+									$any: {
+										$alias: 's',
+										$expr: {
+											s: {
+												service_environment_variable: {
+													$any: {
+														$alias: 'e',
+														$expr: {
+															e: { id: { $in: envVarIdsChunk } },
+														},
 													},
 												},
 											},
@@ -214,8 +251,8 @@ addEnvHooks(
 						},
 					},
 				},
-			},
-		};
+			}),
+		];
 	},
 );
 
@@ -241,23 +278,26 @@ addEnvHooks(
 		if (envVarIds.length === 0) {
 			return;
 		}
-		return {
-			service_install: {
-				$any: {
-					$alias: 's',
-					$expr: {
-						s: {
-							device_service_environment_variable: {
-								$any: {
-									$alias: 'e',
-									$expr: { e: { id: { $in: envVarIds } } },
+		return [
+			envVarIds,
+			(envVarIdsChunk) => ({
+				service_install: {
+					$any: {
+						$alias: 's',
+						$expr: {
+							s: {
+								device_service_environment_variable: {
+									$any: {
+										$alias: 'e',
+										$expr: { e: { id: { $in: envVarIdsChunk } } },
+									},
 								},
 							},
 						},
 					},
 				},
-			},
-		};
+			}),
+		];
 	},
 );
 
@@ -299,25 +339,28 @@ addEnvHooks(
 		if (envVarIds.length === 0) {
 			return;
 		}
-		return {
-			image_install: {
-				$any: {
-					$alias: 'ii',
-					$expr: {
-						installs__image: {
-							$any: {
-								$alias: 'i',
-								$expr: {
-									i: {
-										release_image: {
-											$any: {
-												$alias: 'ri',
-												$expr: {
-													ri: {
-														image_environment_variable: {
-															$any: {
-																$alias: 'e',
-																$expr: { e: { id: { $in: envVarIds } } },
+		return [
+			envVarIds,
+			(envVarIdsChunk) => ({
+				image_install: {
+					$any: {
+						$alias: 'ii',
+						$expr: {
+							installs__image: {
+								$any: {
+									$alias: 'i',
+									$expr: {
+										i: {
+											release_image: {
+												$any: {
+													$alias: 'ri',
+													$expr: {
+														ri: {
+															image_environment_variable: {
+																$any: {
+																	$alias: 'e',
+																	$expr: { e: { id: { $in: envVarIdsChunk } } },
+																},
 															},
 														},
 													},
@@ -330,7 +373,7 @@ addEnvHooks(
 						},
 					},
 				},
-			},
-		};
+			}),
+		];
 	},
 );

--- a/test/20_supervisor_notification.ts
+++ b/test/20_supervisor_notification.ts
@@ -1,0 +1,178 @@
+import * as _ from 'lodash';
+import { expect } from './test-lib/chai';
+import { connectDeviceAndWaitForUpdate } from './test-lib/connect-device-and-wait';
+import * as fakeDevice from './test-lib/fake-device';
+import { UserObjectParam } from './test-lib/supertest';
+import { version } from './test-lib/versions';
+import { pineTest } from './test-lib/pinetest';
+import * as fixtures from './test-lib/fixtures';
+import { Application } from '../src/balena-model';
+import { sbvrUtils } from '@balena/pinejs';
+
+describe(`Supervisor notification`, () => {
+	let fx: fixtures.Fixtures;
+	let admin: UserObjectParam;
+	let pineUser: typeof pineTest;
+	let app1: Application;
+	let device: fakeDevice.Device;
+
+	before(async () => {
+		fx = await fixtures.load('20-supervisor-notification');
+
+		admin = fx.users.admin;
+		app1 = fx.applications.app1;
+		pineUser = pineTest.clone({
+			passthrough: { user: admin },
+		});
+
+		// create a new device in this test application...
+		device = await fakeDevice.provisionDevice(
+			admin,
+			app1.id,
+			'balenaOS 2.42.0+rev1',
+			'9.11.1',
+		);
+	});
+
+	after(async () => {
+		await fixtures.clean(fx);
+	});
+
+	[
+		{
+			resource: 'application_environment_variable',
+			getNaturalKey: () => ({
+				application: app1.id,
+				name: 'testAppVar',
+			}),
+		},
+		{
+			resource: 'device_environment_variable',
+			getNaturalKey: () => ({
+				device: device.id,
+				name: 'testDeviceVar',
+			}),
+		},
+	].forEach(({ resource, getNaturalKey }) => {
+		it(`should notify the supervisor after adding a ${resource}`, async function () {
+			await connectDeviceAndWaitForUpdate(device.uuid, version, async () => {
+				await pineUser
+					.post({
+						resource,
+						body: {
+							...getNaturalKey(),
+							value: 'valueFromPOST',
+						},
+					})
+					.expect(201);
+			});
+		});
+
+		it(`should notify the supervisor after modifying a ${resource}`, async function () {
+			await connectDeviceAndWaitForUpdate(device.uuid, version, async () => {
+				await pineUser
+					.patch({
+						resource,
+						id: getNaturalKey(),
+						body: {
+							value: 'valueFromPATCH',
+						},
+					})
+					.expect(200);
+			});
+		});
+
+		it(`should notify the supervisor deleting modifying a ${resource}`, async function () {
+			await connectDeviceAndWaitForUpdate(device.uuid, version, async () => {
+				await pineUser
+					.delete({
+						resource,
+						id: getNaturalKey(),
+					})
+					.expect(200);
+			});
+		});
+	});
+
+	describe('given a big number of vars', function () {
+		// See: https://www.postgresql.org/docs/13/protocol-message-formats.html#:~:text=The%20number%20of%20parameter%20values%20that%20follow
+		const MAX_SAFE_SQL_BINDS = Math.pow(2, 16) - 1;
+		const testVarsCount = MAX_SAFE_SQL_BINDS + 1;
+
+		before(async function () {
+			// Doing this with SQL, since otherwise simple pine requests would take very long.
+			await sbvrUtils.db.executeSql(`
+				INSERT INTO "device environment variable" ("device", "name", "value")
+				SELECT ${device.id}, 'testDeviceVar_' || i, 'testValue'
+				FROM GENERATE_SERIES(1,${testVarsCount}) i;
+			`);
+
+			const { body: varsCount } = await pineUser
+				.get({
+					resource: 'device_environment_variable',
+					options: {
+						$count: {
+							$filter: {
+								device: device.id,
+							},
+						},
+					},
+				})
+				.expect(200);
+			expect(varsCount).to.equal(testVarsCount);
+		});
+
+		after(async function () {
+			// Manually deleted b/c the fixtures.clean() atm fails to delete them w/ a `code: '08P01'`.
+			await sbvrUtils.db.executeSql(`
+				DELETE FROM "device environment variable"
+				WHERE "device" = ${device.id} AND "name" LIKE 'testDeviceVar_%'
+			`);
+		});
+
+		// Just to confirm that the MAX_SAFE_SQL_BINDS limitation is still valid
+		it('should fail when providing more parameters to $in than PG support', async function () {
+			await pineUser
+				.delete({
+					resource: 'device_environment_variable',
+					options: {
+						$filter: {
+							device: device.id,
+							name: {
+								$in: _.times(testVarsCount).map((i) => `testDeviceVar_${i}`),
+							},
+						},
+					},
+				})
+				.expect(431);
+		});
+
+		it(`should notify the supervisor after deleting ${testVarsCount} device_environment_variables`, async function () {
+			await connectDeviceAndWaitForUpdate(device.uuid, version, async () => {
+				await pineUser
+					.delete({
+						resource: 'device_environment_variable',
+						options: {
+							$filter: {
+								device: device.id,
+							},
+						},
+					})
+					.expect(200);
+			});
+			const { body: varsCount } = await pineUser
+				.get({
+					resource: 'device_environment_variable',
+					options: {
+						$count: {
+							$filter: {
+								device: device.id,
+							},
+						},
+					},
+				})
+				.expect(200);
+			expect(varsCount).to.equal(0);
+		});
+	});
+});

--- a/test/fixtures/20-supervisor-notification/applications.json
+++ b/test/fixtures/20-supervisor-notification/applications.json
@@ -1,0 +1,18 @@
+{
+	"app1": {
+		"user": "admin",
+		"device_type": "intel-nuc",
+		"app_name": "test-app-1"
+	},
+	"app2": {
+		"user": "admin",
+		"device_type": "raspberrypi3",
+		"app_name": "test-app-2"
+	},
+	"supervisorApp": {
+		"user": "admin",
+		"device_type": "raspberrypi3",
+		"app_name": "supervisor-raspberrypi3",
+		"is_public": true
+	}
+}

--- a/test/fixtures/20-supervisor-notification/images.json
+++ b/test/fixtures/20-supervisor-notification/images.json
@@ -1,0 +1,20 @@
+{
+	"release1_image1": {
+		"user": "admin",
+		"service": "app1_service1",
+		"releases": [ "release1" ],
+		"image_size": 2048,
+		"project_type": "Dockerfile.template",
+		"build_log": "This is also the build log",
+		"status": "success"
+	},
+	"release1_image2": {
+		"user": "admin",
+		"service": "app1_service2",
+		"releases": [ "release1" ],
+		"image_size": 2048,
+		"project_type": "Dockerfile.template",
+		"build_log": "This is also the build log",
+		"status": "success"
+	}
+}

--- a/test/fixtures/20-supervisor-notification/releases.json
+++ b/test/fixtures/20-supervisor-notification/releases.json
@@ -1,0 +1,27 @@
+{
+	"release1": {
+		"user": "admin",
+		"application": "app1",
+		"commit": "deadc0de",
+		"status": "success",
+		"composition": {
+			"services": {
+				"image1": {
+					"build": "./image1/"
+				},
+				"image2": {
+					"build": "./image2/"
+				}
+			}
+		},
+		"source": "cloud"
+	},
+	"release2": {
+		"user": "admin",
+		"application": "app1",
+		"commit": "deadc0d3",
+		"status": "success",
+		"composition": {},
+		"source": "cloud"
+	}
+}

--- a/test/fixtures/20-supervisor-notification/services.json
+++ b/test/fixtures/20-supervisor-notification/services.json
@@ -1,0 +1,12 @@
+{
+	"app1_service1": {
+		"user": "admin",
+		"application": "app1",
+		"service_name": "app1_service1"
+	},
+	"app1_service2": {
+		"user": "admin",
+		"application": "app1",
+		"service_name": "app1_service2"
+	}
+}

--- a/test/test-lib/connect-device-and-wait.ts
+++ b/test/test-lib/connect-device-and-wait.ts
@@ -19,6 +19,7 @@ const registerService = async (version: string) => {
 export const connectDeviceAndWaitForUpdate = async (
 	uuid: string,
 	version: string,
+	/** An action that should trigger a device update. */
 	promiseFn: () => PromiseLike<any>,
 ) => {
 	let updateRequested = false;


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-io/balena-api/issues/3742
See: https://sentry.io/organizations/balena/issues/3475598791/
See: https://www.flowdock.com/app/rulemotion/public-s-community/threads/GrL4sR7imv_sfdTqZsgu80lMvpg
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>