### PR TITLE
Update `tar` to 7.1.0 and remove todo type casting workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "statuses": "^2.0.1",
         "strict-event-emitter-types": "^2.0.0",
         "supervisor": "^0.12.0",
-        "tar": "^7.0.0",
+        "tar": "^7.1.0",
         "thirty-two": "^1.0.2",
         "ts-node": "^10.9.2",
         "typed-error": "^3.2.2",
@@ -1720,14 +1720,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -7433,14 +7425,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -9333,6 +9317,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/minizlib": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
@@ -10338,14 +10330,6 @@
       "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "engines": {
         "node": "14 || >=16.14"
-      }
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-to-regexp": {
@@ -12247,13 +12231,13 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.0.1.tgz",
-      "integrity": "sha512-IjMhdQMZFpKsHEQT3woZVxBtCQY+0wk3CVxdRkGXEgyGa0dNS/ehPvOMr2nmfC7x5Zj2N+l6yZUpmICjLGS35w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.1.0.tgz",
+      "integrity": "sha512-ENhg4W6BmjYxl8GTaE7/h99f0aXiSWv4kikRZ9n2/JRxypZniE84ILZqimAhxxX7Zb8Px6pFdheW3EeHfhnXQQ==",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^7.1.0",
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
@@ -12270,14 +12254,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tar/node_modules/minizlib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
@@ -12288,14 +12264,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/tar/node_modules/minizlib/node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/tar/node_modules/mkdirp": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "statuses": "^2.0.1",
     "strict-event-emitter-types": "^2.0.0",
     "supervisor": "^0.12.0",
-    "tar": "^7.0.0",
+    "tar": "^7.1.0",
     "thirty-two": "^1.0.2",
     "ts-node": "^10.9.2",
     "typed-error": "^3.2.2",

--- a/src/features/contracts/contracts-directory.ts
+++ b/src/features/contracts/contracts-directory.ts
@@ -162,11 +162,7 @@ export const fetchContractsLocally = async (repos: RepositoryInfo[]) => {
 					}
 				}) as unknown as NodeJS.ReadableStream;
 
-			await stream.promises.pipeline(
-				get,
-				// TODO: Drop the cast once https://github.com/isaacs/node-tar/issues/409 gets fixed
-				untar as ReturnType<typeof tar.extract> & NodeJS.WritableStream,
-			);
+			await stream.promises.pipeline(get, untar);
 		}),
 	);
 };


### PR DESCRIPTION
Change-type: patch
See: https://github.com/isaacs/node-tar/blob/main/CHANGELOG.md#71
See: https://github.com/isaacs/node-tar/issues/409