### PR TITLE
Move device additions tests to relevant repository

### DIFF
--- a/test/24_device_additions.ts
+++ b/test/24_device_additions.ts
@@ -1,0 +1,169 @@
+import { expect } from 'chai';
+import type { PineTest } from 'pinejs-client-supertest';
+import * as fixtures from './test-lib/fixtures.js';
+import { type UserObjectParam, supertest } from './test-lib/supertest.js';
+import * as versions from './test-lib/versions.js';
+
+export default () => {
+	versions.test(function (version, pineTest) {
+		const testOverallStatus = async (
+			user: UserObjectParam,
+			deviceId: number,
+			overallStatus: string,
+		) => {
+			const {
+				body: {
+					d: [device],
+				},
+			} = await supertest(user)
+				.get(
+					`/${version}/device(${deviceId})?$select=overall_status,id,is_online,api_heartbeat_state,overall_progress`,
+				)
+				.expect(200);
+
+			expect(device).to.have.property('overall_status', overallStatus);
+		};
+
+		describe('Device additions', function () {
+			let pineUser: PineTest;
+			const ctx: AnyObject = {};
+			before(async () => {
+				const fx = await fixtures.load('24-device-additions');
+				ctx.loadedFixtures = fx;
+				ctx.user = fx.users.admin;
+
+				ctx.deviceUpdating = fx.devices.deviceUpdating;
+				ctx.deviceVpnOnHeartbeatOnline = fx.devices.deviceVpnOnHeartbeatOnline;
+				ctx.deviceVpnOnHeartbeatTimeout =
+					fx.devices.deviceVpnOnHeartbeatTimeout;
+				ctx.deviceVpnOnHeartbeatOffline =
+					fx.devices.deviceVpnOnHeartbeatOffline;
+
+				ctx.deviceVpnOffHeartbeatOnline =
+					fx.devices.deviceVpnOffHeartbeatOnline;
+				ctx.deviceVpnOffHeartbeatTimeout =
+					fx.devices.deviceVpnOffHeartbeatTimeout;
+				ctx.deviceVpnOffHeartbeatOffline =
+					fx.devices.deviceVpnOffHeartbeatOffline;
+
+				pineUser = pineTest.clone({ passthrough: { user: ctx.user } });
+
+				// Turn the devices on & off, so that they are no longer configuring
+				const vpnOfflineDevicesFilter = {
+					id: {
+						$in: [
+							ctx.deviceVpnOffHeartbeatOnline,
+							ctx.deviceVpnOffHeartbeatTimeout,
+							ctx.deviceVpnOffHeartbeatOffline,
+						].map((d) => d.id),
+					},
+				};
+				await pineUser
+					.patch({
+						resource: 'device',
+						options: {
+							$filter: vpnOfflineDevicesFilter,
+						},
+						body: {
+							is_online: true,
+						},
+					})
+					.expect(200);
+
+				await pineUser
+					.patch({
+						resource: 'device',
+						options: {
+							$filter: vpnOfflineDevicesFilter,
+						},
+						body: {
+							is_online: false,
+						},
+					})
+					.expect(200);
+			});
+
+			after(async () => {
+				await fixtures.clean(ctx.loadedFixtures);
+			});
+
+			describe('overall_status & overall_progress', () => {
+				describe('Given a device connected to the vpn', () => {
+					it('should have an Idle overall_status when the heartbeat is Online', async () => {
+						await testOverallStatus(
+							ctx.user,
+							ctx.deviceVpnOnHeartbeatOnline.id,
+							'idle',
+						);
+					});
+
+					it('should have an Idle overall_status when the heartbeat is Timeout', async () => {
+						await testOverallStatus(
+							ctx.user,
+							ctx.deviceVpnOnHeartbeatTimeout.id,
+							'idle',
+						);
+					});
+
+					it('should have an Idle overall_status when the heartbeat is Offline', async () => {
+						await testOverallStatus(
+							ctx.user,
+							ctx.deviceVpnOnHeartbeatOffline.id,
+							'idle',
+						);
+					});
+				});
+
+				describe('Given a device disconnected from the vpn', () => {
+					it('should have an Idle overall_status when the heartbeat is Online', async () => {
+						await testOverallStatus(
+							ctx.user,
+							ctx.deviceVpnOffHeartbeatOnline.id,
+							'idle',
+						);
+					});
+
+					it('should have an Idle overall_status when the heartbeat is Timeout', async () => {
+						await testOverallStatus(
+							ctx.user,
+							ctx.deviceVpnOffHeartbeatTimeout.id,
+							'idle',
+						);
+					});
+
+					it('should have an Offline overall_status when the heartbeat is Offline', async () => {
+						await testOverallStatus(
+							ctx.user,
+							ctx.deviceVpnOffHeartbeatOffline.id,
+							'offline',
+						);
+					});
+				});
+
+				describe('Given a device downloading a multicontainer release', () => {
+					it('should properly calculate the overall_status', async () => {
+						await testOverallStatus(
+							ctx.user,
+							ctx.deviceUpdating.id,
+							'updating',
+						);
+					});
+
+					it('should properly calculate the overall_progress', async () => {
+						const {
+							body: {
+								d: [device],
+							},
+						} = await supertest(ctx.user)
+							.get(
+								`/${version}/device(${ctx.deviceUpdating.id})?$select=overall_progress`,
+							)
+							.expect(200);
+
+						expect(device).to.have.property('overall_progress', 75);
+					});
+				});
+			});
+		});
+	});
+};

