### PR TITLE
Fix env-var schema for backwards compatibility

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -56,8 +56,8 @@ export const BLOCKED_NAMES = addReservedPrefixes([
 	'HOST_LOG_TO_DISPLAY',
 ]);
 
-const INVALID_ALPHANUMERIC_REGEX = /^\d|\W/;
-export const INVALID_CHARACTER_REGEX = /^[\d:]|[^A-Za-z0-9_:]/;
+export const INVALID_ENV_VAR_REGEX = /^\d|\W/;
+export const INVALID_CONFIG_VAR_REGEX = /^[\d:]|[^A-Za-z0-9_:]/;
 export const INVALID_NEWLINE_REGEX = /\r|\n/;
 
 const getDefinitionWithMinimumSupervisorVersion = (
@@ -383,7 +383,7 @@ const startsWithAny = (ns: string[], name: string) => {
 };
 
 const checkAlphaNumericWithColon = (type: string, name: string) => {
-	if (INVALID_CHARACTER_REGEX.test(name)) {
+	if (INVALID_CONFIG_VAR_REGEX.test(name)) {
 		throw new BadRequestError(
 			`${type} names can only contain alphanumeric characters, underscores or a colon`,
 		);
@@ -405,7 +405,7 @@ const checkVarName = (
 };
 
 const checkAlphaNumeric = (type: string, name: string) => {
-	if (INVALID_ALPHANUMERIC_REGEX.test(name)) {
+	if (INVALID_ENV_VAR_REGEX.test(name)) {
 		throw new BadRequestError(
 			`${type} names can only contain alphanumeric characters and underscores.`,
 		);

--- a/src/features/vars-schema/schema.ts
+++ b/src/features/vars-schema/schema.ts
@@ -4,7 +4,8 @@ import type { JSONSchema6 } from 'json-schema';
 import {
 	BLOCKED_NAMES,
 	DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES,
-	INVALID_CHARACTER_REGEX,
+	INVALID_ENV_VAR_REGEX,
+	INVALID_CONFIG_VAR_REGEX,
 	RESERVED_NAMES,
 	RESERVED_NAMESPACES,
 	SUPERVISOR_CONFIG_VAR_PROPERTIES,
@@ -31,7 +32,8 @@ export const schema: RequestHandler = (req, res) => {
 	const varsConfig = {
 		reservedNames: RESERVED_NAMES,
 		reservedNamespaces: RESERVED_NAMESPACES,
-		invalidRegex: INVALID_CHARACTER_REGEX.toString(),
+		invalidRegex: INVALID_ENV_VAR_REGEX.toString(),
+		configVarInvalidRegex: INVALID_CONFIG_VAR_REGEX.toString(),
 		whiteListedNames: ALLOWED_NAMES,
 		whiteListedNamespaces: ALLOWED_NAMESPACES,
 		blackListedNames: BLOCKED_NAMES,


### PR DESCRIPTION
PR #1199 relaxed the allowed character set for configuration variables, but it also inadvertently relaxed the `/config/vars` JSON schema exported by the API. This would cause that the UI allows the extended character set for env vars, but the API would ultimately reject it, creating an inconsistency. This PR adds a `configVarInvalidRegex` variable to the schema that should be adopted by the UI to render configuration variables.

Change-type: patch