### PR TITLE
Split metrics from `device` resource

### DIFF
--- a/src/balena-init.sql
+++ b/src/balena-init.sql
@@ -188,3 +188,6 @@ ON "application" ("slug" varchar_pattern_ops, "is public", "is host");
 
 CREATE INDEX IF NOT EXISTS "scheduled_job_run_start_timestamp_idx"
 ON "scheduled job run" (DATE_TRUNC('milliseconds', "start timestamp"));
+
+CREATE INDEX IF NOT EXISTS "device_metrics_record_by_device_idx"
+ON "device metrics record" ("is reported by-device");

--- a/src/balena-model.ts
+++ b/src/balena-model.ts
@@ -364,14 +364,6 @@ export interface Device {
 	public_address: string | null;
 	ip_address: string | null;
 	mac_address: string | null;
-	memory_usage: number | null;
-	memory_total: number | null;
-	storage_block_device: string | null;
-	storage_usage: number | null;
-	storage_total: number | null;
-	cpu_usage: number | null;
-	cpu_temp: number | null;
-	is_undervolted: boolean;
 	cpu_id: string | null;
 	is_running__release: { __id: number } | [Release?] | null;
 	download_progress: number | null;
@@ -403,6 +395,7 @@ export interface Device {
 	service_install?: ServiceInstall[];
 	installs__image?: ImageInstall[];
 	installs__application__has__service_name?: ServiceInstall[];
+	reports__device_metrics_record?: DeviceMetricsRecord[];
 }
 
 export interface DeviceEnvironmentVariable {
@@ -563,6 +556,21 @@ export interface UserHasPublicKey {
 	public_key: string;
 	id: number;
 	title: string;
+}
+
+export interface DeviceMetricsRecord {
+	created_at: DateString;
+	modified_at: DateString;
+	id: number;
+	is_reported_by__device: { __id: number } | [Device];
+	memory_usage: number | null;
+	memory_total: number | null;
+	storage_block_device: string | null;
+	storage_usage: number | null;
+	storage_total: number | null;
+	cpu_usage: number | null;
+	cpu_temp: number | null;
+	is_undervolted: boolean;
 }
 
 export interface DeviceTypeAlias {

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -581,6 +581,31 @@ Fact type: device should be managed by release
 	Necessity: each device should be managed by at most one release
 
 
+Term: device metrics record
+
+-- device metrics record
+Fact type: device metrics record is reported by device
+    Synonymous Form: device reports device metrics record
+    Necessity: each device metrics record is reported by exactly one device
+	Necessity: each device reports exactly one device metrics record
+
+Fact type: device metrics record has memory usage
+	Necessity: each device metrics record has at most one memory usage
+Fact type: device metrics record has memory total
+	Necessity: each device metrics record has at most one memory total
+Fact type: device metrics record has storage block device
+	Necessity: each device metrics record has at most one storage block device
+Fact type: device metrics record has storage usage
+	Necessity: each device metrics record has at most one storage usage
+Fact type: device metrics record has storage total
+	Necessity: each device metrics record has at most one storage total
+Fact type: device metrics record has cpu usage
+	Necessity: each device metrics record has at most one cpu usage
+Fact type: device metrics record has cpu temp
+	Necessity: each device metrics record has at most one cpu temp
+Fact type: device metrics record is undervolted
+
+
 -- application config variable
 
 Fact type: application config variable has value

--- a/src/features/cascade-delete/hooks.ts
+++ b/src/features/cascade-delete/hooks.ts
@@ -22,6 +22,7 @@ setupDeleteCascade('device', {
 	device_tag: 'device',
 	image_install: 'device',
 	service_install: 'device',
+	device_metrics_record: 'is_reported_by__device',
 });
 
 setupDeleteCascade('image', {

--- a/src/features/device-state/index.ts
+++ b/src/features/device-state/index.ts
@@ -23,9 +23,11 @@ export {
 	serviceInstallFromImage,
 } from './state-get-utils';
 export {
-	metricsPatchFields,
+	validDeviceMetricsRecordPatchFields,
 	v2ValidPatchFields,
+	v2ValidDevicePatchFields,
 	v3ValidPatchFields,
+	v3ValidDevicePatchFields,
 } from './state-patch-utils';
 
 const gracefulGet = resolveOrDenyDevicesWithStatus(304);

--- a/src/features/device-state/state-patch-utils.ts
+++ b/src/features/device-state/state-patch-utils.ts
@@ -10,7 +10,32 @@ import {
 import { createMultiLevelStore } from '../../infra/cache';
 import { permissions, sbvrUtils } from '@balena/pinejs';
 
-export const v3ValidPatchFields: Array<
+export type StatePatchDeviceMetricsRecordBody = {
+	memory_usage?: number;
+	memory_total?: number;
+	storage_block_device?: string;
+	storage_usage?: number;
+	storage_total?: number;
+	cpu_temp?: number;
+	cpu_usage?: number;
+	cpu_id?: string;
+	is_undervolted?: boolean;
+};
+
+export const validDeviceMetricsRecordPatchFields: Array<
+	keyof StatePatchDeviceMetricsRecordBody
+> = [
+	'memory_usage',
+	'memory_total',
+	'storage_block_device',
+	'storage_usage',
+	'storage_total',
+	'cpu_temp',
+	'cpu_usage',
+	'is_undervolted',
+];
+
+export const v3ValidDevicePatchFields: Array<
 	Exclude<keyof StatePatchV3Body[string], 'apps'>
 > = [
 	'status',
@@ -25,18 +50,25 @@ export const v3ValidPatchFields: Array<
 	'api_port',
 	'api_secret',
 	'cpu_id',
-	'is_undervolted',
 ];
 
-export const v2ValidPatchFields: Array<
+export const v3ValidPatchFields: Array<
+	Exclude<keyof StatePatchV3Body[string], 'apps'>
+> = [...v3ValidDevicePatchFields, ...validDeviceMetricsRecordPatchFields];
+
+export const v2ValidDevicePatchFields: Array<
 	Exclude<keyof NonNullable<StatePatchV2Body['local']>, 'apps'>
 > = [
-	...v3ValidPatchFields,
+	...v3ValidDevicePatchFields,
 	'should_be_running__release',
 	'device_name',
 	'note',
 	'download_progress',
 ];
+
+export const v2ValidPatchFields: Array<
+	Exclude<keyof NonNullable<StatePatchV2Body['local']>, 'apps'>
+> = [...v2ValidDevicePatchFields, ...validDeviceMetricsRecordPatchFields];
 
 const SHORT_TEXT_LENGTH = 255;
 const ADDRESS_DELIMITER = ' ';
@@ -79,16 +111,6 @@ export const truncateShortTextFields = (
 	}
 	return object;
 };
-
-export const metricsPatchFields = [
-	'memory_usage',
-	'memory_total',
-	'storage_block_device',
-	'storage_usage',
-	'storage_total',
-	'cpu_temp',
-	'cpu_usage',
-] as const;
 
 export const shouldUpdateMetrics = (() => {
 	const lastMetricsReportTime = createMultiLevelStore<number>(

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -51,6 +51,7 @@ export const ROLES: {
 		'resin.application_tag.all',
 		'resin.application_type.all',
 		'resin.device.all',
+		'resin.device_metrics_record.all',
 		'resin.device.tunnel-22222',
 		'resin.device_config_variable.all',
 		'resin.device_environment_variable.all',
@@ -79,6 +80,13 @@ export const DEVICE_API_KEY_PERMISSIONS = [
 	'resin.device_type.read?describes__device/canAccess()',
 	`resin.device.read?${matchesNonFrozenDeviceActor()}`,
 	`resin.device.update?${matchesNonFrozenDeviceActor()}`,
+	'resin.device_metrics_record.read?is_reported_by__device/canAccess()',
+	`resin.device_metrics_record.create?is_reported_by__device/any(d:${matchesNonFrozenDeviceActor(
+		'd',
+	)})`,
+	`resin.device_metrics_record.update?is_reported_by__device/any(d:${matchesNonFrozenDeviceActor(
+		'd',
+	)})`,
 	'resin.application.read?owns__device/canAccess() or (is_public eq true and is_for__device_type/any(dt:dt/describes__device/canAccess()))',
 	'resin.application_tag.read?application/canAccess()',
 	'resin.device_config_variable.read?device/canAccess()',

--- a/src/migrations/00084-split-device-metrics-from-device-schema.sql
+++ b/src/migrations/00084-split-device-metrics-from-device-schema.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS "device metrics record" (
+	"created at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	"is reported by-device" INTEGER NOT NULL UNIQUE
+,	"memory usage" INTEGER NULL
+,	"memory total" INTEGER NULL
+,	"storage block device" VARCHAR(255) NULL
+,	"storage usage" INTEGER NULL
+,	"storage total" INTEGER NULL
+,	"cpu usage" INTEGER NULL
+,	"cpu temp" INTEGER NULL
+,	"is undervolted" BOOLEAN DEFAULT FALSE NOT NULL
+,	FOREIGN KEY ("is reported by-device") REFERENCES "device" ("id")
+);
+
+
+CREATE INDEX IF NOT EXISTS "device_metrics_record_by_device_idx"
+ON "device metrics record" ("is reported by-device");

--- a/src/migrations/00085-split-device-metrics-from-device.async.ts
+++ b/src/migrations/00085-split-device-metrics-from-device.async.ts
@@ -1,0 +1,78 @@
+import type { Migrator } from '@balena/pinejs';
+
+const migration: Migrator.AsyncMigration = {
+	asyncSql: `\
+			INSERT INTO	"device metrics record" (
+				"is reported by-device",
+				"memory usage",
+				"memory total",
+				"storage block device",
+				"storage usage",
+				"storage total",
+				"cpu usage",
+				"cpu temp",
+				"is undervolted"
+			)
+			SELECT
+				"id",
+				"memory usage",
+				"memory total",
+				"storage block device",
+				"storage usage",
+				"storage total",
+				"cpu usage",
+				"cpu temp",
+				"is undervolted"
+			FROM (
+				SELECT * FROM "device"
+				WHERE
+					"device".id NOT IN (
+						SELECT
+							"is reported by-device"
+						FROM
+							"device metrics record"
+					)
+				LIMIT %%ASYNC_BATCH_SIZE%%
+				FOR UPDATE SKIP LOCKED
+			) AS pending;`,
+	syncSql: `\
+		INSERT INTO	"device metrics record" (
+			"is reported by-device",
+			"memory usage",
+			"memory total",
+			"storage block device",
+			"storage usage",
+			"storage total",
+			"cpu usage",
+			"cpu temp",
+			"is undervolted"
+		)
+		SELECT
+			"id",
+			"memory usage",
+			"memory total",
+			"storage block device",
+			"storage usage",
+			"storage total",
+			"cpu usage",
+			"cpu temp",
+			"is undervolted"
+		FROM (
+			SELECT * FROM "device"
+			WHERE
+				"device".id NOT IN (
+					SELECT
+						"is reported by-device"
+					FROM
+						"device metrics record"
+				)
+			FOR UPDATE SKIP LOCKED
+		) AS pending;`,
+	asyncBatchSize: 10000,
+	delayMS: 5000,
+	backoffDelayMS: 60000,
+	errorThreshold: 15,
+	finalize: false,
+};
+
+export default migration;


### PR DESCRIPTION
Remodel `device` resource and split metrics into `device metrics record`

This reduces the load on the `device` resource when updating device metrics periodically. device metrics are far less frequently needed than the `device` resource. Thus writing to the heavily used `device` resource should be offloaded to the `device metrics record` resource.

Change-type: major