--- a/test/fixtures/24-device-additions/applications.json
+++ b/test/fixtures/24-device-additions/applications.json
@@ -1,0 +1,9 @@
+{
+	"app1": {
+		"user": "admin",
+		"app_name": "test_state_endpoint",
+		"device_type": "raspberry-pi",
+		"commit": "deadbeef",
+		"should_track_latest_release": 1
+	}
+}

--- a/test/fixtures/24-device-additions/devices.json
+++ b/test/fixtures/24-device-additions/devices.json
@@ -1,0 +1,72 @@
+{
+	"deviceUpdating": {
+		"belongs_to__application": "app1",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"is_online": true,
+		"api_heartbeat_state": "online",
+		"os_variant": "prod",
+		"os_version": "Resin OS 2.11.0+rev1",
+		"supervisor_version": "6.4.2"
+	},
+	"deviceVpnOnHeartbeatOnline": {
+		"belongs_to__application": "app1",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"is_online": true,
+		"api_heartbeat_state": "online",
+		"os_variant": "prod",
+		"os_version": "Resin OS 2.11.0+rev1",
+		"supervisor_version": "6.4.2"
+	},
+	"deviceVpnOnHeartbeatTimeout": {
+		"belongs_to__application": "app1",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"is_online": true,
+		"api_heartbeat_state": "timeout",
+		"os_variant": "prod",
+		"os_version": "Resin OS 2.11.0+rev1",
+		"supervisor_version": "6.4.2"
+	},
+	"deviceVpnOnHeartbeatOffline": {
+		"belongs_to__application": "app1",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"is_online": true,
+		"api_heartbeat_state": "offline",
+		"os_variant": "prod",
+		"os_version": "Resin OS 2.11.0+rev1",
+		"supervisor_version": "6.4.2"
+	},
+	"deviceVpnOffHeartbeatOnline": {
+		"belongs_to__application": "app1",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"is_online": false,
+		"api_heartbeat_state": "online",
+		"os_variant": "prod",
+		"os_version": "Resin OS 2.11.0+rev1",
+		"supervisor_version": "6.4.2"
+	},
+	"deviceVpnOffHeartbeatTimeout": {
+		"belongs_to__application": "app1",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"is_online": false,
+		"api_heartbeat_state": "timeout",
+		"os_variant": "prod",
+		"os_version": "Resin OS 2.11.0+rev1",
+		"supervisor_version": "6.4.2"
+	},
+	"deviceVpnOffHeartbeatOffline": {
+		"belongs_to__application": "app1",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"is_online": false,
+		"api_heartbeat_state": "offline",
+		"os_variant": "prod",
+		"os_version": "Resin OS 2.11.0+rev1",
+		"supervisor_version": "6.4.2"
+	}
+}

