### PR TITLE
Make public apps & releases accessible by guests

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -8,11 +8,20 @@ export = {
 			username: 'guest',
 			password: ' ',
 			permissions: [
+				// core model permissions
+				'resin.cpu_architecture.read',
 				'resin.device_type.read',
 				'resin.device_type_alias.read',
-				'resin.cpu_architecture.read',
 				'resin.device_family.read',
 				'resin.device_manufacturer.read',
+				// public application & hostApp permissions
+				'resin.application.read?is_public eq true and is_for__device_type/canAccess()',
+				'resin.release.read?belongs_to__application/any(a:a/is_public eq true and is_for__device_type/canAccess())',
+				'resin.service.read?application/any(a:a/is_public eq true and is_for__device_type/canAccess())',
+				`resin.image.read?is_a_build_of__service/any(s:s/application/any(a:a/is_public eq true and is_for__device_type/canAccess()))`,
+				'resin.application_tag.read?application/any(a:a/is_public eq true and is_for__device_type/canAccess())',
+				'resin.release_tag.read?release/any(r:r/belongs_to__application/any(a:a/is_public eq true and is_for__device_type/canAccess()))',
+				`resin.image__is_part_of__release.read?is_part_of__release/any(r:r/belongs_to__application/any(a:a/is_public eq true and is_for__device_type/canAccess()))`,
 			],
 		},
 	],

--- a/test/02_device-types.ts
+++ b/test/02_device-types.ts
@@ -90,7 +90,7 @@ describe('device type resource', () => {
 			expect(deviceType).to.have.property('name').that.is.a('string');
 		});
 
-		expect(res.body.d).to.have.property('length', 13);
+		expect(res.body.d).to.have.property('length', 14);
 	});
 });
 

--- a/test/09_contracts.ts
+++ b/test/09_contracts.ts
@@ -79,7 +79,7 @@ describe('contracts', () => {
 			await fetchContractsLocally([contractRepository]);
 			const contracts = await getContracts('hw.device-type');
 
-			expect(contracts).to.have.length(13);
+			expect(contracts).to.have.length(14);
 			expect(contracts.find((contract) => contract.slug === 'raspberrypi3')).to
 				.not.be.undefined;
 		});
@@ -97,7 +97,7 @@ describe('contracts', () => {
 			]);
 			const contracts = await getContracts('hw.device-type');
 
-			expect(contracts).to.have.length(14);
+			expect(contracts).to.have.length(15);
 			expect(
 				contracts.find((contract) => contract.slug === 'other-contract-dt'),
 			).to.not.be.undefined;
@@ -164,7 +164,7 @@ describe('contracts', () => {
 				(dbDeviceType) => dbDeviceType.slug === 'fincm3',
 			);
 
-			expect(contracts).to.have.length(14);
+			expect(contracts).to.have.length(15);
 			expect(newDt).to.not.be.undefined;
 			expect(finDt).to.have.property('name', 'Fin');
 		});
