### PR TITLE
Prevent unauthenticated requests from proceeding in token auth

### DIFF
--- a/src/features/registry/middleware.ts
+++ b/src/features/registry/middleware.ts
@@ -1,13 +1,21 @@
 import * as BasicAuth from 'basic-auth';
 import type { RequestHandler } from 'express';
 
+import { errors } from '@balena/pinejs';
+
 import { retrieveAPIKey } from '../../infra/auth/api-keys';
 
+import { TOKEN_AUTH_BUILDER_TOKEN } from '../../lib/config';
+
+export class NoAuthProvidedError extends errors.UnauthorizedError {}
+
+export class InvalidAuthProvidedError extends errors.UnauthorizedError {}
+
 // Resolves permissions and populates req.user object, in case an api key is used
-// in the password field of a basic authentication header
+// in the password field of a basic authentication header. Also works with JWTs.
 export const basicApiKeyAuthenticate: RequestHandler = async (
 	req,
-	_res,
+	res,
 	next,
 ) => {
 	const creds = BasicAuth.parse(req.headers['authorization']!);
@@ -17,8 +25,44 @@ export const basicApiKeyAuthenticate: RequestHandler = async (
 	}
 	try {
 		await retrieveAPIKey(req, undefined);
+
+		// Check whether the request was auth'd successfully and if not, see if some form
+		// of credentials was provided and prevent requests with *invalid* credentials from
+		// proceeding.
+		//
+		// Unfortunately, Pine has no way to let us determine auth failure was due to
+		// invalid credentials or due to no credentials provided, so we need to jump over
+		// some hoops here.
+		//
+		// In addition, there's ugly legacy that treats the builder's token as special,
+		// granting it access to images unconditionally, bypassing permissions, so it causes
+		// the check for permissions below to succeed and the request to fail with 401.
+		if (
+			(req.apiKey?.permissions == null ||
+				req.apiKey.permissions.length === 0) &&
+			req.apiKey?.key !== TOKEN_AUTH_BUILDER_TOKEN &&
+			req.user == null
+		) {
+			if (
+				req.headers['authorization'] ||
+				req.params['apikey'] ||
+				req.body['apikey'] ||
+				req.query['apikey']
+			) {
+				throw new InvalidAuthProvidedError();
+			} else {
+				throw new NoAuthProvidedError();
+			}
+		}
+
 		next();
 	} catch (err) {
-		next(err);
+		if (err instanceof NoAuthProvidedError) {
+			next();
+		} else if (err instanceof InvalidAuthProvidedError) {
+			res.status(401).end();
+		} else {
+			next(err);
+		}
 	}
 };


### PR DESCRIPTION
Authentication failure due to "no credentials provided" and due to "invalid credentials provided" are currently treated in exactly the same way: we just let the request proceed and rely on (no) permissions to limit access to resources. This is problematic (it can result in redundant work being done in the API) and misleading ("I've provided creds but I get back no results").

This change separates the latter case and responds immediately with 401, as it should.

This is however a workaround and ideally it would be Pine that makes this distinction and throws an exception appropriately but this would be a breaking change to existing code.

Chat thread: https://jel.ly.fish/thread-79f9d489-8af5-42dd-b45f-84cef2d379a9

Change-type: patch