### PR TITLE
Allow public applications be of a legacy application type

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -855,7 +855,6 @@ Fact type: config has description (Auth)
 Rule: It is necessary that each device1 that is managed by a device2, belongs to an application1 that depends on an application2 that owns the device2.
 Rule: It is necessary that each release that has a release version1 and has a status that is equal to "success" and is not invalidated, belongs to an application that owns exactly one release that has a release version2 that is equal to the release version1 and has a status that is equal to "success" and is not invalidated.
 Rule: It is necessary that each image that has a status that is equal to "success", has a push timestamp.
-Rule: It is necessary that each application that is public, has an application type that is not legacy.
 Rule: It is necessary that each application that owns a release1 that has a status that is equal to "success" and has a commit1, owns at most one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.
 Rule: It is necessary that each application that owns a release1 that has a revision, owns at most one release2 that has a semver major that is of the release1 and has a semver minor that is of the release1 and has a semver patch that is of the release1 and has a semver prerelease that is of the release1 and has a variant that is of the release1 and has a revision that is of the release1.
 Rule: It is necessary that each release that should be running on a device, has a status that is equal to "success" and belongs to an application1 that the device belongs to.


### PR DESCRIPTION
Moving the rule to bC to make grandfathering
application types easier.

Change-type: patch