### PR TITLE
Allow registering user with `null` email

### DIFF
--- a/src/infra/auth/auth.ts
+++ b/src/infra/auth/auth.ts
@@ -317,7 +317,7 @@ export async function findUser<
 export const registerUser = async (
 	userData: AnyObject & {
 		username: string;
-		email: string;
+		email: string | null;
 		password?: string;
 	},
 	tx: Tx,


### PR DESCRIPTION
user (Auth) email is a nullable property. However, instead of using the actual null current API behaviour forces it to be an empty string. This is problematic as ideally the email field would have a unique constraint to it (and NULL value is considered distinct by default, different than empty string)

Change-type: minor