### PR TITLE
Use `authenticatedApiKey` middleware for device logs endpoints

### DIFF
--- a/src/features/device-logs/index.ts
+++ b/src/features/device-logs/index.ts
@@ -34,12 +34,12 @@ export const setup = (
 	app.post(
 		'/device/v2/:uuid/logs',
 		deviceLogsRateLimiter('params.uuid'),
-		middleware.resolveApiKey,
+		middleware.authenticatedApiKey,
 		store,
 	);
 	app.post(
 		'/device/v2/:uuid/log-stream',
-		middleware.resolveApiKey,
+		middleware.authenticatedApiKey,
 		storeStream(onLogWriteStreamInitialized),
 	);
 };


### PR DESCRIPTION
Change-type: patch