### PR TITLE
Fix the construction of the Redis RO auth options in non-cluster mode

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -215,7 +215,7 @@ function redisOpts(
 	if (roHosts.length > 1) {
 		throw new Error(`'${roHostVarName}' must contain at most one entry`);
 	}
-	const roAuth = redisAuthVar(roHostVarName, auth);
+	const roAuth = redisAuthVar(roAuthVarName, auth);
 	return {
 		isCluster,
 		host: hosts[0],


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-io/open-balena-api/pull/1399