### PR TITLE
Optimize the device should be running release rule

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -858,7 +858,7 @@ Rule: It is necessary that each image that has a status that is equal to "succes
 Rule: It is necessary that each application that is public, has an application type that is not legacy.
 Rule: It is necessary that each application that owns a release1 that has a status that is equal to "success" and has a commit1, owns at most one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.
 Rule: It is necessary that each application that owns a release1 that has a revision, owns at most one release2 that has a semver major that is of the release1 and has a semver minor that is of the release1 and has a semver patch that is of the release1 and has a semver prerelease that is of the release1 and has a variant that is of the release1 and has a revision that is of the release1.
-Rule: It is necessary that each release that should be running on a device, has a status that is equal to "success" and belongs to an application1 that the device belongs to.
+Rule: It is necessary that each device that should be running a release, should be running a release that has a status that is equal to "success" and belongs to an application1 that the device belongs to.
 Rule: It is necessary that each release that should be running on an application, has a status that is equal to "success" and belongs to the application.
 Rule: It is necessary that each application type that does not supports multicontainer, is of no application that owns a release that contains at least 2 images.
 Rule: It is necessary that each release that should operate a device, has a status that is equal to "success".


### PR DESCRIPTION
[From 1.2s](https://explain.dalibo.com/plan/82c78c9f6a2d280f)
[To 293ms](https://explain.dalibo.com/plan/846h39c73a9a828d)

Apparently PG can now (after the COUNT(*) =0 change or after the PG 14 bump) reason that we are joining the `device.should_be_running__release` with the `release.id`s and only does one `FROM release` (since there is no `release2` reference in the execution plan):
```sql
SELECT (
	SELECT COUNT(*)
	FROM "device" AS "device.0",
		"release" AS "release.1"
	WHERE "device.0"."should be running-release" = "release.1"."id"
	AND NOT EXISTS (
		SELECT 1
		FROM "release" AS "release.2",
			"application" AS "application.4"
		WHERE "device.0"."belongs to-application" = "application.4"."id"
		AND "release.2"."belongs to-application" = "application.4"."id"
		AND "release.2"."status" = 'status'
		AND "release.2"."status" IS NOT NULL
		AND "device.0"."should be running-release" = "release.2"."id"
	)
) = 0 AS "result";
```
this was not the case when I originally optimized this rule.

Change-type: patch