### PR TITLE
Fix code scanning alert - Type confusion through parameter tampering

### DIFF
--- a/src/features/device-logs/lib/supervisor.ts
+++ b/src/features/device-logs/lib/supervisor.ts
@@ -9,7 +9,7 @@ const MAX_LOGS_PER_BATCH = 10;
 
 export class Supervisor {
 	public convertLogs(logs: SupervisorLog[]): DeviceLog[] {
-		if (logs.length > MAX_LOGS_PER_BATCH) {
+		if (Array.isArray(logs) && logs.length > MAX_LOGS_PER_BATCH) {
 			throw new errors.BadRequestError(
 				`Batches cannot include more than ${MAX_LOGS_PER_BATCH} logs`,
 			);


### PR DESCRIPTION
Fixes: Fix code scanning alert - Type confusion through parameter tampering #1484

Change-type: patch