### PR TITLE
fasttest: Stop syncing node_modules/grpc to fix conflicting lib errors

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -102,6 +102,8 @@ services:
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup
         - ./node_modules:/usr/src/app/node_modules
+        # Exclude syncing grpc from the host to avoid issues when built w/ different library versions
+        - /usr/src/app/node_modules/grpc
         - ./package.json:/usr/src/app/package.json
         - ./package-lock.json:/usr/src/app/package-lock.json
         - ./src:/usr/src/app/src


### PR DESCRIPTION
Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/open-balena-api.20node18.20fasttest
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>