### PR TITLE
Optimize the unique release_version rule

### DIFF
--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -846,7 +846,7 @@ Fact Type: scheduled job run has status
 
 -- Rules
 
-Rule: It is necessary that each release that has a release version1 and has a status that is equal to "success" and is not invalidated, belongs to an application that owns exactly one release that has a release version2 that is equal to the release version1 and has a status that is equal to "success" and is not invalidated.
+Rule: It is necessary that each application that owns a release1 that has a status that is equal to "success" and is not invalidated and has a release version, owns at most one release2 that has a status that is equal to "success" and is not invalidated and has a release version that is of the release1.
 Rule: It is necessary that each image that has a status that is equal to "success", has a push timestamp.
 Rule: It is necessary that each application that owns a release1 that has a status that is equal to "success" and has a commit1, owns at most one release2 that has a status that is equal to "success" and has a commit2 that is equal to the commit1.
 Rule: It is necessary that each application that owns a release1 that has a revision, owns at most one release2 that has a semver major that is of the release1 and has a semver minor that is of the release1 and has a semver patch that is of the release1 and has a semver prerelease that is of the release1 and has a variant that is of the release1 and has a revision that is of the release1.


### PR DESCRIPTION
~~Let's first decide about #1345 since it reduces the need for this PR.~~

Enables row narrowing when the rule is
triggered by application changes, but more
importantly allows bC to rewrite the rule using
a GROUP BY.
See: https://github.com/balena-io/balena-api/pull/4426
Also reduces slightly the full rule runtime from
~200ms to ~180ms.

Change-type: patch
See: https://explain.dalibo.com/plan/978hb14b2dd56ccb
See: https://explain.dalibo.com/plan/6f1hd8f4ee0ada6d