### PR TITLE
Enforces login with auth permission

### DIFF
--- a/src/features/auth/login.ts
+++ b/src/features/auth/login.ts
@@ -3,6 +3,7 @@ import { errors, sbvrUtils } from '@balena/pinejs';
 import { comparePassword, findUser } from '../../infra/auth/auth.js';
 import { loginUserXHR } from '../../infra/auth/jwt.js';
 import { captureException } from '../../infra/error-handling/index.js';
+import { permissions } from '@balena/pinejs';
 
 import type { SetupOptions } from '../../index.js';
 
@@ -28,6 +29,12 @@ export const login =
 				if (!matches) {
 					throw new BadRequestError('Current password incorrect.');
 				}
+
+				const userPermissions = await permissions.getUserPermissions(user.id);
+				if (!userPermissions.includes('auth.credentials_login')) {
+					throw new BadRequestError('User not allowed to login.');
+				}
+
 				if (onLogin) {
 					await onLogin(user, tx);
 				}


### PR DESCRIPTION
We are moving towards more granular login permissions based on roles. The main advantage is that this allow for more control over different permissions, for example, users added by SAML won't be able to do `auth.credentials_login` (and `auth.social_service_account_login` still to be done in balena-api). More over, this also allow for more control, for example, in the future I could see orgs configuring their users to only allow specific login methods (altough this is a stretch, the work here creates the foundation for it to be possible).