### PR TITLE
fix: let go request with `x-forwarded-proto`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -403,6 +403,9 @@ function fixProtocolMiddleware(skipUrls: string[] = []): Handler {
 		if (req.protocol === 'https' || skipUrls.includes(req.url)) {
 			return next();
 		}
+		if (req.headers['x-forwarded-proto'] == 'https') {
+			return next();
+		}
 		if (req.headers['x-forwarded-for'] == null) {
 			const trust = req.app.get('trust proxy fn') as ReturnType<
 				typeof import('proxy-addr').compile


### PR DESCRIPTION
let go request with `x-forwarded-proto` header equals to 'https', which mostly comes from lb.

without this, we will have to config `trust proxy`, which seems likes not that convenient considering changing IPs in container environment.
