### PR TITLE
auth: Fix the JWT's actor being a deferred navigation resource

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ import { getV6Translations } from './translations/v6/v6';
 
 export * as tags from './features/tags/validation';
 
-export type { Creds, User } from './infra/auth/jwt-passport';
+export type { Creds, TokenUserPayload } from './infra/auth/jwt-passport';
 export type { Access } from './features/registry/registry';
 export type { ApplicationType } from './features/application-types/application-types';
 export type { DeviceTypeJson } from './features/device-types/device-type-json';

--- a/src/infra/auth/auth.ts
+++ b/src/infra/auth/auth.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { sbvrUtils, hooks, permissions, errors } from '@balena/pinejs';
 
 import { retrieveAPIKey } from './api-keys';
-import { User } from './jwt-passport';
+import type { TokenUserPayload } from './jwt-passport';
 
 import { getIP } from '../../lib/utils';
 import type { PickDeferred, User as DbUser } from '../../balena-model';
@@ -190,12 +190,12 @@ export function getUser(
 	req: Request | hooks.HookReq,
 	txParam: Tx | undefined,
 	required?: true,
-): Promise<User>;
+): Promise<TokenUserPayload>;
 export function getUser(
 	req: Request | hooks.HookReq,
 	txParam: Tx | undefined,
 	required: false,
-): Promise<User | undefined>;
+): Promise<TokenUserPayload | undefined>;
 export async function getUser(
 	req: hooks.HookReq & Pick<Request, 'user' | 'creds'>,
 	/** You should always be passing a Tx, unless you are using this in a middleware. */

--- a/src/infra/auth/jwt-passport.ts
+++ b/src/infra/auth/jwt-passport.ts
@@ -28,7 +28,7 @@ export interface ApiKey extends sbvrUtils.ApiKey {
 	key: string;
 }
 
-export interface User extends sbvrUtils.User {
+export interface TokenUserPayload extends sbvrUtils.User {
 	username: string;
 	email: string | null;
 	created_at: string;
@@ -38,7 +38,7 @@ export interface User extends sbvrUtils.User {
 	authTime?: number;
 }
 
-export type Creds = ServiceToken | User | ScopedToken;
+export type Creds = ServiceToken | TokenUserPayload | ScopedToken;
 export type JwtUser = Creds | ScopedAccessToken;
 const TOKEN_BODY_FIELD = '_token';
 
@@ -149,7 +149,7 @@ export const middleware: RequestHandler = (req, res, next) => {
 					twoFactorRequired: true;
 				};
 			} else {
-				req.user = auth as User & {
+				req.user = auth as TokenUserPayload & {
 					twoFactorRequired: false;
 				};
 			}

--- a/src/infra/auth/jwt.ts
+++ b/src/infra/auth/jwt.ts
@@ -7,7 +7,7 @@ import jsonwebtoken from 'jsonwebtoken';
 
 import { sbvrUtils, permissions, errors } from '@balena/pinejs';
 
-import type { SignOptions, User as TokenUserPayload } from './jwt-passport';
+import type { SignOptions, TokenUserPayload } from './jwt-passport';
 import type { User as DbUser, PickDeferred } from '../../balena-model';
 import { pseudoRandomBytesAsync } from '../../lib/utils';
 import { getUser, userFields } from './auth';

--- a/test/test-lib/api-helpers.ts
+++ b/test/test-lib/api-helpers.ts
@@ -3,7 +3,7 @@ import type { PineTest } from 'pinejs-client-supertest';
 import type { Release } from '../../src/balena-model';
 import { expect } from 'chai';
 import { supertest, UserObjectParam } from '../test-lib/supertest';
-import type { User as TokenUserPayload } from '../../src';
+import type { TokenUserPayload } from '../../src';
 
 const version = 'resin';
 

--- a/test/test-lib/api-helpers.ts
+++ b/test/test-lib/api-helpers.ts
@@ -1,7 +1,9 @@
+import jsonwebtoken from 'jsonwebtoken';
 import type { PineTest } from 'pinejs-client-supertest';
 import type { Release } from '../../src/balena-model';
 import { expect } from 'chai';
 import { supertest, UserObjectParam } from '../test-lib/supertest';
+import type { User as TokenUserPayload } from '../../src';
 
 const version = 'resin';
 
@@ -126,3 +128,43 @@ export const expectResourceToMatch = async <T = AnyObject>(
 	}
 	return result!;
 };
+
+const validJwtProps = [
+	'id',
+	'actor',
+	'username',
+	'email',
+	'created_at',
+	'jwt_secret',
+	'authTime',
+	'permissions',
+	'iat',
+	'exp',
+];
+
+export function expectJwt(tokenOrJwt: string | AnyObject) {
+	const decoded = (
+		typeof tokenOrJwt === 'string'
+			? jsonwebtoken.decode(tokenOrJwt)
+			: tokenOrJwt
+	) as TokenUserPayload;
+	expect(decoded).to.have.property('id').that.is.a('number');
+	expect(decoded).to.have.property('username').that.is.a.string;
+	expect(decoded).to.have.property('jwt_secret').that.is.a.string;
+	expect(decoded).to.have.property('authTime').that.is.a('number');
+	expect(decoded).to.have.property('iat').that.is.a('number');
+	expect(decoded).to.have.property('exp').that.is.a('number');
+	expect(decoded).to.have.property('actor').that.is.a('number');
+	expect(decoded).to.have.property('email').that.is.a.string;
+	expect(decoded).to.have.property('created_at').that.is.a.string;
+	expect(decoded).to.have.property('permissions').that.is.an('array');
+
+	const unexpectedKeys = new Set(Object.keys(decoded));
+	validJwtProps.forEach((key) => unexpectedKeys.delete(key));
+	expect(
+		[...unexpectedKeys],
+		'expect there are no unexpected keys',
+	).to.deep.equal([]);
+
+	return decoded;
+}

--- a/test/test-lib/init-tests.ts
+++ b/test/test-lib/init-tests.ts
@@ -1,4 +1,3 @@
-import jsonwebtoken from 'jsonwebtoken';
 import * as fixtures from './fixtures';
 import {
 	supertest,
@@ -9,6 +8,7 @@ import {
 	getContractRepos,
 	synchronizeContracts,
 } from '../../src/features/contracts';
+import { expectJwt } from './api-helpers';
 
 const version = 'resin';
 
@@ -47,11 +47,10 @@ const loadAdminUserAndOrganization = async () => {
 			.expect(200)
 	).text;
 
-	const user = (await jsonwebtoken.decode(token)) as UserObjectParam;
-	user.token = token;
-	user.actor = (
-		await supertest(user).get(`/${version}/user(${user.id})`).expect(200)
-	).body.d[0].actor as number;
+	const user: UserObjectParam = {
+		...(await expectJwt(token)),
+		token,
+	};
 
 	const org = (
 		await supertest(user)

--- a/test/test-lib/supertest.ts
+++ b/test/test-lib/supertest.ts
@@ -1,6 +1,6 @@
 import { app } from '../../init';
 import $supertest from 'supertest';
-import { User as TokenUserPayload } from '../../src/infra/auth/jwt-passport';
+import type { TokenUserPayload } from '../../src/infra/auth/jwt-passport';
 import { ThisShouldNeverHappenError } from '../../src/infra/error-handling';
 
 export type UserObjectParam = Partial<TokenUserPayload> & { token: string };

--- a/test/test-lib/supertest.ts
+++ b/test/test-lib/supertest.ts
@@ -1,9 +1,9 @@
 import { app } from '../../init';
 import $supertest from 'supertest';
-import { User } from '../../src/infra/auth/jwt-passport';
+import { User as TokenUserPayload } from '../../src/infra/auth/jwt-passport';
 import { ThisShouldNeverHappenError } from '../../src/infra/error-handling';
 
-export type UserObjectParam = Partial<User> & { token: string };
+export type UserObjectParam = Partial<TokenUserPayload> & { token: string };
 
 export const augmentStatusAssertionError = () => {
 	// We need to cast this because otherwise the supertest-extension `_assertStatus` method isn't included

--- a/typings/express-extension.d.ts
+++ b/typings/express-extension.d.ts
@@ -3,7 +3,7 @@ declare namespace Express {
 	import type { Creds } from '../src/infra/auth/jwt-passport';
 	// For some reason TS doesn't like v so we had to use `import()`
 	// import type { User as ApiUser } from '../src/infra/auth/jwt-passport';
-	type ApiUser = import('../src/infra/auth/jwt-passport').User;
+	type ApiUser = import('../src/infra/auth/jwt-passport').TokenUserPayload;
 
 	// Augment Express.User to include the props of our ApiUser.
 	// eslint-disable-next-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
Replicating the bC fix https://github.com/balena-io/balena-api/pull/4852
Given that we are already doing a major I also renamed the auth User to TokenUserPayload, since it was already helpful while doing this PR and removed the ambiguity between the DB User and the JWT User.

Change-type: major
See: https://github.com/balena-io/balena-api/pull/4852