### PR TITLE
Add unique email constraint on user model

### DIFF
--- a/src/balena-init.sql
+++ b/src/balena-init.sql
@@ -201,3 +201,5 @@ ADD CONSTRAINT "user$M+9koFfMHn7kQFDNBaQZbS7gAvNMB1QkrTtsaVZoETw=" CHECK (NOT (
 		AND "email" IS NOT NULL
 	)
 ));
+
+ALTER TABLE "user" ADD UNIQUE ("email");

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -436,6 +436,7 @@ Fact type: organization has handle
 Fact type: user (Auth) has email
 	Necessity: each user (Auth) has at most one email.
 	Necessity: each user (Auth) that has an email, has an email that has a Length (Type) that is greater than 4.
+	Necessity: each email is of exactly one user (Auth).
 
 Fact type: user (Auth) has public key
 	Term Form: user public key

--- a/src/migrations/00089-add-unique-constraint-to-user-email.sql
+++ b/src/migrations/00089-add-unique-constraint-to-user-email.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD UNIQUE ("email");


### PR DESCRIPTION
This enforces database level uniqueness on the email field. I opted for keeping the current hooks alongside this (see https://github.com/balena-io/open-balena-api/blob/d3b61faad9d3aeb6fa22f129e70c2a75ce2f3070/src/features/auth/hooks/validate-username-email.ts#L45) in order to keep the error messages clean. In the case of a PATCH for a user with an email that is duplicated, without this hook api would respond with 200 and just don't do anything, so I decided to keep it. As the case where the hook fail is a very rare race condition I could not figure it out how to test the constraint.

Change-type: minor