### PR TITLE
Fix timing of log publishing

### DIFF
--- a/src/features/device-logs/lib/store.ts
+++ b/src/features/device-logs/lib/store.ts
@@ -243,7 +243,7 @@ function handleStreamingWrite(
 					});
 				}
 				// Even if the connection was closed, still flush the buffer
-				const publishPromise = publishBackend(backend, ctx, buffer);
+				const publishPromise = publishBackend(backend, ctx, [...buffer]);
 				// Clear the buffer
 				buffer.length = 0;
 				// Resume in case it was paused due to buffering


### PR DESCRIPTION
Logs are frequently not published to redis / loki because the line:

```
buffer.length = 0;
```

in `src/features/device-logs/lib/store.ts` comes before the line:

```
await publishPromise
```

So the publishPromise must complete *very* quickly before the buffer is wiped out otherwise no logs are published.  This can be fixed by simply spreading buffer into a new array, copying the values, and avoiding the timing issue.

Change-type: patch
