### PR TITLE
is_pinned_on__release: Add migration to sync 'is pinned on-release' with 'should be running-release' in device table

### DIFF
--- a/src/migrations/00090-sync-is-pinned-on-release-to-should-be-running-release-on-device.sql
+++ b/src/migrations/00090-sync-is-pinned-on-release-to-should-be-running-release-on-device.sql
@@ -1,0 +1,13 @@
+UPDATE "device" AS "dev"
+SET
+  "is pinned on-release" = "should be running-release"
+WHERE NOT (
+  (
+      ("dev"."should be running-release") IS NOT NULL
+      AND ("dev"."is pinned on-release") IS NOT NULL
+      AND ("dev"."should be running-release") = ("dev"."is pinned on-release")
+  )
+  OR (
+      ("dev"."should be running-release") IS NULL AND ("dev"."is pinned on-release") IS NULL
+  )
+);


### PR DESCRIPTION
Depends-on: Async migration finalisation

Projects: https://balena.fibery.io/Work/Project/Server-side-pagination-for-devices-Cycle-3-539

Change-type: minor