### PR TITLE
Update @balena/pinejs to enable ISODatestring as internal pine API interface for date and date time fields.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@balena/env-parsing": "^1.1.10",
         "@balena/es-version": "^1.0.3",
         "@balena/node-metrics-gatherer": "^6.0.3",
-        "@balena/pinejs": "^15.6.1",
+        "@balena/pinejs": "^16.0.0",
         "@balena/pinejs-webresource-cloudfront": "^0.0.5",
         "@sentry/node": "^7.99.0",
         "@types/basic-auth": "^1.1.8",
@@ -1334,6 +1334,85 @@
       }
     },
     "node_modules/@balena/pinejs": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@balena/pinejs/-/pinejs-16.0.0.tgz",
+      "integrity": "sha512-4kgcsZcvEmjm9+qjLF2w04S2zb41RNs+qBGITaNhZ81pj0nhozkqFkT7/bWBINHjCrF7ew1WrRv3IXhl9/1rHg==",
+      "dependencies": {
+        "@balena/abstract-sql-compiler": "^9.0.4",
+        "@balena/abstract-sql-to-typescript": "^2.1.3",
+        "@balena/env-parsing": "^1.1.10",
+        "@balena/lf-to-abstract-sql": "^5.0.1",
+        "@balena/odata-parser": "^3.0.3",
+        "@balena/odata-to-abstract-sql": "^6.2.3",
+        "@balena/sbvr-parser": "^1.4.3",
+        "@balena/sbvr-types": "^7.0.1",
+        "@types/body-parser": "^1.19.5",
+        "@types/compression": "^1.7.5",
+        "@types/cookie-parser": "^1.4.6",
+        "@types/deep-freeze": "^0.1.5",
+        "@types/express": "^4.17.21",
+        "@types/express-session": "^1.17.10",
+        "@types/lodash": "^4.14.202",
+        "@types/memoizee": "^0.4.11",
+        "@types/method-override": "^0.0.35",
+        "@types/multer": "^1.4.11",
+        "@types/mysql": "^2.15.25",
+        "@types/node": "^20.11.2",
+        "@types/passport": "^1.0.16",
+        "@types/passport-local": "^1.0.38",
+        "@types/passport-strategy": "^0.2.38",
+        "@types/pg": "^8.10.9",
+        "@types/randomstring": "^1.1.11",
+        "@types/websql": "^0.0.30",
+        "busboy": "^1.6.0",
+        "commander": "^11.1.0",
+        "deep-freeze": "^0.0.1",
+        "eventemitter3": "^5.0.1",
+        "express-session": "^1.17.3",
+        "lodash": "^4.17.21",
+        "memoizee": "^0.4.15",
+        "pinejs-client-core": "^6.14.0",
+        "randomstring": "^1.3.0",
+        "typed-error": "^3.2.2"
+      },
+      "bin": {
+        "abstract-sql-compiler": "bin/abstract-sql-compiler.js",
+        "odata-compiler": "bin/odata-compiler.js",
+        "sbvr-compiler": "bin/sbvr-compiler.js"
+      },
+      "engines": {
+        "node": ">=16.13.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/client-s3": "^3.490.0",
+        "@aws-sdk/lib-storage": "^3.490.0",
+        "@aws-sdk/s3-request-presigner": "^3.490.0",
+        "bcrypt": "^5.1.1",
+        "body-parser": "^1.20.2",
+        "compression": "^1.7.4",
+        "cookie-parser": "^1.4.6",
+        "express": "^4.18.2",
+        "method-override": "^3.0.0",
+        "mysql": "^2.18.1",
+        "passport": "^0.7.0",
+        "passport-local": "^1.0.0",
+        "pg": "^8.11.3",
+        "pg-connection-string": "^2.6.2",
+        "serve-static": "^1.15.0"
+      }
+    },
+    "node_modules/@balena/pinejs-webresource-cloudfront": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@balena/pinejs-webresource-cloudfront/-/pinejs-webresource-cloudfront-0.0.5.tgz",
+      "integrity": "sha512-mE9KX2yqs49abmpTU6ZZ9PlOhVK8jo6wMZ/GlOKAZp8+hKzLs6w5T7N9aPJziMNncM0qASdBsTufC3ZUPR84ig==",
+      "dependencies": {
+        "@aws-sdk/cloudfront-signer": "^3.398.0",
+        "@balena/pinejs": "^15.3.3",
+        "memoizee": "^0.4.15"
+      }
+    },
+    "node_modules/@balena/pinejs-webresource-cloudfront/node_modules/@balena/pinejs": {
       "version": "15.6.3",
       "resolved": "https://registry.npmjs.org/@balena/pinejs/-/pinejs-15.6.3.tgz",
       "integrity": "sha512-CTvoOsVfBzZOYTPx2TB3SiFw9Bglq5WXwR9oTtuvfjVZvgFIm7ddh4oza+Z7hhWvTAHHEzemXsTDso7iPzXCFw==",
@@ -1402,17 +1481,7 @@
         "serve-static": "^1.15.0"
       }
     },
-    "node_modules/@balena/pinejs-webresource-cloudfront": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@balena/pinejs-webresource-cloudfront/-/pinejs-webresource-cloudfront-0.0.5.tgz",
-      "integrity": "sha512-mE9KX2yqs49abmpTU6ZZ9PlOhVK8jo6wMZ/GlOKAZp8+hKzLs6w5T7N9aPJziMNncM0qASdBsTufC3ZUPR84ig==",
-      "dependencies": {
-        "@aws-sdk/cloudfront-signer": "^3.398.0",
-        "@balena/pinejs": "^15.3.3",
-        "memoizee": "^0.4.15"
-      }
-    },
-    "node_modules/@balena/pinejs/node_modules/@balena/sbvr-types": {
+    "node_modules/@balena/pinejs-webresource-cloudfront/node_modules/@balena/sbvr-types": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@balena/sbvr-types/-/sbvr-types-6.1.1.tgz",
       "integrity": "sha512-jHSJDM1iuS65QGXcJK7laz0tz95oERn4ySWXXv2f7MHlLyW3XKlS2gxTHvWb3yrhpHmC8RFZvfpaR8rFXhyftg==",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@balena/env-parsing": "^1.1.10",
     "@balena/es-version": "^1.0.3",
     "@balena/node-metrics-gatherer": "^6.0.3",
-    "@balena/pinejs": "^15.6.1",
+    "@balena/pinejs": "^16.0.0",
     "@balena/pinejs-webresource-cloudfront": "^0.0.5",
     "@sentry/node": "^7.99.0",
     "@types/basic-auth": "^1.1.8",

--- a/test/08_api-keys.ts
+++ b/test/08_api-keys.ts
@@ -155,9 +155,8 @@ export default () => {
 						);
 
 						expect(apiKeyResp).to.have.property('expiry_date');
-						expect(apiKeyResp!.expiry_date.getTime()).to.equal(
-							tomorrowDate.getTime(),
-						);
+						const expiryDate = new Date(apiKeyResp!.expiry_date);
+						expect(expiryDate.getTime()).to.equal(tomorrowDate.getTime());
 					});
 
 					it('should not be able to create a provisioning key with a in-valid expiry date', async function () {


### PR DESCRIPTION

Fix usage of `DateString` to actually as DateString and not as a `Date`

This is a major change as the exported internal API reference from `open-balena-api` when used as module breaks the type interface. The model types have always been generated as `string` but actually returned as `Date`.

Change-type: major