### PR TITLE
Use the release semver fields along with release_tags in hostApp operations

### DIFF
--- a/test/15_target-hostapp.ts
+++ b/test/15_target-hostapp.ts
@@ -6,6 +6,7 @@ import type { UserObjectParam } from './test-lib/supertest.js';
 import { supertest } from './test-lib/supertest.js';
 import * as versions from './test-lib/versions.js';
 import type { Application, Device } from '../src/balena-model.js';
+import { expectResourceToMatch } from './test-lib/api-helpers.js';
 
 export default () => {
 	versions.test((version, pineTest) => {
@@ -15,19 +16,28 @@ export default () => {
 			let pineUser: typeof pineTest;
 			let applicationId: number;
 			let nucHostApp: Application;
-			let device: fakeDevice.Device;
+			let nucEsrHostApp: Application;
+			let device1: fakeDevice.Device;
 			let device2: fakeDevice.Device;
-			let preprovisionedDevice: fakeDevice.Device;
-			let esrDevice: fakeDevice.Device;
 			let noMatchDevice: fakeDevice.Device;
-			let invalidatedReleaseDevice: fakeDevice.Device;
-			let prodNucHostappReleaseId: number;
-			let raspberryPiHostappReleaseId: number;
+			/* eslint-disable @typescript-eslint/naming-convention */
+			let nuc2_50_0_rev1prodId: number;
+			let nuc2_51_0_rev1prodTagAndSemverId: number;
+			let nuc2_51_0_rev2prodSemverOnlyId: number;
+			let nucDraft2_90_0TagOnlyId: number;
+			let nucDraft2_90_1SemverOnlyId: number;
+			let nucDraft2_90_1rev1SemverOnlyId: number;
+			/* eslint-enable @typescript-eslint/naming-convention */
+			let rpi3hostAppReleaseId: number;
 			let failedIntelNucHostAppReleaseId: number;
-			let upgradeReleaseId: number;
-			let esrHostappReleaseId: number;
-			let invalidatedReleaseId: number;
+			let esrTagOnlyHostAppReleaseId: number;
+			let esrUnifiedHostAppReleaseId: number;
+			let esrSemverOnlyHostAppReleaseId: number;
+			let invalidatedTagOnlyReleaseId: number;
+			let invalidatedSemverOnlyReleaseId: number;
 			let unifiedHostAppReleaseId: number;
+			let unifiedSemverOnlyHostAppReleaseId: number;
+			let unifiedSemverRevHostAppReleaseId: number;
 
 			before(async () => {
 				fx = await fixtures.load('15-target-hostapps');
@@ -39,82 +49,135 @@ export default () => {
 				});
 				applicationId = fx.applications['user-app1'].id;
 				nucHostApp = fx.applications['intel-nuc'];
-				device = await fakeDevice.provisionDevice(admin, applicationId);
+				nucEsrHostApp = fx.applications['intel-nuc-esr'];
+				device1 = await fakeDevice.provisionDevice(admin, applicationId);
 				device2 = await fakeDevice.provisionDevice(admin, applicationId);
-				preprovisionedDevice = await fakeDevice.provisionDevice(
-					admin,
-					applicationId,
-				);
-				esrDevice = await fakeDevice.provisionDevice(admin, applicationId);
 				noMatchDevice = await fakeDevice.provisionDevice(admin, applicationId);
-				invalidatedReleaseDevice = await fakeDevice.provisionDevice(
-					admin,
-					applicationId,
-				);
-				prodNucHostappReleaseId = fx.releases.release0.id;
-				raspberryPiHostappReleaseId = fx.releases.release1.id;
+				nuc2_50_0_rev1prodId = fx.releases.release2_50_0_rev1.id;
+				nuc2_51_0_rev1prodTagAndSemverId = fx.releases.release2_51_0_rev1.id;
+				nuc2_51_0_rev2prodSemverOnlyId = fx.releases.release2_51_0_rev2.id;
+				rpi3hostAppReleaseId = fx.releases.rpi3release.id;
 				failedIntelNucHostAppReleaseId = fx.releases.releaseIntelNucFailed.id;
-				upgradeReleaseId = fx.releases.release2.id;
-				esrHostappReleaseId = fx.releases.release3.id;
-				invalidatedReleaseId = fx.releases.release5.id;
-				unifiedHostAppReleaseId = fx.releases.unifiedRelease.id;
+				esrTagOnlyHostAppReleaseId = fx.releases.releaseNucEsrTagOnly.id;
+				esrUnifiedHostAppReleaseId = fx.releases.releaseNucEsrUnified.id;
+				esrSemverOnlyHostAppReleaseId = fx.releases.releaseNucEsrSemverOnly.id;
+				invalidatedTagOnlyReleaseId =
+					fx.releases.releaseNucInvalidated2_52_0_rev1TagOnly.id;
+				invalidatedSemverOnlyReleaseId =
+					fx.releases.releaseNucInvalidated2_52_1rev1SemverOnly.id;
+				unifiedHostAppReleaseId = fx.releases.unified2_88_4Release.id;
+				unifiedSemverOnlyHostAppReleaseId =
+					fx.releases.unified2_88_5SemverOnlyRelease.id;
+				unifiedSemverRevHostAppReleaseId =
+					fx.releases.unified2_88_5_rev1SemverOnlyRelease.id;
+				nucDraft2_90_0TagOnlyId = fx.releases.nucDraft2_90_0TagOnly.id;
+				nucDraft2_90_1SemverOnlyId = fx.releases.nucDraft2_90_1SemverOnly.id;
+				nucDraft2_90_1rev1SemverOnlyId =
+					fx.releases.nucDraft2_90_1rev1SemverOnly.id;
 			});
 
 			after(async () => {
-				await fixtures.clean({
-					devices: [
-						device,
-						device2,
-						esrDevice,
-						noMatchDevice,
-						invalidatedReleaseDevice,
-						preprovisionedDevice,
-					],
-				});
 				await fixtures.clean(fx);
 			});
 
-			it('should provision with a linked prod hostapp (using PATCH)', async () => {
-				const devicePatchBody = {
-					local: {
+			const versionsToTest = [
+				[
+					'prod release_tag only',
+					{
 						os_version: 'balenaOS 2.50.0+rev1',
 						os_variant: 'prod',
 					},
-				};
-
-				await device.patchStateV2(devicePatchBody);
-				const { body } = await supertest(admin)
-					.get(
-						`/${version}/device(${device.id})?$select=should_be_operated_by__release`,
-					)
-					.expect(200);
-				expect(body.d[0]).to.not.be.undefined;
-				expect(body.d[0]).to.have.nested.property(
-					'should_be_operated_by__release.__id',
-					prodNucHostappReleaseId,
-				);
-			});
-
-			it('should provision with a linked unified hostapp (using PATCH)', async () => {
-				const devicePatchBody = {
-					local: {
+					() => nuc2_50_0_rev1prodId,
+				],
+				[
+					'prod release_tag & semver',
+					{
+						os_version: 'balenaOS 2.51.0+rev1',
+						os_variant: 'prod',
+					},
+					() => nuc2_51_0_rev1prodTagAndSemverId,
+				],
+				[
+					'prod semver only',
+					{
+						os_version: 'balenaOS 2.51.0+rev2',
+						os_variant: 'prod',
+					},
+					() => nuc2_51_0_rev2prodSemverOnlyId,
+				],
+				[
+					'unified release_tag & semver',
+					{
 						os_version: 'balenaOS 2.88.4',
 						os_variant: 'prod',
 					},
-				};
-
-				await device2.patchStateV2(devicePatchBody);
-				const { body } = await supertest(admin)
-					.get(
-						`/${version}/device(${device2.id})?$select=should_be_operated_by__release`,
-					)
-					.expect(200);
-				expect(body.d[0]).to.not.be.undefined;
-				expect(body.d[0]).to.have.nested.property(
-					'should_be_operated_by__release.__id',
-					unifiedHostAppReleaseId,
-				);
-			});
+					() => unifiedHostAppReleaseId,
+				],
+				[
+					'unified semver only',
+					{
+						os_version: 'balenaOS 2.88.5',
+						os_variant: 'prod',
+					},
+					() => unifiedSemverOnlyHostAppReleaseId,
+				],
+				[
+					'unified semver only with revision',
+					{
+						os_version: 'balenaOS 2.88.5+rev1',
+						os_variant: 'prod',
+					},
+					() => unifiedSemverRevHostAppReleaseId,
+				],
+				[
+					'ESR release_tag only',
+					{
+						os_version: 'balenaOS 2021.01.0',
+						os_variant: 'prod',
+					},
+					() => esrTagOnlyHostAppReleaseId,
+				],
+				[
+					'unified ESR',
+					{
+						os_version: 'balenaOS 2023.1.0',
+						os_variant: 'prod',
+					},
+					() => esrUnifiedHostAppReleaseId,
+				],
+				[
+					'ESR semver only',
+					{
+						os_version: 'balenaOS 2023.10.0',
+						os_variant: 'prod',
+					},
+					() => esrSemverOnlyHostAppReleaseId,
+				],
+				[
+					'draft release_tag only',
+					{
+						os_version: 'balenaOS 2.90.0',
+						os_variant: 'prod',
+					},
+					() => nucDraft2_90_0TagOnlyId,
+				],
+				[
+					'draft semver only',
+					{
+						os_version: 'balenaOS 2.90.1',
+						os_variant: 'prod',
+					},
+					() => nucDraft2_90_1SemverOnlyId,
+				],
+				[
+					'draft semver only',
+					{
+						os_version: 'balenaOS 2.90.1+rev1',
+						os_variant: 'prod',
+					},
+					() => nucDraft2_90_1rev1SemverOnlyId,
+				],
+			] as const;
 
 			(
 				[
@@ -150,8 +213,7 @@ export default () => {
 							const { body: provisioningKey } = await supertest(admin)
 								.post(`/api-key/application/${applicationId}/provisioning`)
 								.expect(200);
-							const uuid =
-								'f716a3e020bd444b885cb394453917520c3cf82e69654f84be0d33e31a0e15';
+							const uuid = fakeDevice.generateDeviceUuid();
 							return await supertest()
 								.post(`/device/register?apikey=${provisioningKey}`)
 								.send({
@@ -163,6 +225,31 @@ export default () => {
 								.expect(201);
 						},
 					],
+					[
+						'device POST & state PATCH',
+						async ({
+							belongs_to__application,
+							device_type,
+							...restDevicePostBody
+						}: AnyObject) => {
+							const testDevice = await fakeDevice.provisionDevice(
+								admin,
+								applicationId,
+							);
+							await testDevice.patchStateV2({
+								local: restDevicePostBody,
+							});
+							return await pineUser
+								.get({
+									resource: 'device',
+									id: testDevice.id,
+									options: {
+										$select: 'id',
+									},
+								})
+								.expect(200);
+						},
+					],
 				] as const
 			).forEach(([titlePart, provisionFn]) => {
 				it(`should provision WITHOUT a linked hostapp when not providing a version (using ${titlePart})`, async () => {
@@ -170,18 +257,8 @@ export default () => {
 						belongs_to__application: applicationId,
 						device_type: 'raspberrypi3',
 					});
-					const { body } = await supertest(admin)
-						.get(
-							`/${version}/device(${res.body.id})?$select=should_be_operated_by__release`,
-						)
-						.expect(200);
-					expect(body.d[0]).to.not.be.undefined;
-					expect(body.d[0]).to.have.property(
-						'should_be_operated_by__release',
-						null,
-					);
-					await fixtures.clean({
-						devices: [res.body],
+					await expectResourceToMatch(pineUser, 'device', res.body.id, {
+						should_be_operated_by__release: null,
 					});
 				});
 
@@ -192,42 +269,16 @@ export default () => {
 						os_version: 'balenaOS 2.99.0+rev1',
 						os_variant: 'prod',
 					});
-					const { body } = await supertest(admin)
-						.get(
-							`/${version}/device(${res.body.id})?$select=should_be_operated_by__release`,
-						)
-						.expect(200);
-					expect(body.d[0]).to.not.be.undefined;
-					expect(body.d[0]).to.have.property(
-						'should_be_operated_by__release',
-						null,
-					);
-					await fixtures.clean({
-						devices: [res.body],
+					await expectResourceToMatch(pineUser, 'device', res.body.id, {
+						should_be_operated_by__release: null,
 					});
 				});
 
-				(
-					[
-						[
-							'prod',
-							{
-								os_version: 'balenaOS 2.50.0+rev1',
-								os_variant: 'prod',
-							},
-							() => prodNucHostappReleaseId,
-						],
-						[
-							'unified',
-							{
-								os_version: 'balenaOS 2.88.4',
-								os_variant: 'prod',
-							},
-							() => unifiedHostAppReleaseId,
-						],
-					] as const
-				).forEach(
+				versionsToTest.forEach(
 					([osTypeTitlePart, osVersionVariantParams, getHostAppReleaseId]) => {
+						const isEsr =
+							osVersionVariantParams.os_version.startsWith('balenaOS 20');
+
 						describe(`provisioning with a ${osTypeTitlePart} OS (using ${titlePart})`, function () {
 							let registeredDevice: Device;
 
@@ -243,23 +294,24 @@ export default () => {
 									device_type: 'intel-nuc',
 									...osVersionVariantParams,
 								}));
-								const {
-									body: {
-										d: [fetchedDevice],
+								await expectResourceToMatch(
+									pineUser,
+									'device',
+									registeredDevice.id,
+									{
+										should_be_operated_by__release: {
+											__id: getHostAppReleaseId(),
+										},
 									},
-								} = await supertest(admin)
-									.get(
-										`/${version}/device(${registeredDevice.id})?$select=should_be_operated_by__release`,
-									)
-									.expect(200);
-								const hostappReleaseId = getHostAppReleaseId();
-								expect(fetchedDevice).to.have.nested.property(
-									'should_be_operated_by__release.__id',
-									hostappReleaseId,
 								);
 							});
 
 							it(`should create a service install for the linked hostapp`, async () => {
+								const targetHostApp = isEsr ? nucEsrHostApp : nucHostApp;
+								const targetService =
+									fx.services[
+										isEsr ? 'intel-nuc-esr_service1' : 'intel-nuc_service1'
+									];
 								const { body: serviceInstalls } = await pineUser
 									.get({
 										resource: 'service_install',
@@ -276,7 +328,7 @@ export default () => {
 														$alias: 'is',
 														$expr: {
 															is: {
-																application: nucHostApp.id,
+																application: targetHostApp.id,
 															},
 														},
 													},
@@ -287,10 +339,7 @@ export default () => {
 									.expect(200);
 								expect(serviceInstalls).to.have.lengthOf(1);
 								const [service] = serviceInstalls[0].installs__service;
-								expect(service).to.have.property(
-									'id',
-									fx.services['intel-nuc_service1'].id,
-								);
+								expect(service).to.have.property('id', targetService.id);
 								expect(service).to.have.property('service_name', 'main');
 							});
 						});
@@ -298,29 +347,21 @@ export default () => {
 				);
 			});
 
-			it('should provision with a linked ESR hostapp', async () => {
-				const devicePatchBody = {
+			it('should fail to PATCH intel-nuc device to raspberrypi3 hostapp', async () => {
+				// given a device w/ a linked hostApp
+				await device1.patchStateV2({
 					local: {
-						os_version: 'balenaOS 2021.01.0',
+						os_version: 'balenaOS 2.50.0+rev1',
 						os_variant: 'prod',
 					},
-				};
+				});
+				await expectResourceToMatch(pineUser, 'device', device1.id, {
+					should_be_operated_by__release: { __id: nuc2_50_0_rev1prodId },
+				});
 
-				await esrDevice.patchStateV2(devicePatchBody);
-				const { body } = await supertest(admin)
-					.get(
-						`/${version}/device(${esrDevice.id})?$select=should_be_operated_by__release`,
-					)
-					.expect(200);
-				expect(body.d[0]).to.not.be.undefined;
-				expect(body.d[0]).to.have.property('should_be_operated_by__release')
-					.that.is.not.null;
-			});
-
-			it('should fail to PATCH intel-nuc device to raspberrypi3 hostapp', async () => {
 				await supertest(admin)
-					.patch(`/${version}/device(${device.id})`)
-					.send({ should_be_operated_by__release: raspberryPiHostappReleaseId })
+					.patch(`/${version}/device(${device1.id})`)
+					.send({ should_be_operated_by__release: rpi3hostAppReleaseId })
 					.expect(
 						400,
 						'"It is necessary that each release that should operate a device that is of a device type, belongs to an application that is host and is for the device type."',
@@ -329,7 +370,7 @@ export default () => {
 
 			it('should fail to PATCH intel-nuc device to a failed hostapp release', async () => {
 				await supertest(admin)
-					.patch(`/${version}/device(${device.id})`)
+					.patch(`/${version}/device(${device1.id})`)
 					.send({
 						should_be_operated_by__release: failedIntelNucHostAppReleaseId,
 					})
@@ -340,74 +381,81 @@ export default () => {
 					);
 			});
 
-			it('should succeed in PATCHing device to greater version', async () => {
-				await supertest(admin)
-					.patch(`/${version}/device(${device.id})`)
-					.send({ should_be_operated_by__release: upgradeReleaseId })
-					.expect(200);
-				const { body } = await supertest(admin).get(
-					`/${version}/device(${device.id})?$select=should_be_operated_by__release`,
-				);
-				expect(body.d[0]).to.not.be.undefined;
-				expect(body.d[0]['should_be_operated_by__release'].__id).to.equal(
-					upgradeReleaseId,
-				);
-			});
+			(
+				[
+					[
+						'semver & release_tag',
+						'balenaOS 2.51.0+rev1',
+						() => nuc2_51_0_rev1prodTagAndSemverId,
+					],
+					[
+						'semver only',
+						'balenaOS 2.51.0+rev2',
+						() => nuc2_51_0_rev2prodSemverOnlyId,
+					],
+				] as const
+			).forEach(([titlePart, osVersion, getUpgradeReleaseId]) => {
+				it(`should succeed in PATCHing device to a greater version (with ${titlePart})`, async () => {
+					await supertest(admin)
+						.patch(`/${version}/device(${device1.id})`)
+						.send({ should_be_operated_by__release: getUpgradeReleaseId() })
+						.expect(200);
+					await expectResourceToMatch(pineUser, 'device', device1.id, {
+						should_be_operated_by__release: { __id: getUpgradeReleaseId() },
+					});
+				});
 
-			it('should fail to downgrade', async () => {
-				await supertest(admin)
-					.patch(`/${version}/device(${device.id})`)
-					.send({ should_be_operated_by__release: prodNucHostappReleaseId })
-					.expect(400, '"Attempt to downgrade hostapp, which is not allowed"');
-			});
+				it(`should fail to downgrade (when on a release with ${titlePart})`, async () => {
+					await supertest(admin)
+						.patch(`/${version}/device(${device1.id})`)
+						.send({ should_be_operated_by__release: nuc2_50_0_rev1prodId })
+						.expect(
+							400,
+							'"Attempt to downgrade hostapp, which is not allowed"',
+						);
+				});
 
-			it('should remove target preprovisioned hostapp, if it is an implied downgrade', async () => {
-				// if a device is preprovisioned and pinned to a release
-				// less than the version it initially checks in with, make sure the downgrade doesn't persist
-				const { body } = await supertest(admin)
-					.get(
-						`/${version}/device(${preprovisionedDevice.id})?$select=should_be_operated_by__release`,
-					)
-					.expect(200);
-				expect(body.d[0]).to.have.property(
-					'should_be_operated_by__release',
-					null,
-				);
+				it(`should move the device from older preprovisioned OS release, to the upgraded release reported in state patch (using ${titlePart})`, async () => {
+					// if a device is preprovisioned and pinned to a release with a semver
+					// less than the version it initially checks in with, we need to clear
+					// the old hostApp release, otherwise the model would imply a scheduled OS downgrade.
+					const preprovisionedDevice = await fakeDevice.provisionDevice(
+						admin,
+						applicationId,
+					);
+					await supertest(admin)
+						.patch(`/${version}/device(${preprovisionedDevice.id})`)
+						.send({ should_be_operated_by__release: nuc2_50_0_rev1prodId })
+						.expect(200);
 
-				await supertest(admin)
-					.patch(`/${version}/device(${preprovisionedDevice.id})`)
-					.send({ should_be_operated_by__release: prodNucHostappReleaseId })
-					.expect(200);
-				const devicePatchBody = {
-					local: {
+					// run the actual test
+					const devicePatchBody = {
 						// this version is greater than the one provided by prodNucHostappReleaseId
-						os_version: 'balenaOS 2.50.1+rev1',
-						os_variant: 'prod',
-					},
-				};
-				await preprovisionedDevice.patchStateV2(devicePatchBody);
-				const body2 = await supertest(admin)
-					.get(
-						`/${version}/device(${preprovisionedDevice.id})?$select=should_be_operated_by__release`,
-					)
-					.expect(200);
-				expect(body2.body.d[0]['should_be_operated_by__release'].__id).to.equal(
-					upgradeReleaseId,
-				);
+						local: {
+							os_version: osVersion,
+							os_variant: 'prod',
+						},
+					};
+					await preprovisionedDevice.patchStateV2(devicePatchBody);
+					await expectResourceToMatch(
+						pineUser,
+						'device',
+						preprovisionedDevice.id,
+						{
+							should_be_operated_by__release: { __id: getUpgradeReleaseId() },
+						},
+					);
+				});
 			});
 
 			it('should succeed in PATCHing device to ESR release', async () => {
 				await supertest(admin)
-					.patch(`/${version}/device(${device.id})`)
-					.send({ should_be_operated_by__release: esrHostappReleaseId })
+					.patch(`/${version}/device(${device1.id})`)
+					.send({ should_be_operated_by__release: esrTagOnlyHostAppReleaseId })
 					.expect(200);
-				const { body } = await supertest(admin).get(
-					`/${version}/device(${device.id})?$select=should_be_operated_by__release`,
-				);
-				expect(body.d[0]).to.not.be.undefined;
-				expect(body.d[0]['should_be_operated_by__release'].__id).to.equal(
-					esrHostappReleaseId,
-				);
+				await expectResourceToMatch(pineUser, 'device', device1.id, {
+					should_be_operated_by__release: { __id: esrTagOnlyHostAppReleaseId },
+				});
 			});
 
 			it('should still provision with a nonexistent hostapp', async () => {
@@ -433,64 +481,104 @@ export default () => {
 				expect(body.d[0]['os_variant']).to.be.not.null;
 			});
 
-			it('should provision with an invalidated hostapp release', async () => {
-				const devicePatchBody = {
-					local: {
-						os_version: 'balenaOS 2.52.0+rev1',
-						os_variant: 'prod',
-					},
-				};
+			(
+				[
+					[
+						'release_tag only',
+						'balenaOS 2.52.0+rev1',
+						() => invalidatedTagOnlyReleaseId,
+					],
+					[
+						'semver only',
+						'balenaOS 2.52.1+rev1',
+						() => invalidatedSemverOnlyReleaseId,
+					],
+				] as const
+			).forEach(([osTypeTitlePart, initialOsVersion, getHostAppReleaseId]) => {
+				it(`should provision with an invalidated ${osTypeTitlePart} hostapp release`, async () => {
+					const invalidatedReleaseDevice = await fakeDevice.provisionDevice(
+						admin,
+						applicationId,
+					);
+					const initialInvalidatedReleaseId = getHostAppReleaseId();
+					await invalidatedReleaseDevice.patchStateV2({
+						local: {
+							os_version: initialOsVersion,
+							os_variant: 'prod',
+						},
+					});
+					await expectResourceToMatch(
+						pineUser,
+						'device',
+						invalidatedReleaseDevice.id,
+						{
+							os_version: initialOsVersion,
+							os_variant: 'prod',
+							should_be_operated_by__release: {
+								__id: initialInvalidatedReleaseId,
+							},
+						},
+					);
 
-				await invalidatedReleaseDevice.patchStateV2(devicePatchBody);
-				const { body } = await supertest(admin)
-					.get(
-						`/${version}/device(${invalidatedReleaseDevice.id})?$select=should_be_operated_by__release`,
-					)
-					.expect(200);
-				expect(body.d[0]).to.not.be.undefined;
-				expect(body.d[0]['should_be_operated_by__release'].__id).to.equal(
-					invalidatedReleaseId,
-				);
-				expect(body.d[0]['os_version']).to.be.not.null;
-				expect(body.d[0]['os_variant']).to.be.not.null;
-				const supervisorVersion = 'v12.3.5';
-				const devicePatchBody2 = {
-					local: {
-						supervisor_version: supervisorVersion,
-					},
-				};
-
-				await invalidatedReleaseDevice.patchStateV2(devicePatchBody2);
-				// after provisioning to our invalidated release, let's make sure we're not blocked
-				// in further PATCHing (using supervisor_version here as a proxy/dummy value)
-				const resp = await supertest(admin)
-					.get(
-						`/${version}/device(${invalidatedReleaseDevice.id})?$select=supervisor_version`,
-					)
-					.expect(200);
-				expect(resp.body.d[0]['supervisor_version']).to.equal(
-					supervisorVersion,
-				);
+					const supervisorVersion = 'v12.3.5';
+					const newOsVersion = 'balenaOS 2.88.5+rev1';
+					await invalidatedReleaseDevice.patchStateV2({
+						local: {
+							supervisor_version: supervisorVersion,
+							os_version: newOsVersion,
+							os_variant: 'prod',
+						},
+					});
+					// after provisioning to our invalidated release, let's make sure we're not blocked
+					// in further PATCHing (ie there is no rule/hook blocking the device from working)
+					await expectResourceToMatch(
+						pineUser,
+						'device',
+						invalidatedReleaseDevice.id,
+						{
+							supervisor_version: supervisorVersion,
+							os_version: newOsVersion,
+							os_variant: 'prod',
+							// Atm the should_be_operated_by__release is only updated when the device provisions.
+							// We might change this during the scheduled or tri-app HUP.
+							should_be_operated_by__release: {
+								__id: initialInvalidatedReleaseId,
+							},
+						},
+					);
+				});
 			});
 
 			it('should be able to invalidate a release with devices attached', async () => {
+				await device2.patchStateV2({
+					local: {
+						os_version: 'balenaOS 2.50.0+rev1',
+						os_variant: 'prod',
+					},
+				});
+				await expectResourceToMatch(pineUser, 'device', device2.id, {
+					should_be_operated_by__release: { __id: nuc2_50_0_rev1prodId },
+				});
+
 				await supertest(admin)
-					.patch(`/${version}/release(${prodNucHostappReleaseId})`)
+					.patch(`/${version}/release(${nuc2_50_0_rev1prodId})`)
 					.send({ is_invalidated: true })
 					.expect(200);
 				const { body } = await supertest(admin)
-					.get(`/${version}/release(${prodNucHostappReleaseId})`)
+					.get(`/${version}/release(${nuc2_50_0_rev1prodId})`)
 					.expect(200);
 				expect(body.d[0].is_invalidated).to.be.true;
 			});
 
 			it('should not be able to upgrade to an invalidated release', async () => {
 				await supertest(admin)
-					.patch(`/${version}/device(${device.id})`)
-					.send({ should_be_operated_by__release: prodNucHostappReleaseId })
+					.patch(`/${version}/device(${device2.id})`)
+					.send({
+						should_be_operated_by__release: invalidatedSemverOnlyReleaseId,
+					})
 					.expect(
 						400,
-						`"Could not find a hostapp release with this ID ${prodNucHostappReleaseId}"`,
+						`"Could not find a hostapp release with this ID ${invalidatedSemverOnlyReleaseId}"`,
 					);
 			});
 
@@ -502,12 +590,12 @@ export default () => {
 					.expect(200);
 				expect(body.d[0]['id']).to.be.not.null;
 				await supertest(admin)
-					.patch(`/${version}/device(${device.id})`)
+					.patch(`/${version}/device(${device2.id})`)
 					.send({ is_of__device_type: body.d[0]['id'] })
 					.expect(200);
 				const { body: dev } = await supertest(admin)
 					.get(
-						`/${version}/device(${device.id})?$select=should_be_operated_by__release`,
+						`/${version}/device(${device2.id})?$select=should_be_operated_by__release`,
 					)
 					.expect(200);
 				expect(dev.d[0].should_be_operated_by__release).to.be.null;

--- a/test/fixtures/15-target-hostapps/images.json
+++ b/test/fixtures/15-target-hostapps/images.json
@@ -1,29 +1,50 @@
 {
-	"nucRelease0Image": {
+	"nucRelease2_50_0_rev1Image": {
 		"user": "admin",
 		"service": "intel-nuc_service1",
-		"releases": [ "release0" ],
+		"releases": [ "release2_50_0_rev1" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
-	"release1Image": {
+	"rpi3releaseImage": {
 		"user": "admin",
 		"service": "raspberrypi3_service1",
-		"releases": [ "release1" ],
+		"releases": [ "rpi3release" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
-	"nucRelease2Image": {
+	"release2_51_0_rev1Image": {
 		"user": "admin",
 		"service": "intel-nuc_service1",
-		"releases": [ "release2" ],
+		"releases": [ "release2_51_0_rev1" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
-	"release3Image": {
+	"release2_51_0_rev2Image": {
+		"user": "admin",
+		"service": "intel-nuc_service1",
+		"releases": [ "release2_51_0_rev2" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"releaseNucEsrTagOnlyImage": {
 		"user": "admin",
 		"service": "intel-nuc-esr_service1",
-		"releases": [ "release3" ],
+		"releases": [ "releaseNucEsrTagOnly" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"releaseNucEsrUnifiedImage": {
+		"user": "admin",
+		"service": "intel-nuc-esr_service1",
+		"releases": [ "releaseNucEsrUnified" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"releaseNucEsrSemverOnlyImage": {
+		"user": "admin",
+		"service": "intel-nuc-esr_service1",
+		"releases": [ "releaseNucEsrSemverOnly" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
@@ -34,10 +55,17 @@
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
-	"nucRelease5Image": {
+	"nucReleaseInvalidated2_52_0_rev1TagOnlyImage": {
 		"user": "admin",
 		"service": "intel-nuc_service1",
-		"releases": [ "release5" ],
+		"releases": [ "releaseNucInvalidated2_52_0_rev1TagOnly" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"nucReleaseInvalidated2_52_1rev1SemverOnlyImage": {
+		"user": "admin",
+		"service": "intel-nuc_service1",
+		"releases": [ "releaseNucInvalidated2_52_1rev1SemverOnly" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
@@ -48,10 +76,45 @@
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	},
-	"nucUnifiedReleaseImage": {
+	"unified2_88_4ReleaseImage": {
 		"user": "admin",
 		"service": "intel-nuc_service1",
-		"releases": [ "unifiedRelease" ],
+		"releases": [ "unified2_88_4Release" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"unified2_88_5SemverOnlyReleaseImage": {
+		"user": "admin",
+		"service": "intel-nuc_service1",
+		"releases": [ "unified2_88_5SemverOnlyRelease" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"unified2_88_5_rev1SemverOnlyReleaseImage": {
+		"user": "admin",
+		"service": "intel-nuc_service1",
+		"releases": [ "unified2_88_5_rev1SemverOnlyRelease" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"nucDraft2_90_0TagOnlyImage": {
+		"user": "admin",
+		"service": "intel-nuc_service1",
+		"releases": [ "nucDraft2_90_0TagOnly" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"nucDraft2_90_1SemverOnlyImage": {
+		"user": "admin",
+		"service": "intel-nuc_service1",
+		"releases": [ "nucDraft2_90_1SemverOnly" ],
+		"project_type": "Dockerfile.template",
+		"status": "success"
+	},
+	"nucDraft2_90_1rev1SemverOnlyImage": {
+		"user": "admin",
+		"service": "intel-nuc_service1",
+		"releases": [ "nucDraft2_90_1rev1SemverOnly" ],
 		"project_type": "Dockerfile.template",
 		"status": "success"
 	}

--- a/test/fixtures/15-target-hostapps/release_tags.json
+++ b/test/fixtures/15-target-hostapps/release_tags.json
@@ -1,39 +1,27 @@
 {
-	"releasetag0-variant": {
+	"release2_50_0_rev1-variant": {
 		"user": "admin",
-		"release": "release0",
+		"release": "release2_50_0_rev1",
 		"tag_key": "variant",
 		"value": "production"
 	},
-	"releasetag0-version": {
+	"release2_50_0_rev1-version": {
 		"user": "admin",
-		"release": "release0",
+		"release": "release2_50_0_rev1",
 		"tag_key": "version",
 		"value": "2.50.0+rev1"
 	},
-	"releasetag1-variant": {
+	"rpi3releasetag1-variant": {
 		"user": "admin",
-		"release": "release1",
+		"release": "rpi3release",
 		"tag_key": "variant",
 		"value": "production"
 	},
-	"releasetag1-version": {
+	"rpi3releasetag1-version": {
 		"user": "admin",
-		"release": "release1",
+		"release": "rpi3release",
 		"tag_key": "version",
 		"value": "2.50.0+rev1"
-	},
-	"releasetag2-variant": {
-		"user": "admin",
-		"release": "release2",
-		"tag_key": "variant",
-		"value": "production"
-	},
-	"releasetag2-version": {
-		"user": "admin",
-		"release": "release2",
-		"tag_key": "version",
-		"value": "2.50.1+rev1"
 	},
 	"releaseIntelNucFailedTag2-variant": {
 		"user": "admin",
@@ -45,19 +33,37 @@
 		"user": "admin",
 		"release": "releaseIntelNucFailed",
 		"tag_key": "version",
-		"value": "2.50.1+rev1"
+		"value": "2.51.0+rev1"
 	},
-	"releasetag3-variant": {
+	"release2_51_0_rev1-variant": {
 		"user": "admin",
-		"release": "release3",
+		"release": "release2_51_0_rev1",
 		"tag_key": "variant",
 		"value": "production"
 	},
-	"releasetag3-version": {
+	"release2_51_0_rev1-version": {
 		"user": "admin",
-		"release": "release3",
+		"release": "release2_51_0_rev1",
+		"tag_key": "version",
+		"value": "2.51.0+rev1"
+	},
+	"releaseNucEsrTagOnly-variant": {
+		"user": "admin",
+		"release": "releaseNucEsrTagOnly",
+		"tag_key": "variant",
+		"value": "production"
+	},
+	"releaseNucEsrTagOnly-version": {
+		"user": "admin",
+		"release": "releaseNucEsrTagOnly",
 		"tag_key": "version",
 		"value": "2021.01.0"
+	},
+	"releaseNucEsrUnified-version": {
+		"user": "admin",
+		"release": "releaseNucEsrUnified",
+		"tag_key": "version",
+		"value": "2023.1.0"
 	},
 	"releasetag4-variant": {
 		"user": "admin",
@@ -71,15 +77,15 @@
 		"tag_key": "version",
 		"value": "2.50.0+rev1"
 	},
-	"releasetag5-variant": {
+	"releaseNucInvalidated2_52_0_rev1TagOnly-variant": {
 		"user": "admin",
-		"release": "release5",
+		"release": "releaseNucInvalidated2_52_0_rev1TagOnly",
 		"tag_key": "variant",
 		"value": "production"
 	},
-	"releasetag5-version": {
+	"releaseNucInvalidated2_52_0_rev1TagOnly-version": {
 		"user": "admin",
-		"release": "release5",
+		"release": "releaseNucInvalidated2_52_0_rev1TagOnly",
 		"tag_key": "version",
 		"value": "2.52.0+rev1"
 	},
@@ -95,10 +101,16 @@
 		"tag_key": "version",
 		"value": "2.53.0+rev1"
 	},
-	"unifiedReleaseTag-version": {
+	"unified2_88_4Release-version": {
 		"user": "admin",
-		"release": "unifiedRelease",
+		"release": "unified2_88_4Release",
 		"tag_key": "version",
 		"value": "2.88.4"
+	},
+	"nucDraft2_90_0TagOnly-version": {
+		"user": "admin",
+		"release": "nucDraft2_90_0TagOnly",
+		"tag_key": "version",
+		"value": "2.90.0"
 	}
 }

--- a/test/fixtures/15-target-hostapps/releases.json
+++ b/test/fixtures/15-target-hostapps/releases.json
@@ -1,37 +1,72 @@
 {
-	"release0": {
+	"release2_50_0_rev1": {
+		"notes": "release_tag only",
 		"application": "intel-nuc",
 		"composition": {},
 		"source": "cloud",
 		"status": "success",
 		"user": "admin"
 	},
-	"release1": {
+	"rpi3release": {
 		"application": "raspberrypi3",
 		"composition": {},
 		"source": "cloud",
 		"status": "success",
 		"user": "admin"
 	},
-	"release2": {
-		"application": "intel-nuc",
-		"composition": {},
-		"source": "cloud",
-		"status": "success",
-		"user": "admin"
-	},
 	"releaseIntelNucFailed": {
+		"notes": "failed with release_tag and semver",
 		"application": "intel-nuc",
 		"composition": {},
 		"source": "cloud",
 		"status": "failed",
+		"semver": "2.51.0",
+		"variant": "prod",
 		"user": "admin"
 	},
-	"release3": {
+	"release2_51_0_rev1": {
+		"createAfterRelease": "releaseIntelNucFailed",
+		"notes": "release_tag and semver",
+		"application": "intel-nuc",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"semver": "2.51.0+rev1",
+		"variant": "prod",
+		"user": "admin"
+	},
+	"release2_51_0_rev2": {
+		"createAfterRelease": "release2_51_0_rev1",
+		"notes": "semver only",
+		"application": "intel-nuc",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"semver": "2.51.0+rev2",
+		"variant": "prod",
+		"user": "admin"
+	},
+	"releaseNucEsrTagOnly": {
 		"application": "intel-nuc-esr",
 		"composition": {},
 		"source": "cloud",
 		"status": "success",
+		"user": "admin"
+	},
+	"releaseNucEsrUnified": {
+		"application": "intel-nuc-esr",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"semver": "2023.1.0",
+		"user": "admin"
+	},
+	"releaseNucEsrSemverOnly": {
+		"application": "intel-nuc-esr",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"semver": "2023.10.0",
 		"user": "admin"
 	},
 	"release4": {
@@ -41,11 +76,34 @@
 		"status": "success",
 		"user": "admin"
 	},
-	"release5": {
+	"releaseNucInvalidated2_52_0_rev1TagOnly": {
 		"application": "intel-nuc",
 		"composition": {},
 		"source": "cloud",
 		"status": "success",
+		"is_invalidated": true,
+		"user": "admin"
+	},
+	"releaseNucFailed2_52_1SemverOnly": {
+		"note": "remove this release once we allow skipping revisions",
+		"application": "intel-nuc",
+		"composition": {},
+		"source": "cloud",
+		"status": "failed",
+		"semver": "2.52.1",
+		"variant": "prod",
+		"is_invalidated": true,
+		"user": "admin"
+	},
+	"releaseNucInvalidated2_52_1rev1SemverOnly": {
+		"createAfterRelease": "releaseNucFailed2_52_1SemverOnly",
+		"note": "remove this release once we allow skipping revisions",
+		"application": "intel-nuc",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"semver": "2.52.1+rev1",
+		"variant": "prod",
 		"is_invalidated": true,
 		"user": "admin"
 	},
@@ -57,12 +115,56 @@
 		"is_invalidated": true,
 		"user": "admin"
 	},
-	"unifiedRelease": {
+	"unified2_88_4Release": {
 		"application": "intel-nuc",
 		"composition": {},
 		"source": "cloud",
 		"status": "success",
-		"is_invalidated": true,
+		"semver": "2.88.4",
+		"user": "admin"
+	},
+	"unified2_88_5SemverOnlyRelease": {
+		"application": "intel-nuc",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"semver": "2.88.5",
+		"user": "admin"
+	},
+	"unified2_88_5_rev1SemverOnlyRelease": {
+		"createAfterRelease": "unified2_88_5SemverOnlyRelease",
+		"application": "intel-nuc",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"semver": "2.88.5+rev1",
+		"user": "admin"
+	},
+	"nucDraft2_90_0TagOnly": {
+		"application": "intel-nuc",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"is_final": false,
+		"user": "admin"
+	},
+	"nucDraft2_90_1SemverOnly": {
+		"application": "intel-nuc",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"is_final": false,
+		"semver": "2.90.1",
+		"user": "admin"
+	},
+	"nucDraft2_90_1rev1SemverOnly": {
+		"createAfterRelease": "nucDraft2_90_1SemverOnly",
+		"application": "intel-nuc",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"is_final": false,
+		"semver": "2.90.1+rev1",
 		"user": "admin"
 	}
 }

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -198,6 +198,7 @@ const loaders: types.Dictionary<LoaderFunc> = {
 					'source',
 					'release_version',
 					'semver',
+					'variant',
 					'is_invalidated',
 					'is_final',
 					'is_passing_tests',


### PR DESCRIPTION
Change-type: minor
See: https://balena.fibery.io/Work/Project/Remove-hostApp-version-release-tag-dependencies-226
See: https://balena.fibery.io/Work/Improvement/Start-using-the-release-semver-fields-for-hostapp-validation-in-the-API-along-with-release_tags-1447
See: https://balena.fibery.io/Work/Task/Use-the-release-semver-fields-along-with-release_tags-in-hostApp-operations-1840