### PR TITLE
Do not rewrite the field names when aliasing relationships

### DIFF
--- a/src/abstract-sql-utils.ts
+++ b/src/abstract-sql-utils.ts
@@ -70,9 +70,8 @@ const $aliasRelationships = (
 				resourceRegex,
 				`$1${toResourceName}$3`,
 			);
-			if (resourceRegex.test(mapping[0])) {
-				mapping[0] = mapping[0].replace(resourceRegex, `$1${toResourceName}$3`);
-			}
+			// Note: We do not remap `mapping[0]` as that refers to the foreign key fields, we only add aliases that point that
+			// field to the aliased referenced table
 
 			relationships.$ = mapping;
 		}


### PR DESCRIPTION
This can cause problems because looking up a rewritten field will fail because it does not actually exist, and instead we expect the one field to point to two different places via aliasing

Change-type: patch