### PR TITLE
fasttest: Stop syncing node_modules/@napi-rs that have a native build step

### DIFF
--- a/docker-compose.test-custom.yml
+++ b/docker-compose.test-custom.yml
@@ -142,6 +142,7 @@ services:
         - /usr/src/app/node_modules/grpc
         - /usr/src/app/node_modules/nan
         - /usr/src/app/node_modules/node-addon-api
+        - /usr/src/app/node_modules/@napi-rs
         - ./package.json:/usr/src/app/package.json
         - ./package-lock.json:/usr/src/app/package-lock.json
         - ./config.ts:/usr/src/app/config.ts


### PR DESCRIPTION
fasttest: Stop syncing node_modules/@napi-rs that have a native build step

Change-type: patch