### PR TITLE
Enforce that for a release to be marked "successful" all its images must have been successfully built

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -848,6 +848,7 @@ Fact Type: scheduled job run has status
 
 Rule: It is necessary that each release that has a release version1 and has a status that is equal to "success" and is not invalidated, belongs to an application that owns exactly one release that has a release version2 that is equal to the release version1 and has a status that is equal to "success" and is not invalidated.
 Rule: It is necessary that each image that has a status that is equal to "success", has a push timestamp.
+Rule: It is necessary that each image that is part of a release that has a status that equals "success", has a status that equals "success".
 Rule: It is necessary that each application that owns a release1 that has a status that is equal to "success" and has a commit1, owns at most one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.
 Rule: It is necessary that each application that owns a release1 that has a revision, owns at most one release2 that has a semver major that is of the release1 and has a semver minor that is of the release1 and has a semver patch that is of the release1 and has a semver prerelease that is of the release1 and has a variant that is of the release1 and has a revision that is of the release1.
 Rule: It is necessary that each release that should be running on a device, has a status that is equal to "success" and belongs to an application1 that the device belongs to.

--- a/src/migrations/00082-ensure-successful-releases-have-successful-images.sql
+++ b/src/migrations/00082-ensure-successful-releases-have-successful-images.sql
@@ -1,0 +1,47 @@
+UPDATE "release" SET "status" = 'failed' WHERE "id" IN (
+  SELECT "release.1"."id"
+  FROM "image" AS "image.0",
+    "release" AS "release.1",
+    "image-is part of-release" AS "image.0-is part of-release.1"
+  WHERE 'success' = "release.1"."status"
+  AND "release.1"."status" IS NOT NULL
+  AND "image.0-is part of-release.1"."image" = "image.0"."id"
+  AND "image.0-is part of-release.1"."is part of-release" = "release.1"."id"
+  AND NOT (
+    'success' = "image.0"."status"
+    AND "image.0"."status" IS NOT NULL
+  )
+  -- As a precaution, exclude releases that `should be-running` on any device,
+  -- as it's invalid for non-successful releases to be running on devices.
+  -- There's no simple way to handle these cases so leave them alone, we'll fail
+  -- the migration when the check below runs. Thankfully we don't have such data
+  -- on balenaCloud and it's *extremely* unlikely other installations do, but it
+  -- never hurts to be cautious in a data migration.
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "device" AS "d"
+    WHERE "d"."should be running-release" = "release.1"."id"
+  )
+);
+
+DO $$
+BEGIN
+  -- Check that the DB is in a valid state and raise an exception if that's not the case
+  IF (
+    SELECT COUNT(*)
+    FROM "image" AS "image.0",
+      "release" AS "release.1",
+      "image-is part of-release" AS "image.0-is part of-release.1"
+    WHERE 'success' = "release.1"."status"
+    AND "release.1"."status" IS NOT NULL
+    AND "image.0-is part of-release.1"."image" = "image.0"."id"
+    AND "image.0-is part of-release.1"."is part of-release" = "release.1"."id"
+    AND NOT (
+      'success' = "image.0"."status"
+      AND "image.0"."status" IS NOT NULL
+    )
+  ) > 0
+  THEN
+    RAISE EXCEPTION 'migration failed: It is necessary that each image that is part of a release that has a status that equals "success", has a status that equals "success".';
+  END IF;
+END $$;


### PR DESCRIPTION
This rule should exist since multi-container but apparently doesn't.

```sql
-- It is necessary that each image that is part of a release that has a status that equals "success", has a status that equals "success".
SELECT (
	SELECT COUNT(*)
	FROM "image" AS "image.0",
		"release" AS "release.1",
		"image-is part of-release" AS "image.0-is part of-release.1"
	WHERE $1 = "release.1"."status"
	AND "release.1"."status" IS NOT NULL
	AND "image.0-is part of-release.1"."image" = "image.0"."id"
	AND "image.0-is part of-release.1"."is part of-release" = "release.1"."id"
	AND NOT (
		$2 = "image.0"."status"
		AND "image.0"."status" IS NOT NULL
	)
	AND ($3 = '{}'
	OR "image.0"."id" = ANY(CAST($3 AS INTEGER[])))
) = 0 AS "result";
```

See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/.22successful.22.20release.20images