### PR TITLE
Reduce `TokenUserPayload` by removing `username`, `email`, `created_at`, `permissions`

### DIFF
--- a/src/features/auth/whoami.ts
+++ b/src/features/auth/whoami.ts
@@ -56,44 +56,44 @@ type ActorResponse =
 
 export const whoami: RequestHandler = async (req, res) => {
 	try {
-		const userInfo = await sbvrUtils.db.readTransaction(async (tx) => {
-			const user = await getUser(req, tx, true);
-			if (user.actor && user.email === undefined) {
-				// If we get to this point, then the request is most likely being made
-				// using a scoped access token.
-				// First we check to see if this token can access the user resource,
-				// then if it can, we retrieve user document that corresponds to the
-				// `actor` value on the token using root privileges.
-				const [userWithId] = (await api.resin.get({
+		const userInfo = await sbvrUtils.db.readTransaction(
+			async (
+				tx,
+			): Promise<
+				Pick<User, 'id'> & Partial<Pick<User, 'username' | 'email'>>
+			> => {
+				const user = await getUser(req, tx, true);
+				const [userWithUsername] = (await api.resin.get({
 					resource: 'user',
 					passthrough: { req, tx },
 					options: {
-						$top: 1,
-						$select: 'id',
-						$filter: {
-							actor: user.actor,
-						},
+						$select: ['id', 'username'],
+						$filter: { actor: user.actor },
 					},
-				})) as Array<Pick<User, 'id'>>;
+				})) as [Pick<User, 'id' | 'username'>?];
 
-				// If the count is 0, then this token doesn't have access to the
-				// user resource and we should just continue with whatever was
-				// provided from the `getUser` call above.
-				if (userWithId) {
-					// If we reach this step, then the token has access and we can
-					// retrieve the user document in full
-					return (await api.resin.get({
-						resource: 'user',
-						passthrough: { req: permissions.root, tx },
-						id: userWithId.id,
-						options: {
-							$select: ['id', 'username', 'email'],
-						},
-					})) as Pick<User, 'id' | 'username' | 'email'>;
+				if (userWithUsername == null) {
+					// If we can't retrieve the user, then this request might be from
+					// a scoped api key which doesn't have access to the user resource
+					// and we should just continue with whatever was provided from the `getUser` call above.
+					return user;
 				}
-			}
-			return user;
-		});
+
+				const userWithEmail = (await api.resin.get({
+					resource: 'user',
+					passthrough: { req: permissions.root, tx },
+					id: userWithUsername.id,
+					options: {
+						$select: 'email',
+					},
+				})) as Pick<User, 'email'>;
+
+				return {
+					...userWithUsername,
+					...userWithEmail,
+				};
+			},
+		);
 		res.json({
 			id: userInfo.id,
 			username: userInfo.username,

--- a/src/infra/auth/auth.ts
+++ b/src/infra/auth/auth.ts
@@ -144,14 +144,9 @@ export const reqHasPermission = (
 
 // If adding/removing fields, please also update `User`
 // in "typings/common.d.ts".
-export const userFields = [
-	'id',
-	'actor',
-	'username',
-	'email',
-	'created_at',
-	'jwt_secret',
-] satisfies Array<keyof DbUser>;
+export const userFields = ['id', 'actor', 'jwt_secret'] satisfies Array<
+	keyof DbUser
+>;
 
 const getUserQuery = _.once(
 	() =>

--- a/src/infra/auth/jwt.ts
+++ b/src/infra/auth/jwt.ts
@@ -58,18 +58,15 @@ let $getUserTokenDataCallback: GetUserTokenDataFn = async (
 	existingToken,
 	tx: Tx,
 ): Promise<TokenUserPayload> => {
-	const [userData, permissionData] = await Promise.all([
-		api.resin.get({
-			resource: 'user',
-			id: userId,
-			passthrough: { req: permissions.root, tx },
-			options: {
-				$select: tokenFields,
-			},
-		}) as Promise<PickDeferred<DbUser, (typeof tokenFields)[number]>>,
-		permissions.getUserPermissions(userId, tx),
-	]);
-	if (!userData || !permissionData) {
+	const userData = (await api.resin.get({
+		resource: 'user',
+		id: userId,
+		passthrough: { req: permissions.root, tx },
+		options: {
+			$select: tokenFields,
+		},
+	})) as PickDeferred<DbUser, (typeof tokenFields)[number]>;
+	if (!userData) {
 		throw new Error('No data found?!');
 	}
 	const newTokenData = {
@@ -80,7 +77,6 @@ let $getUserTokenDataCallback: GetUserTokenDataFn = async (
 	const tokenData: TokenUserPayload = {
 		...existingToken,
 		...newTokenData,
-		permissions: permissionData,
 	};
 
 	if (!Number.isFinite(tokenData.authTime!)) {

--- a/test/04_session.ts
+++ b/test/04_session.ts
@@ -125,8 +125,8 @@ versions.test((version) => {
 				expect(tokenParts).to.have.property('length', 3);
 				const payload = parseJwt(token);
 				expect(payload).to.have.property('id');
-				expect(payload).to.have.property('username');
-				expect(payload).to.have.property('email');
+				expect(payload).to.not.have.property('username');
+				expect(payload).to.not.have.property('email');
 			});
 
 			it('should refresh & update the authTime with a POST to /user/v1/refresh-token using a correct password', async function () {
@@ -140,8 +140,8 @@ versions.test((version) => {
 				expect(tokenParts).to.have.property('length', 3);
 				const payload = parseJwt(token);
 				expect(payload).to.have.property('id');
-				expect(payload).to.have.property('username');
-				expect(payload).to.have.property('email');
+				expect(payload).to.not.have.property('username');
+				expect(payload).to.not.have.property('email');
 				expect(payload).to.have.property('authTime');
 				const initialAuthTime: number = payload.authTime;
 
@@ -156,8 +156,8 @@ versions.test((version) => {
 				expect(tokenParts1).to.have.property('length', 3);
 				const payload1 = parseJwt(token);
 				expect(payload1).to.have.property('id');
-				expect(payload1).to.have.property('username');
-				expect(payload1).to.have.property('email');
+				expect(payload1).to.not.have.property('username');
+				expect(payload1).to.not.have.property('email');
 				expect(payload1)
 					.to.have.property('authTime')
 					.to.be.above(initialAuthTime);
@@ -173,8 +173,8 @@ versions.test((version) => {
 				expect(tokenParts).to.have.property('length', 3);
 				const payload = parseJwt(token);
 				expect(payload).to.have.property('id');
-				expect(payload).to.have.property('username');
-				expect(payload).to.have.property('email');
+				expect(payload).to.not.have.property('username');
+				expect(payload).to.not.have.property('email');
 				expect(payload).to.have.property('authTime');
 				const initialAuthTime: number = payload.authTime;
 
@@ -187,8 +187,8 @@ versions.test((version) => {
 				expect(tokenParts1).to.have.property('length', 3);
 				const payload1 = parseJwt(token);
 				expect(payload1).to.have.property('id');
-				expect(payload1).to.have.property('username');
-				expect(payload1).to.have.property('email');
+				expect(payload1).to.not.have.property('username');
+				expect(payload1).to.not.have.property('email');
 				expect(payload1)
 					.to.have.property('authTime')
 					.that.equals(initialAuthTime);

--- a/test/test-lib/api-helpers.ts
+++ b/test/test-lib/api-helpers.ts
@@ -129,18 +129,7 @@ export const expectResourceToMatch = async <T = AnyObject>(
 	return result!;
 };
 
-const validJwtProps = [
-	'id',
-	'actor',
-	'username',
-	'email',
-	'created_at',
-	'jwt_secret',
-	'authTime',
-	'permissions',
-	'iat',
-	'exp',
-];
+const validJwtProps = ['id', 'actor', 'jwt_secret', 'authTime', 'iat', 'exp'];
 
 export function expectJwt(tokenOrJwt: string | AnyObject) {
 	const decoded = (
@@ -149,18 +138,18 @@ export function expectJwt(tokenOrJwt: string | AnyObject) {
 			: tokenOrJwt
 	) as TokenUserPayload;
 	expect(decoded).to.have.property('id').that.is.a('number');
-	expect(decoded).to.have.property('username').that.is.a.string;
 	expect(decoded).to.have.property('jwt_secret').that.is.a.string;
 	expect(decoded).to.have.property('authTime').that.is.a('number');
 	expect(decoded).to.have.property('iat').that.is.a('number');
 	expect(decoded).to.have.property('exp').that.is.a('number');
 	expect(decoded).to.have.property('actor').that.is.a('number');
-	expect(decoded).to.have.property('email').that.is.a.string;
-	expect(decoded).to.have.property('created_at').that.is.a.string;
-	expect(decoded).to.have.property('permissions').that.is.an('array');
 
 	const unexpectedKeys = new Set(Object.keys(decoded));
-	validJwtProps.forEach((key) => unexpectedKeys.delete(key));
+	validJwtProps.forEach((key) => {
+		expect(decoded).to.have.property(key);
+		unexpectedKeys.delete(key);
+	});
+
 	expect(
 		[...unexpectedKeys],
 		'expect there are no unexpected keys',


### PR DESCRIPTION
Improves performance for encoding, decoding and bandwith as JWT token length is reduced.

https://balena.fibery.io/Work/Task/Reduce-JWT-payload-to-minimum-amount-of-static-information-1597

Change-type: major