### PR TITLE
Require a freshly authenticated JWT when creating a user api_key

### DIFF
--- a/test/test-lib/api-helpers.ts
+++ b/test/test-lib/api-helpers.ts
@@ -136,6 +136,15 @@ export const expectResourceToMatch = async <T = AnyObject>(
 	return result;
 };
 
+export const getUserFromToken = (token: string) => {
+	const user: UserObjectParam = {
+		...expectJwt(token),
+		token,
+	};
+
+	return user;
+};
+
 const validJwtProps = ['id', 'jwt_secret', 'authTime', 'iat', 'exp'].sort();
 
 export function expectJwt(tokenOrJwt: string | AnyObject) {

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -17,6 +17,11 @@ import type Model from '../../src/balena-model.js';
 const { api } = sbvrUtils;
 const version = 'resin';
 
+// Use undefined masquerading as a Tx to pass to functions that "require"
+// a Tx based on how they should be used within the main api code, but
+// can actually work without one and makes tests life easier
+export const fakeTx = undefined as any as Tx;
+
 type PendingFixtures = types.Dictionary<
 	PromiseLike<types.Dictionary<PromiseLike<any>>>
 >;

--- a/test/test-lib/init-tests.ts
+++ b/test/test-lib/init-tests.ts
@@ -1,11 +1,10 @@
 import * as fixtures from './fixtures.js';
-import type { UserObjectParam } from './supertest.js';
 import { supertest, augmentStatusAssertionError } from './supertest.js';
 import {
 	getContractRepos,
 	synchronizeContracts,
 } from '../../src/features/contracts/index.js';
-import { expectJwt } from './api-helpers.js';
+import { getUserFromToken } from './api-helpers.js';
 
 const version = 'resin';
 
@@ -44,10 +43,7 @@ const loadAdminUserAndOrganization = async () => {
 			.expect(200)
 	).text;
 
-	const user: UserObjectParam = {
-		...expectJwt(token),
-		token,
-	};
+	const user = getUserFromToken(token);
 
 	const org = (
 		await supertest(user)

--- a/test/test-lib/users.ts
+++ b/test/test-lib/users.ts
@@ -1,0 +1,26 @@
+import { fakeTx } from './fixtures.js';
+import { expectJwt, getUserFromToken } from './api-helpers.js';
+import type { TokenUserPayload } from '../../src/infra/auth/jwt.js';
+import { createSessionToken } from '../../src/infra/auth/jwt.js';
+
+/**
+ * Issues a JWT that's from 30' in the past, so that it's no longer a sudo JWT
+ * (atm defined in oB as SUDO_TOKEN_VALIDITY=20').
+ */
+export const loginUserSudoTimeoutAgo = async (
+	userId: number,
+	existingTokenString?: string,
+) => {
+	const existingToken: Partial<TokenUserPayload> = existingTokenString
+		? expectJwt(existingTokenString)
+		: {};
+
+	existingToken.authTime = Date.now() - 30 * 60 * 1000;
+	const newToken = await createSessionToken(userId, {
+		existingToken,
+		tx: fakeTx,
+	});
+
+	const user = getUserFromToken(newToken);
+	return user;
+};


### PR DESCRIPTION
Depends-on: https://github.com/balena-io/balena-ui/pull/6638
Change-type: major
See: https://balena.zulipchat.com/#narrow/stream/345885-aspect.2Fsecurity/topic/Requiring.20a.20sudo.20token.20when.20creating.20a.20new.20api.20key/near/441432122
See: https://balena.fibery.io/Work/Project/Require-SUDO-privileges-when-creating-an-api-key-605