@@ -233,7 +233,7 @@ describe('contracts', () => {
 				(dbDeviceType) => dbDeviceType.slug === 'raspberry-pi',
 			);
 
-			expect(dbDeviceTypes).to.have.length(14);
+			expect(dbDeviceTypes).to.have.length(15);
 			expect(newDt).to.not.be.undefined;
 			expect(finDt).to.have.property('name', 'Fin');
 			expect(finDt).to.have.deep.property(

--- a/test/fixtures/16-supervisor-app/applications.json
+++ b/test/fixtures/16-supervisor-app/applications.json
@@ -21,7 +21,7 @@
 	},
 	"amd64_supervisor_app": {
 		"user": "admin",
-		"device_type": "intel-nuc",
+		"device_type": "genericx86-64-ext",
 		"is_public": true,
 		"app_name": "amd64-supervisor",
 		"organization": "balena_os"

--- a/test/fixtures/contracts/base-contracts/contracts/hw.device-type/genericx86-64-ext/contract.json
+++ b/test/fixtures/contracts/base-contracts/contracts/hw.device-type/genericx86-64-ext/contract.json
@@ -1,0 +1,29 @@
+{
+  "slug": "genericx86-64-ext",
+  "version": "1",
+  "type": "hw.device-type",
+  "aliases": [],
+  "name": "Generic x86_64",
+  "assets": {
+    "logo": {
+      "url": "./genericx86-64-ext.svg",
+      "name": "logo"
+    }
+  },
+  "data": {
+    "arch": "amd64",
+    "hdmi": true,
+    "led": false,
+    "connectivity": {
+      "bluetooth": false,
+      "wifi": false
+    },
+    "storage": {
+      "internal": true
+    },
+    "media": {
+      "installation": "usbkey"
+    },
+    "is_private": false
+  }
+}

--- a/test/fixtures/contracts/base-contracts/contracts/hw.device-type/genericx86-64-ext/genericx86-64-ext.svg
+++ b/test/fixtures/contracts/base-contracts/contracts/hw.device-type/genericx86-64-ext/genericx86-64-ext.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2328"
+   sodipodi:docname="genericx86-64-ext.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:version="0.32"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   x="0px"
+   y="0px"
+   width="616px"
+   height="641px"
+   viewBox="-164 -203.5 616 641"
+   enable-background="new -164 -203.5 616 641"
+   xml:space="preserve"><metadata
+   id="metadata19"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs17" />
+<sodipodi:namedview
+   inkscape:cy="249.93763"
+   inkscape:cx="219.80302"
+   inkscape:zoom="1.0154639"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   gridtolerance="10.0"
+   guidetolerance="10.0"
+   objecttolerance="10.0"
+   id="base"
+   inkscape:current-layer="svg2328"
+   inkscape:window-y="0"
+   inkscape:window-x="0"
+   inkscape:pageopacity="0.0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1280"
+   inkscape:window-height="995"
+   showgrid="false"
+   inkscape:window-maximized="1">
+	</sodipodi:namedview>
+<g
+   id="g12">
+	<path
+   id="path6"
+   fill="#127CC1"
+   d="M444.329-86.082c-28.613-139.479-298.504-148.313-472.478-42.048v11.736   c173.745-89.683,420.28-89.11,442.716,39.371c7.558,42.564-16.252,86.831-58.943,112.303v33.332   C407.015,49.758,459.548-11.271,444.329-86.082 M127.971,158.123C7.907,169.237-117.193,151.746-134.707,57.557   c-8.698-46.378,12.475-95.604,40.405-126.146V-84.94c-50.361,44.328-77.717,100.398-61.922,166.598   c20.144,84.958,127.503,133.047,291.406,117.034c64.897-6.266,149.825-27.233,208.765-59.763V92.713   C290.384,124.792,201.793,151.294,127.971,158.123z" />
+	<path
+   id="path8"
+   fill="#127CC1"
+   d="M334.331-106.246h-31.473V34.559c0,16.538,7.897,30.918,31.473,33.199" />
+	<path
+   id="path10"
+   fill="#127CC1"
+   d="M-40.624-54.788h-31.476v91.966c0,16.542,7.898,30.922,31.476,33.202" />
+	<rect
+   id="rect12"
+   x="-72.099"
+   y="-101.967"
+   fill="#127CC1"
+   width="31.476"
+   height="29.954" />
+	<path
+   id="path14"
+   fill="#127CC1"
+   d="M147.997,68.9c-25.52,0-36.279-17.803-36.279-35.374V-88.617h31.131v33.829h23.576v25.33   h-23.576v61.1c0,7.187,3.436,11.128,10.871,11.128h12.705V68.9H147.997" />
+	<path
+   id="path16"
+   fill="#127CC1"
+   d="M230.751-30.995c-10.643,0-18.883,5.533-22.317,13.007c-2.061,4.505-2.747,7.929-3.086,13.467   h48.184C252.845-18.045,246.773-30.995,230.751-30.995 M205.348,16.812c0,16.033,10.065,27.836,27.692,27.836   c13.851,0,20.719-3.878,28.73-11.8l19.23,18.539c-12.362,12.205-25.296,19.622-48.187,19.622   c-29.872,0-58.487-16.371-58.487-64.067c0-40.79,24.949-63.836,57.8-63.836c33.306,0,52.419,26.984,52.419,62.413v11.296h-79.198" />
+	<path
+   id="path18"
+   fill="#127CC1"
+   d="M44.189-29.458c9.155,0,12.933,4.509,12.933,11.867V69.07H88.37v-86.774   c0-17.628-9.386-37.084-36.74-37.084h-64.438V69.068h31.131v-98.526" />
+	<text
+   transform="matrix(1.0217,0,0,1,352.1602,-85.6602)"
+   font-size="28.8313"
+   id="text10"
+   style="font-size:28.83130074px;line-height:0%;font-family:ArialMT;fill:#127cc1">®</text>
+
+</g>
+
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#127cc1;fill-opacity:1;stroke:none"
+   x="-140.36548"
+   y="360.68784"
+   id="text3726"><tspan
+     sodipodi:role="line"
+     id="tspan3724"
+     x="-140.36548"
+     y="360.68784"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:160px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#127cc1;fill-opacity:1">x86-64</tspan></text>
+</svg>


### PR DESCRIPTION
This also fixes devices not being able to create
service installs for their supervisor when the
supervisor app's DT doesn't match the
device's.

Discussed as an ad-hoc item in the 2022-12-01 arch call.
See: https://balena.zulipchat.com/#narrow/stream/345748-aspect.2Farchitecture/topic/architecture.20brainstorms

Change-type: patch