### PR TITLE
Draft: Remove `username` & `email` from User token payload

### DIFF
--- a/src/features/registry/registry.ts
+++ b/src/features/registry/registry.ts
@@ -694,7 +694,12 @@ const getSubject = async (
 	if (req.apiKey != null && !_.isEmpty(req.apiKey.permissions)) {
 		return await $getSubject(req.apiKey.key, req.params.subject, tx);
 	} else if (req.user) {
-		// If there's no api key then try to use the username from the JWT
-		return req.user.username;
+		// If there's no api key then use jwt userId to fetch username
+		const user = (await api.resin.get({
+			resource: 'user',
+			id: req.user.id,
+			options: { $select: 'username' },
+		})) as DbUser;
+		return user.username;
 	}
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ import { apiRoot } from './balena';
 
 export * as tags from './features/tags/validation';
 
-export type { Creds, User } from './infra/auth/jwt-passport';
+export type { Creds, TokenPayload } from './infra/auth/jwt-passport';
 export type { Access } from './features/registry/registry';
 export type { ApplicationType } from './features/application-types/application-types';
 export type { DeviceTypeJson } from './features/device-types/device-type-json';

--- a/src/infra/auth/jwt-passport.ts
+++ b/src/infra/auth/jwt-passport.ts
@@ -28,9 +28,7 @@ export interface ApiKey extends sbvrUtils.ApiKey {
 	key: string;
 }
 
-export interface User extends sbvrUtils.User {
-	username: string;
-	email: string | null;
+export interface TokenPayload extends sbvrUtils.User {
 	created_at: string;
 	jwt_secret: string | null;
 
@@ -38,7 +36,7 @@ export interface User extends sbvrUtils.User {
 	authTime?: number;
 }
 
-export type Creds = ServiceToken | User | ScopedToken;
+export type Creds = ServiceToken | TokenPayload | ScopedToken;
 export type JwtUser = Creds | ScopedAccessToken;
 const TOKEN_BODY_FIELD = '_token';
 
@@ -149,7 +147,7 @@ export const middleware: RequestHandler = (req, res, next) => {
 					twoFactorRequired: true;
 				};
 			} else {
-				req.user = auth as User & {
+				req.user = auth as TokenPayload & {
 					twoFactorRequired: false;
 				};
 			}

--- a/src/infra/auth/jwt.ts
+++ b/src/infra/auth/jwt.ts
@@ -7,7 +7,7 @@ import jsonwebtoken from 'jsonwebtoken';
 
 import { sbvrUtils, permissions, errors } from '@balena/pinejs';
 
-import { SignOptions, User } from './jwt-passport';
+import { SignOptions, TokenPayload } from './jwt-passport';
 
 import { pseudoRandomBytesAsync } from '../../lib/utils';
 import { getUser, userFields } from './auth';
@@ -21,7 +21,9 @@ const { api } = sbvrUtils;
 
 const SUDO_TOKEN_VALIDITY = 20 * 60 * 1000;
 
-export const checkSudoValidity = async (user: User): Promise<boolean> => {
+export const checkSudoValidity = async (
+	user: TokenPayload,
+): Promise<boolean> => {
 	const notAuthBefore = Date.now() - SUDO_TOKEN_VALIDITY;
 	return user.authTime != null && user.authTime > notAuthBefore;
 };
@@ -36,14 +38,14 @@ export const generateNewJwtSecret = async (): Promise<string> => {
 export const tokenFields = [...userFields];
 
 export interface ExtraParams {
-	existingToken?: Partial<User>;
+	existingToken?: Partial<TokenPayload>;
 	jwtOptions?: SignOptions;
 	tx: Tx;
 }
 
 export type GetUserTokenDataFn = (
 	userId: number,
-	existingToken: Partial<User> | undefined,
+	existingToken: Partial<TokenPayload> | undefined,
 	tx: Tx,
 ) => PromiseLike<AnyObject>;
 
@@ -55,7 +57,7 @@ let $getUserTokenDataCallback: GetUserTokenDataFn = async (
 	userId,
 	existingToken,
 	tx: Tx,
-): Promise<User> => {
+): Promise<TokenPayload> => {
 	const [userData, permissionData] = await Promise.all([
 		api.resin.get({
 			resource: 'user',
@@ -70,20 +72,20 @@ let $getUserTokenDataCallback: GetUserTokenDataFn = async (
 	if (!userData || !permissionData) {
 		throw new Error('No data found?!');
 	}
-	const newTokenData: Partial<User> = _.pick(userData, tokenFields);
+	const newTokenData: Partial<TokenPayload> = _.pick(userData, tokenFields);
 
 	const tokenData = {
 		...existingToken,
 		...newTokenData,
 		permissions: permissionData,
-	} as User;
+	} as TokenPayload;
 
 	if (!Number.isFinite(tokenData.authTime!)) {
 		tokenData.authTime = Date.now();
 	}
 
 	// skip nullish attributes
-	return _.omitBy(tokenData, _.isNil) as User;
+	return _.omitBy(tokenData, _.isNil) as TokenPayload;
 };
 
 export const createSessionToken = async (

--- a/test/test-lib/supertest.ts
+++ b/test/test-lib/supertest.ts
@@ -1,9 +1,9 @@
 import { app } from '../../init';
 import $supertest from 'supertest';
-import { User } from '../../src/infra/auth/jwt-passport';
+import { TokenPayload } from '../../src/infra/auth/jwt-passport';
 import { ThisShouldNeverHappenError } from '../../src/infra/error-handling';
 
-export type UserObjectParam = Partial<User & { token: string }>;
+export type UserObjectParam = Partial<TokenPayload & { token: string }>;
 
 export const augmentStatusAssertionError = () => {
 	const originalExpect: $supertest.Test['expect'] =

--- a/typings/express-extension.d.ts
+++ b/typings/express-extension.d.ts
@@ -3,7 +3,7 @@ declare namespace Express {
 	import type { Creds } from '../src/infra/auth/jwt-passport';
 	// For some reason TS doesn't like v so we had to use `import()`
 	// import type { User as ApiUser } from '../src/infra/auth/jwt-passport';
-	type ApiUser = import('../src/infra/auth/jwt-passport').User;
+	type ApiUser = import('../src/infra/auth/jwt-passport').TokenPayload;
 
 	// Augment Express.User to include the props of our ApiUser.
 	// eslint-disable-next-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
Breaking change on the exposed interfaces.
- Rename `jwt-passport.User` to `jwt-passport.TokenPayload`
- Remove `username: string;` from interface
- Remove `email: string | null;` from interface

Change-type: major
Signed-off-by: Harald Fischer <harald@balena.io>