--- a/test/fixtures/24-device-additions/image_installs.json
+++ b/test/fixtures/24-device-additions/image_installs.json
@@ -1,0 +1,18 @@
+{
+  "ii1": {
+    "device": "deviceUpdating",
+    "release": "release1",
+    "image": "image1",
+    "download_progress": 50,
+    "status": "Downloading",
+    "user": "admin"
+  },
+  "ii2": {
+    "device": "deviceUpdating",
+    "release": "release1",
+    "image": "image2",
+    "download_progress": null,
+    "status": "Running",
+    "user": "admin"
+  }
+}

--- a/test/fixtures/24-device-additions/images.json
+++ b/test/fixtures/24-device-additions/images.json
@@ -1,0 +1,20 @@
+{
+	"image1": {
+		"user": "admin",
+		"service": "service1",
+		"releases": [ "release1" ],
+		"image_size": 12345678,
+		"project_type": "Dockerfile.template",
+		"build_log": "this is the build log",
+		"status": "success"
+	},
+	"image2": {
+		"user": "admin",
+		"service": "service2",
+		"releases": [ "release1" ],
+		"image_size": 12345678,
+		"project_type": "Dockerfile.template",
+		"build_log": "This is also the build log",
+		"status": "success"
+	}
+}

--- a/test/fixtures/24-device-additions/releases.json
+++ b/test/fixtures/24-device-additions/releases.json
@@ -1,0 +1,19 @@
+{
+	"release1": {
+		"user": "admin",
+		"application": "app1",
+		"commit": "deadc0de",
+		"composition": {
+			"services": {
+				"image1": {
+					"build": "./image1/"
+				},
+				"image2": {
+					"build": "./image2/"
+				}
+			}
+		},
+		"status": "success",
+		"source": "cloud"
+	}
+}

--- a/test/fixtures/24-device-additions/services.json
+++ b/test/fixtures/24-device-additions/services.json
@@ -1,0 +1,12 @@
+{
+	"service1": {
+		"service_name": "service1",
+		"application": "app1",
+		"user": "admin"
+	},
+	"service2": {
+		"service_name": "service2",
+		"application": "app1",
+		"user": "admin"
+	}
+}

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -339,6 +339,37 @@ const loaders: types.Dictionary<LoaderFunc> = {
 
 		return { ...iev, ...{ release_image: image.image__is_part_of__release } };
 	},
+	image_installs: async (jsonData, fixtures) => {
+		const device = await fixtures.devices[jsonData.device];
+		if (device == null) {
+			logErrorAndThrow('Could not find device: ', jsonData.device);
+		}
+		const release = await fixtures.releases[jsonData.release];
+		if (release == null) {
+			logErrorAndThrow('Could not find release: ', jsonData.release);
+		}
+		const image = await fixtures.images[jsonData.image];
+		if (image == null) {
+			logErrorAndThrow('Could not find image: ', jsonData.image);
+		}
+		const user = await fixtures.users[jsonData.user];
+		if (user == null) {
+			logErrorAndThrow('Could not find user: ', jsonData.user);
+		}
+
+		return await createResource({
+			resource: 'image_install',
+			body: {
+				installs__image: image.id,
+				device: device.id,
+				install_date: jsonData.install_date ?? Date.now(),
+				download_progress: jsonData.download_progress,
+				status: jsonData.status,
+				is_provided_by__release: release.id,
+			},
+			user,
+		});
+	},
 	image_labels: async (jsonData, fixtures) => {
 		const user = await fixtures.users[jsonData.user];
 		if (user == null) {
@@ -432,6 +463,7 @@ const loaders: types.Dictionary<LoaderFunc> = {
 			user,
 		});
 	},
+
 	devices: async (jsonData, fixtures) => {
 		const user = await fixtures.users[jsonData.belongs_to__user];
 		if (user == null) {
@@ -458,11 +490,13 @@ const loaders: types.Dictionary<LoaderFunc> = {
 					'custom_latitude',
 					'custom_longitude',
 					'is_online',
+					'api_heartbeat_state',
 					'latitude',
 					'longitude',
 					'os_variant',
 					'os_version',
 					'supervisor_version',
+					'overall_progress',
 					'uuid',
 				),
 			},


### PR DESCRIPTION
This commit relocates the test cases for the device additions from balena-api to open-balena-api. The move consolidates the tests with their corresponding implementation, enhancing maintainability and coherence in project structure.

Change-type: patch