### PR TITLE
Cache the entirety of the device logs write context

### DIFF
--- a/src/features/device-logs/lib/config.ts
+++ b/src/features/device-logs/lib/config.ts
@@ -12,13 +12,13 @@ export const LOKI_ENABLED = LOKI_HOST && LOKI_WRITE_PCT > 0;
 export const shouldPublishToLoki = () =>
 	LOKI_ENABLED && LOKI_WRITE_PCT > Math.random() * 100;
 
-export function addRetentionLimit<T extends LogContext>(
-	ctx: Omit<T, 'retention_limit'>,
-): T {
+export function addRetentionLimit(
+	ctx: Omit<LogContext, 'retention_limit'>,
+): LogContext {
 	return {
 		...ctx,
 		retention_limit: LOGS_DEFAULT_RETENTION_LIMIT,
-	} as T;
+	};
 }
 
 export const getBackend = _.once((): DeviceLogsBackend => new RedisBackend());

--- a/test/06_device-log.ts
+++ b/test/06_device-log.ts
@@ -57,8 +57,7 @@ describe('device log', () => {
 		supertest(ctx.device.apiKey)
 			.post(`/device/v2/${ctx.device2.uuid}/logs`)
 			.send([createLog()])
-			// Yields 404 because fetching device2 by uuid yields nothing
-			.expect(404));
+			.expect(401));
 
 	it('should accept and store batches where some logs have serviceId', () =>
 		supertest(ctx.device.apiKey)


### PR DESCRIPTION
This will have more impact than caching only the permissions checking part.

Change-type: patch