### PR TITLE
Add partial index to optimize the unique release_version rule

### DIFF
--- a/src/balena-init.sql
+++ b/src/balena-init.sql
@@ -168,6 +168,12 @@ ON "release" ("belongs to-application", "revision", "semver major", "semver mino
 CREATE INDEX IF NOT EXISTS "release_belongs_to_app_revision_semver_prerelease_variant_idx"
 ON "release" ("belongs to-application", "revision", "semver major", "semver minor", "semver patch", "semver prerelease", "variant");
 
+-- Optimization for the app-release_version uniqueness rule,
+-- while preserving the index for the deprecated release_version small.
+CREATE INDEX IF NOT EXISTS "release_belongs_to_app_release_version_partial_idx"
+ON "release" ("belongs to-application", "release version")
+WHERE "release"."release version" IS NOT NULL;
+
 -- Optimize the overall status computed fact type
 CREATE INDEX IF NOT EXISTS "image_install_status_dl_progress_exists_device_idx"
 ON "image install" ("status", ("download progress" IS NOT NULL), "device");

--- a/src/migrations/0077-add-release-application-release-version-partial-index.sql
+++ b/src/migrations/0077-add-release-application-release-version-partial-index.sql
@@ -1,0 +1,5 @@
+-- Optimization for the app-release_version uniqueness rule,
+-- while preserving the index for the deprecated release_version small.
+CREATE INDEX IF NOT EXISTS "release_belongs_to_app_release_version_partial_idx"
+ON "release" ("belongs to-application", "release version")
+WHERE "release"."release version" IS NOT NULL;


### PR DESCRIPTION
Currently that rule does a full table scan and
needs 2s, so adding a partial index on the
deprecated release_version, fields should
greatly improve its performance, while having
small DB size & index maintenance work load.

Change-type: patch
See: https://explain.dalibo.com/plan/594c634725b2684e w/o index