### PR TITLE
Add the device.changed_api_heartbeat_state_on__date term to the model

### DIFF
--- a/src/balena-model.ts
+++ b/src/balena-model.ts
@@ -682,6 +682,7 @@ export interface Device {
 		id: Types['Serial']['Read'];
 		actor: { __id: Actor['Read']['id'] } | [Actor['Read']];
 		api_heartbeat_state: 'online' | 'offline' | 'timeout' | 'unknown';
+		changed_api_heartbeat_state_on__date: Types['Date Time']['Read'] | null;
 		uuid: Types['Text']['Read'];
 		local_id: Types['Short Text']['Read'] | null;
 		device_name: Types['Short Text']['Read'] | null;
@@ -786,6 +787,7 @@ export interface Device {
 		id: Types['Serial']['Write'];
 		actor: Actor['Write']['id'];
 		api_heartbeat_state: 'online' | 'offline' | 'timeout' | 'unknown';
+		changed_api_heartbeat_state_on__date: Types['Date Time']['Write'] | null;
 		uuid: Types['Text']['Write'];
 		local_id: Types['Short Text']['Write'] | null;
 		device_name: Types['Short Text']['Write'] | null;

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -374,6 +374,9 @@ Term: device
 		Necessity: each device has exactly one api heartbeat state
 		Definition: "online" or "offline" or "timeout" or "unknown"
 
+	Fact type: device [changed api heartbeat state on] date
+		Necessity: each device [changed api heartbeat state on] at most one date.
+
 	Fact type: device has env var name
 		Term Form: device environment variable
 		Database Table Name: device environment variable
@@ -451,7 +454,7 @@ Fact type: user (Auth) has public key
 -- user public key
 
 Fact type: user public key has title
-    Necessity: each user public key has exactly one title
+	Necessity: each user public key has exactly one title
 
 
 -- application type

--- a/src/migrations/00093-device-last-api-heartbeat-state-change-event.sql
+++ b/src/migrations/00093-device-last-api-heartbeat-state-change-event.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "device"
+ADD COLUMN IF NOT EXISTS "changed api heartbeat state on-date" TIMESTAMP NULL;

--- a/src/translations/v7/v7.sbvr
+++ b/src/translations/v7/v7.sbvr
@@ -379,6 +379,9 @@ Term: device
 		Necessity: each device has exactly one api heartbeat state
 		Definition: "online" or "offline" or "timeout" or "unknown"
 
+	Fact type: device [changed api heartbeat state on] date
+		Necessity: each device [changed api heartbeat state on] at most one date.
+
 	Fact type: device has env var name
 		Term Form: device environment variable
 		Database Table Name: device environment variable

--- a/test/test-lib/api-helpers.ts
+++ b/test/test-lib/api-helpers.ts
@@ -188,6 +188,24 @@ export const getUserFromToken = (token: string) => {
 	return user;
 };
 
+export const thatIsDateStringAfter = (
+	dateParam: Date | string | number | null,
+) => {
+	if (dateParam == null) {
+		throw new Error(
+			`The date ${dateParam} provided to thatIsAfterDateString has to have a value`,
+		);
+	}
+	const date = !_.isDate(dateParam) ? new Date(dateParam) : dateParam;
+	return (prop: Chai.Assertion, value: unknown) =>
+		prop.that.is
+			.a('string')
+			.that.satisfies(
+				(d: string) => new Date(d) > date,
+				`Expected ${value} to be after ${date.toISOString()}`,
+			);
+};
+
 const validJwtProps = ['id', 'jwt_secret', 'authTime', 'iat', 'exp'].sort();
 
 export function expectJwt(tokenOrJwt: string | AnyObject) {


### PR DESCRIPTION
Resolves: #644
Change-type: minor
See: https://balena.fibery.io/Work/Project/Start-recording-the-last-timestamp-the-device-heartbeat-changed-254