### PR TITLE
vars-schema: Add custom DTB support for imx8mm-var-som

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -287,6 +287,7 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 				'photon-tx2-nx',
 			],
 			'14.0.8': ['imx8m-var-dart', 'imx8mm-var-dart'],
+			'14.0.16': ['imx8mm-var-som'],
 		},
 		{
 			RESIN_HOST_EXTLINUX_fdt: {


### PR DESCRIPTION
Adds custom device-tree support for the upcoming iMX8MM VAR SOM Devkit

Connects-to: https://github.com/balena-os/balena-supervisor/pull/2002
Change-type: minor
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Marked as draft until we know the SV version that includes support.