### PR TITLE
Disable changing device name via the state PATCH

### DIFF
--- a/src/features/device-state/routes/state-patch-v3.ts
+++ b/src/features/device-state/routes/state-patch-v3.ts
@@ -274,7 +274,6 @@ export const statePatchV3: RequestHandler = async (req, res) => {
 
 			let deviceBody:
 				| Pick<StatePatchV3Body[string], typeof v3ValidPatchFields[number]> & {
-						device_name?: string;
 						is_running__release?: number | null;
 				  } = _.pick(state, v3ValidPatchFields);
 			let metricsBody: Pick<
@@ -289,10 +288,6 @@ export const statePatchV3: RequestHandler = async (req, res) => {
 				// that we don't try to merge it again later
 				deviceBody = { ...deviceBody, ...metricsBody };
 				metricsBody = {};
-			}
-
-			if (state.name != null) {
-				deviceBody.device_name = state.name;
 			}
 
 			if (apps != null || Object.keys(deviceBody).length > 0) {

--- a/test/03_device-state.ts
+++ b/test/03_device-state.ts
@@ -558,14 +558,14 @@ mockery.registerMock('../src/lib/config', configMock);
 				stateVersion,
 			);
 
-			await expectResourceToMatch(
-				pineUser,
-				'device',
-				device.id,
-				_.mapKeys(devicePatchBody[stateKey], (_v, key) =>
-					key === 'name' ? 'device_name' : key,
-				),
-			);
+			const expectedData =
+				stateVersion === 'v2'
+					? _.mapKeys(devicePatchBody[stateKey], (_v, key) =>
+							key === 'name' ? 'device_name' : key,
+					  )
+					: _.pickBy(devicePatchBody[stateKey], (_v, key) => key !== 'name');
+
+			await expectResourceToMatch(pineUser, 'device', device.id, expectedData);
 		});
 
 		it('should accept addresses longer than 255 chars and truncate at space delimiters', async () => {


### PR DESCRIPTION
While the state endpoint allows patching the device name since v2, that feature hasn't really been used by supervisor until supervisor v13 when that feature was introduced by mistake. Because of a race condition between supervisors v13.0.0 and v14.0.2, the device name may get either an empty value or the value 'local', this can cause confusion in users or affect the user workflows that depend on having distinct device names.

This commit removes the device name from the list of allowed patch variables for the v3 state endpoint.

Change-type: patch