### PR TITLE
Avoid any async operations for loki publish before processing logs

### DIFF
--- a/src/features/device-logs/lib/backends/loki.ts
+++ b/src/features/device-logs/lib/backends/loki.ts
@@ -204,16 +204,16 @@ export class LokiBackend implements DeviceLogsBackend {
 	}
 
 	public async publish(
-		$ctx: LogContext,
+		ctx: LogContext,
 		logs: Array<DeviceLog & { version?: number }>,
 	): Promise<any> {
-		const ctx = await assertLokiLogContext($ctx);
 		const countLogs = logs.length;
 		incrementPublishCallTotal();
 		incrementPublishLogMessagesTotal(countLogs);
 		const streams = this.fromDeviceLogsToStreams(ctx, logs);
+		const lokiCtx = await assertLokiLogContext(ctx);
 		try {
-			await this.push(ctx.belongs_to__application, streams);
+			await this.push(lokiCtx.belongs_to__application, streams);
 			incrementPublishCallSuccessTotal();
 		} catch (err) {
 			incrementPublishCallFailedTotal();

--- a/src/features/device-logs/lib/struct.ts
+++ b/src/features/device-logs/lib/struct.ts
@@ -46,7 +46,9 @@ export type Subscription = (log: DeviceLog) => void;
 export interface DeviceLogsBackend {
 	history(ctx: LogContext, count: number): Promise<DeviceLog[]>;
 	available: boolean;
-	// `logs` will be mutated to empty and so must be handled synchronously
+	/**
+	 * `logs` will be mutated to empty and so must be handled synchronously
+	 */
 	publish(ctx: LogContext, logs: DeviceLog[]): Promise<any>;
 	subscribe(ctx: LogContext, subscription: Subscription): void;
 	unsubscribe(ctx: LogContext, subscription: Subscription): void;


### PR DESCRIPTION
This means the logs are processed before being cleared as is expected by the interface

Change-type: patch