### PR TITLE
Add config with a TTL for the Online heartbeat update cache

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -67,6 +67,15 @@ export const API_HEARTBEAT_STATE_TIMEOUT_SECONDS = intVar(
 	'API_HEARTBEAT_STATE_TIMEOUT_SECONDS',
 	15,
 );
+/**
+ * null:do not update the DB's device heartbeat to Online, if Redis says it's already Online
+ * 0: always run DB device heartbeat updates to Online
+ * >0: skip updating the DB's device heartbeat to Online N times, if Redis says it's already Online
+ */
+export const API_HEARTBEAT_STATE_ONLINE_UPDATE_CACHE_TTL = intVar(
+	'API_HEARTBEAT_STATE_ONLINE_UPDATE_CACHE_TTL',
+	null,
+);
 export const API_VPN_SERVICE_API_KEY = requiredVar('API_VPN_SERVICE_API_KEY');
 export const VPN_CONNECT_PROXY_PORT = intVar('VPN_CONNECT_PROXY_PORT', 3128);
 export const AUTH_RESINOS_REGISTRY_CODE = optionalVar(


### PR DESCRIPTION
Potentially a more re-usable alternative to #1338

Change-type: minor
See: https://balena.zulipchat.com/#narrow/stream/345882-_help/topic/device.20state.20stuck.20at.20VPN.20only