### PR TITLE
better handling of exceptions from AWS/S3

### DIFF
--- a/config/services/open-balena-api.service
+++ b/config/services/open-balena-api.service
@@ -2,6 +2,7 @@
 Description=open-balena-api
 Requires=confd.service
 After=confd.service
+StartLimitIntervalSec=0
 
 [Service]
 StandardOutput=journal+console
@@ -11,7 +12,6 @@ EnvironmentFile=/usr/src/app/config/env
 ExecStart=/usr/src/app/entry.sh
 Restart=always
 SyslogIdentifier=api
-StartLimitIntervalSec=0
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
.. required (ideally) by https://github.com/balena-io/open-balena/pull/141

We have two contracts repos, one is [private](https://github.com/balena-io/private-contracts/tree/master/contracts/hw.device-type) and the other [public](https://github.com/balena-io/contracts/tree/master/contracts/hw.device-type).

So open-balena-api can't access the private repo, to check which device types are private, but it can enumerate the entire images bucket, which has with public `List` ACL enabled. Since it can see private devices in the enumerated list, the API will try to access various assets, but will get back a 403 from S3 API, since the objects themselves don't have public-read enabled. This behaviour produces a lot of exceptions in the API logs and this is what this PR attempts to make better.

A more complete solution would probably require rethinking private/public DT handling in open-balena-api vs. balena-api.

.. in any case, events now reflected in the logs as follows:

```
...
May 21 19:30:31 45abc1b164c4 api[22260]: Forbidden (403): images/coral-dev/2.101.1+rev1/IGNORE belongs to a private device type or has incorrect permissions
May 21 19:30:31 45abc1b164c4 api[22260]: Forbidden (403): images/asus-tinker-edge-t/2.101.1+rev1/IGNORE belongs to a private device type or has incorrect permissions
...
May 21 22:58:39 45abc1b164c4 api[46805]: AccessDenied (403): images/imx8mmebcrs08a2/2.108.1+rev3/device-type.json belongs to a private device type or has incorrect permissions
May 21 22:58:39 45abc1b164c4 api[46805]: AccessDenied (403): images/bigmak-imx8m-plus/2.114.6/device-type.json belongs to a private device type or has incorrect permissions
```

* [StartLimitIntervalSec](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval)