### PR TITLE
Remove unused `max` option from the global multi-level-store typings

### DIFF
--- a/src/infra/cache/multi-level-store.ts
+++ b/src/infra/cache/multi-level-store.ts
@@ -24,7 +24,10 @@ export function createMultiLevelStore<T extends Defined>(
 		| {
 				default: MultiStoreOpt & cacheManager.CacheOptions;
 				local?: MultiStoreOpt | false;
-				global?: MultiStoreOpt;
+				/**
+				 * The global store will ignore the `max` anyway, so avoiding passing it in will help reduce confusion
+				 */
+				global?: Exclude<MultiStoreOpt, 'max'>;
 		  },
 	useVersion = true,
 ): {


### PR DESCRIPTION
Change-type: patch