### PR TITLE
Drop superseded release versioning index

### DIFF
--- a/src/balena-init.sql
+++ b/src/balena-init.sql
@@ -162,9 +162,7 @@ ON "image" USING GIN ("is stored at-image location" gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS "release_id_belongs_to_app_status_idx"
 ON "release" ("id", "belongs to-application", "status");
 
--- Optimization for the app-semver-revision uniqueness rule and for computing the next revision
-CREATE INDEX IF NOT EXISTS "release_belongs_to_app_revision_semver_idx"
-ON "release" ("belongs to-application", "revision", "semver major", "semver minor", "semver patch"); -- TODO: Drop this in a follow-up PR.
+-- Optimization for the app-semver-revision uniqueness rule, computing the next revision & the target hostApp release
 CREATE INDEX IF NOT EXISTS "release_belongs_to_app_revision_semver_prerelease_variant_idx"
 ON "release" ("belongs to-application", "revision", "semver major", "semver minor", "semver patch", "semver prerelease", "variant");
 

--- a/src/migrations/00086-drop-superseded-release-semver-index.sql
+++ b/src/migrations/00086-drop-superseded-release-semver-index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "release_belongs_to_app_revision_semver_idx";


### PR DESCRIPTION
On the environments I tested (primarily writer, but readers as well)
pg_stat_all_indexes shows the longer index (release_belongs_to_app_revision_semver_prerelease_variant_idx)
being used at least 2000x more often, and
surprisingly enough being slightly smaller as well, which I guess might mean that the old index has bloat.

Change-type: patch