### PR TITLE
Fix device requests to gateway_download failing with 401

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -113,6 +113,9 @@ export const DEVICE_API_KEY_PERMISSIONS = [
 
 	'resin.image_environment_variable.read?release_image/canAccess()',
 
+	// So that requests do not get rejected with 401 but still do not have any effect.
+	`resin.gateway_download.all?1 eq 0`,
+
 	`resin.device.write-log?${matchesActor}`,
 ];
 


### PR DESCRIPTION
Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/345889-loop.2Fbalena-os/topic/Python.20SDK.20doesn't.20work.20with.20device.20API.20key