### PR TITLE
state-get-v2/v3: Do not count expired api key requests as heartbeats

### DIFF
--- a/src/features/device-state/routes/state-get-v2.ts
+++ b/src/features/device-state/routes/state-get-v2.ts
@@ -314,6 +314,8 @@ const stateQuery = _.once(() =>
 
 const getStateV2 = async (req: Request, uuid: string): Promise<StateV2> => {
 	const device = await getDevice(req, uuid);
+	// At this point we are sure that the api key is valid and not expired.
+	events.emit('get-state', uuid, { apiKey: req.apiKey });
 	const config = getConfig(device);
 
 	const userApp = getUserAppForState(device, config);
@@ -339,9 +341,6 @@ export const stateV2: RequestHandler = async (req, res) => {
 	if (!uuid) {
 		return res.status(400).end();
 	}
-
-	const { apiKey } = req;
-	events.emit('get-state', uuid, { apiKey });
 
 	try {
 		res.json(await getStateV2(req, uuid));

--- a/src/features/device-state/routes/state-get-v3.ts
+++ b/src/features/device-state/routes/state-get-v3.ts
@@ -283,6 +283,8 @@ const stateQuery = _.once(() =>
 
 const getStateV3 = async (req: Request, uuid: string): Promise<StateV3> => {
 	const device = await getDevice(req, uuid);
+	// At this point we are sure that the api key is valid and not expired.
+	events.emit('get-state', uuid, { apiKey: req.apiKey });
 	const config = getConfig(device);
 
 	let apps = getUserAppState(device, config);
@@ -317,9 +319,6 @@ export const stateV3: RequestHandler = async (req, res) => {
 	if (!uuid) {
 		return res.status(400).end();
 	}
-
-	const { apiKey } = req;
-	events.emit('get-state', uuid, { apiKey });
 
 	try {
 		const state = await getStateV3(req, uuid);


### PR DESCRIPTION
Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/346009-aspect.2Fcustomer-success/topic/Nebra.20bills