### PR TITLE
Avoid unnecessarily fetching the var name when getting a poll interval

### DIFF
--- a/src/features/device-heartbeat/index.ts
+++ b/src/features/device-heartbeat/index.ts
@@ -25,7 +25,7 @@ const getPollIntervalForDevice = _.once(() =>
 		resource: 'device_config_variable',
 		passthrough: { req: permissions.root },
 		options: {
-			$select: ['name', 'value'],
+			$select: ['value'],
 			$top: 1,
 			$filter: {
 				device: {
@@ -54,7 +54,7 @@ const getPollIntervalForParentApplication = _.once(() =>
 		resource: 'application_config_variable',
 		passthrough: { req: permissions.root },
 		options: {
-			$select: ['name', 'value'],
+			$select: ['value'],
 			$top: 1,
 			$filter: {
 				application: {


### PR DESCRIPTION
Change-type: patch