### PR TITLE
Always apply device configuration filtering

### DIFF
--- a/src/features/device-state/routes/state-get-v2.ts
+++ b/src/features/device-state/routes/state-get-v2.ts
@@ -311,7 +311,7 @@ const getConfig = (device: AnyObject) => {
 
 	// override with device-specific values...
 	varListInsert(device.device_config_variable, config, rejectUiConfig);
-	filterDeviceConfig(config, device.os_version);
+	filterDeviceConfig(config);
 	setDefaultConfigVariables(config);
 
 	return config;

--- a/src/features/device-state/routes/state-get-v3.ts
+++ b/src/features/device-state/routes/state-get-v3.ts
@@ -347,7 +347,7 @@ const getConfig = (device: AnyObject) => {
 
 	// override with device-specific values...
 	varListInsert(device.device_config_variable, config, rejectUiConfig);
-	filterDeviceConfig(config, device.os_version);
+	filterDeviceConfig(config);
 	setDefaultConfigVariables(config);
 
 	return config;

--- a/src/features/device-state/state-get-utils.ts
+++ b/src/features/device-state/state-get-utils.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import * as semver from 'balena-semver';
 import { sbvrUtils, dbModule } from '@balena/pinejs';
 import { DEFAULT_SUPERVISOR_POLL_INTERVAL } from '../../lib/config';
 
@@ -61,17 +60,12 @@ export const formatImageLocation = (imageLocation: string) =>
 // be sent to the device.
 //
 // `configVars` should be in the form { [name: string]: string }
-export const filterDeviceConfig = (
-	configVars: Dictionary<string>,
-	osVersion: string,
-): void => {
+export const filterDeviceConfig = (configVars: Dictionary<string>): void => {
 	// ResinOS >= 2.x has a read-only file system, and this var causes the
 	// supervisor to run `systemctl enable|disable [unit]`, which does not
 	// persist over reboots. This causes the supervisor to go into a reboot
 	// loop, so filter out this var for these os versions.
-	if (semver.gte(osVersion, '2.0.0')) {
-		delete configVars.RESIN_HOST_LOG_TO_DISPLAY;
-	}
+	delete configVars.RESIN_HOST_LOG_TO_DISPLAY;
 };
 
 let $readTransaction: dbModule.Database['readTransaction'] = (


### PR DESCRIPTION
Dropping os.semver >= 2.0.0 filter for testing device configuration. open-balena-api does not support resinOS anymore and for sure only balenaOS 2.x

Checked with:
```
SELECT * from 
(
  -- DEVICE ENVIRONMENT VARIABLES
    SELECT * from "device environment variable" as envtable
    where 
      (envtable.name = 'RESIN_HOST_LOG_TO_DISPLAY')
  UNION
  -- APPLICATION ENVIRONMENT VARIABLES
    SELECT * from "application environment variable" as envtable
    where 
      (envtable.name = 'RESIN_HOST_LOG_TO_DISPLAY')
  UNION 
    -- SERVICE ENVIRONMENT VARIABLES
    SELECT * from "service environment variable" as envtable
    where 
      (envtable.name = 'RESIN_HOST_LOG_TO_DISPLAY')
  UNION 
  -- DEVICE SERVICE ENVIRONMENT VARIABLE
    SELECT * from "device service environment variable" as envtable
    where 
      (envtable.name = 'RESIN_HOST_LOG_TO_DISPLAY')
  UNION
  -- IMAGE ENVIRONMENT VARIABLES
    SELECT * from "image environment variable" as envtable
    where 
      (envtable.name = 'RESIN_HOST_LOG_TO_DISPLAY')
) as test
```
No entries with this ENVVAR name is existing


Change-type: minor
Signed-off-by: Harald Fischer <harald@balena.io>