### PR TITLE
Correct gpio example env var

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -198,7 +198,7 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 				description:
 					'Allows GPIO pins to be set to specific modes and values at boot time.',
 				will_reboot: true,
-				examples: ['"gpio=19=op,dh","gpio=0-25=a2"'],
+				examples: ['"19=op,dh","0-25=a2"'],
 			},
 			BALENA_HOST_CONFIG_hdmi_cvt: {
 				type: 'string',


### PR DESCRIPTION
Corrected from `"gpio=19=op,dh","gpio=0-25=a2"` which will result in
`gpio=gpio=...` in config.txt being applied by the Supervisor.

If `"gpio=19=op,dh","gpio=0-25=a2"` is set via the dashboard as in the old example, the `config.txt` value will formatted by the Supervisor as `gpio=gpio=19=op` which is invalid.

Change-type: patch
Signed-off-by: Christina Wang <christina@balena.io>