### PR TITLE
Simplify the device host & SV app permissions to rely only on is_public

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -68,7 +68,7 @@ export const DEVICE_API_KEY_PERMISSIONS = [
 	'resin.device_type.read?describes__device/canAccess()',
 	`resin.device.read?${matchesActor}`,
 	`resin.device.update?${matchesActor}`,
-	'resin.application.read?owns__device/canAccess() or ((is_host eq true or is_public eq true) and is_for__device_type/any(dt:dt/describes__device/canAccess()))',
+	'resin.application.read?owns__device/canAccess() or (is_public eq true and is_for__device_type/any(dt:dt/describes__device/canAccess()))',
 	'resin.application_tag.read?application/canAccess()',
 	'resin.device_config_variable.read?device/canAccess()',
 	`resin.device_config_variable.create?device/any(d:d/${matchesActor})`,
@@ -104,7 +104,7 @@ export const DEVICE_API_KEY_PERMISSIONS = [
 	'resin.image.read?image_install/canAccess() or image__is_part_of__release/canAccess()',
 
 	'resin.image_install.read?device/canAccess()',
-	`resin.image_install.create?device/any(d:d/${matchesActor}) and installs__image/any(i:i/image__is_part_of__release/any(ipr:ipr/is_part_of__release/any(r:r/belongs_to__application/any(a:a/${ownsDevice} or a/is_public eq true or a/is_host eq true))))`,
+	`resin.image_install.create?device/any(d:d/${matchesActor}) and installs__image/any(i:i/image__is_part_of__release/any(ipr:ipr/is_part_of__release/any(r:r/belongs_to__application/any(a:a/${ownsDevice} or a/is_public eq true))))`,
 	`resin.image_install.update?device/any(d:d/${matchesActor})`,
 
 	'resin.image_label.read?release_image/canAccess()',


### PR DESCRIPTION
Atm `is_host eq 1 or is_public eq 1 === is_public eq 1`, so the is_host check is redundant.
It seem that the `is_host eq 1` is a leftover since before we added `is_public` and adopted its semantics in host app permissions.

Change-type: patch
See: https://github.com/balena-io/open-balena-api/pull/645