### PR TITLE
Remove misleading date header removal for supervisor requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -328,9 +328,6 @@ export async function setup(app: Application, options: SetupOptions) {
 			// itself as "Supervisor/X.X.X (Linux; Resin OS X.X.X; prod)" and the
 			// cron-updater uses curl, all of which ignore CORS and other browser related
 			// headers, so we can drop them to save bandwidth.
-
-			// We can also remove the date header as unnecessary
-			res.removeHeader('Date');
 			return next();
 		}
 		res.set('X-Frame-Options', 'DENY');


### PR DESCRIPTION
Since the date header is automatically added when you set the status
you need to remove it after the fact (or disable nodejs adding it
altogether) so it was not having any effect here other than adding
confusion

Change-type: patch