### PR TITLE
Stop unnecessarily fetching `os_version` for state queries

### DIFF
--- a/src/features/device-state/routes/state-get-v2.ts
+++ b/src/features/device-state/routes/state-get-v2.ts
@@ -192,7 +192,7 @@ const stateQuery = _.once(() =>
 		resource: 'device',
 		id: { uuid: { '@': 'uuid' } },
 		options: {
-			$select: ['device_name', 'os_version'],
+			$select: ['device_name'],
 			$expand: {
 				device_config_variable: {
 					$select: ['name', 'value'],

--- a/src/features/device-state/routes/state-get-v3.ts
+++ b/src/features/device-state/routes/state-get-v3.ts
@@ -269,7 +269,7 @@ const stateQuery = _.once(() =>
 		resource: 'device',
 		id: { uuid: { '@': 'uuid' } },
 		options: {
-			$select: ['device_name', 'os_version'],
+			$select: ['device_name'],
 			$expand: deviceExpand,
 		},
 	}),


### PR DESCRIPTION
Change-type: patch