### PR TITLE
rate-limiting: Use the ceiling of ms values for the Retry-After header

### DIFF
--- a/src/infra/rate-limiting/index.ts
+++ b/src/infra/rate-limiting/index.ts
@@ -66,7 +66,7 @@ export const createRateLimiter = (
 				if (e instanceof RateLimiterRes) {
 					const headers: { [header: string]: string } = {};
 					if (e.msBeforeNext) {
-						headers['Retry-After'] = `${Math.round(e.msBeforeNext / 1000)}`;
+						headers['Retry-After'] = `${Math.ceil(e.msBeforeNext / 1000)}`;
 					}
 					throw new TooManyRequestsError(
 						'Too Many Requests',


### PR DESCRIPTION
Previously we were rounding the value, which
could make clients relying on it to be hitting
unexpected 429s.

Change-type: patch