### PR TITLE
Add auth.credentials_login permission to default-user

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -157,6 +157,7 @@ ROLES['device-api-key'] = [
 
 export const DEFAULT_USER_EXTRA_PERMISSIONS = [
 	'auth.create_token',
+	'auth.credentials_login',
 	`resin.user.create-user-api-key?${matchesActor}`,
 	`resin.user.create-named-user-api-key?${matchesActor}`,
 	// api_key.create is not allowed, must be done via the custom endpoints


### PR DESCRIPTION
This is a step towards enabling more granular logins. Once this is merged we will want to enforce the user has this permission when logg n in here: https://github.com/balena-io/open-balena-api/blob/423fc589cd36287e2b28cbc209fd3ee7feae67d8/src/features/auth/index.ts#L28

This can't be done directly using the `middleware.permissionRequired` because this middleware requires a partiallyAuthenticatedUser to work. So we can just enforce it on the login method, as: https://github.com/balena-io/open-balena-api/pull/1654/files#diff-09036ece83a65b9a83897a8dd10e51dec832301f86fe4a21aed2b76d3ef98050R27-R31 in here

We also want to have a "auth.service_account_login" for SSO providers and enforce it, but on balena-api. On SAML specific, the saml role won't have these permissions.

Change-type: minor