### PR TITLE
One additional Redis AUTH location

### DIFF
--- a/src/features/device-heartbeat/index.ts
+++ b/src/features/device-heartbeat/index.ts
@@ -190,6 +190,7 @@ export class DeviceOnlineStateManager extends EventEmitter<{
 		this.rsmq = new RedisSMQ({
 			// TODO: RSMQ does not currently support a redis cluster
 			...REDIS.general.host,
+			...REDIS.general.auth,
 			ns: DeviceOnlineStateManager.REDIS_NAMESPACE,
 		});
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -420,10 +420,10 @@ export const IGNORE_FROZEN_DEVICE_PERMISSIONS = boolVar(
  * into a RedisAuth object. Auth is optional, so this can return
  * an empty RedisAuth object.
  */
-export const redisAuthVar = (
+function redisAuthVar(
 	varName: string | string[],
 	defaultAuth?: RedisAuth,
-): RedisAuth => {
+): RedisAuth {
 	const authPair = optionalVar(varName);
 	if (authPair == null) {
 		if (defaultAuth == null) {
@@ -447,4 +447,4 @@ export const redisAuthVar = (
 	}
 
 	return {};
-};
+}


### PR DESCRIPTION
also fixed possible 'redisAuthVar' use before initialization

Change-type: patch