### PR TITLE
Update pinejs version for async migrator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@balena/env-parsing": "^1.1.0",
         "@balena/es-version": "^1.0.1",
         "@balena/node-metrics-gatherer": "^6.0.3",
-        "@balena/pinejs": "^14.49.2",
+        "@balena/pinejs": "^14.50.0",
         "@sentry/node": "^7.12.1",
         "@types/basic-auth": "^1.1.3",
         "@types/bluebird": "^3.5.36",
@@ -425,9 +425,9 @@
       }
     },
     "node_modules/@balena/pinejs": {
-      "version": "14.49.2",
-      "resolved": "https://registry.npmjs.org/@balena/pinejs/-/pinejs-14.49.2.tgz",
-      "integrity": "sha512-drkeKOXVmBgt+tPrt5GlyXnLJ8COfNo0z/u0+iKdDrorxiCTIgpA1YyVPinmXQoK2a3Ck6SawBXN5w91W3yqjA==",
+      "version": "14.50.0",
+      "resolved": "https://registry.npmjs.org/@balena/pinejs/-/pinejs-14.50.0.tgz",
+      "integrity": "sha512-4aU2xSrvCeBD1crCST5bouCm7smUweiFqtRhX/pnURR6pInCsxsuSCcrmJ/oGV3O7iDftqLLcQdMO8KLO8pibQ==",
       "dependencies": {
         "@balena/abstract-sql-compiler": "^7.20.0",
         "@balena/abstract-sql-to-typescript": "^1.2.0",
@@ -9070,9 +9070,9 @@
       }
     },
     "@balena/pinejs": {
-      "version": "14.49.2",
-      "resolved": "https://registry.npmjs.org/@balena/pinejs/-/pinejs-14.49.2.tgz",
-      "integrity": "sha512-drkeKOXVmBgt+tPrt5GlyXnLJ8COfNo0z/u0+iKdDrorxiCTIgpA1YyVPinmXQoK2a3Ck6SawBXN5w91W3yqjA==",
+      "version": "14.50.0",
+      "resolved": "https://registry.npmjs.org/@balena/pinejs/-/pinejs-14.50.0.tgz",
+      "integrity": "sha512-4aU2xSrvCeBD1crCST5bouCm7smUweiFqtRhX/pnURR6pInCsxsuSCcrmJ/oGV3O7iDftqLLcQdMO8KLO8pibQ==",
       "requires": {
         "@balena/abstract-sql-compiler": "^7.20.0",
         "@balena/abstract-sql-to-typescript": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@balena/env-parsing": "^1.1.0",
     "@balena/es-version": "^1.0.1",
     "@balena/node-metrics-gatherer": "^6.0.3",
-    "@balena/pinejs": "^14.49.2",
+    "@balena/pinejs": "^14.50.0",
     "@sentry/node": "^7.12.1",
     "@types/basic-auth": "^1.1.3",
     "@types/bluebird": "^3.5.36",


### PR DESCRIPTION
Update @balena/pinejs from 14.49.2 to 14.50.0

Change-type: minor
Signed-off-by: Harald Fischer <harald@balena.io>