### PR TITLE
Use `assertExists` in place of `expect(..).to.not.be.undefined`

### DIFF
--- a/test/03_device-state.ts
+++ b/test/03_device-state.ts
@@ -9,7 +9,7 @@ import { supertest } from './test-lib/supertest.js';
 import * as versions from './test-lib/versions.js';
 import * as config from '../src/lib/config.js';
 import * as stateMock from '../src/features/device-heartbeat/index.js';
-import { itExpectsError, waitFor } from './test-lib/common.js';
+import { assertExists, itExpectsError, waitFor } from './test-lib/common.js';
 import * as fixtures from './test-lib/fixtures.js';
 import { expectResourceToMatch } from './test-lib/api-helpers.js';
 import { redis, redisRO } from '../src/infra/redis/index.js';
@@ -285,7 +285,7 @@ export default () => {
 											.get(`/${version}/device(${getDevice().id})`)
 											.expect(200);
 
-										expect(body.d[0]).to.not.be.undefined;
+										assertExists(body.d[0]);
 										expect(body.d[0]).to.have.property(
 											'api_heartbeat_state',
 											DeviceOnlineStates.Unknown,
@@ -316,7 +316,7 @@ export default () => {
 											.get(`/${version}/device(${getDevice().id})`)
 											.expect(200);
 
-										expect(body.d[0]).to.not.be.undefined;
+										assertExists(body.d[0]);
 										expect(body.d[0]).to.have.property(
 											'api_heartbeat_state',
 											heartbeatAfterGet,
@@ -346,7 +346,7 @@ export default () => {
 											.get(`/${version}/device(${getDevice().id})`)
 											.expect(200);
 
-										expect(body.d[0]).to.not.be.undefined;
+										assertExists(body.d[0]);
 										expect(body.d[0]).to.have.property(
 											'api_heartbeat_state',
 											DeviceOnlineStates.Timeout,
@@ -371,7 +371,7 @@ export default () => {
 											.get(`/${version}/device(${getDevice().id})`)
 											.expect(200);
 
-										expect(body.d[0]).to.not.be.undefined;
+										assertExists(body.d[0]);
 										expect(body.d[0]).to.have.property(
 											'api_heartbeat_state',
 											DeviceOnlineStates.Online,
@@ -399,7 +399,7 @@ export default () => {
 											.get(`/${version}/device(${getDevice().id})`)
 											.expect(200);
 
-										expect(body.d[0]).to.not.be.undefined;
+										assertExists(body.d[0]);
 										expect(body.d[0]).to.have.property(
 											'api_heartbeat_state',
 											DeviceOnlineStates.Offline,
@@ -447,7 +447,7 @@ export default () => {
 									.get(`/${version}/device(${device.id})`)
 									.expect(200);
 
-								expect(body.d[0]).to.not.be.undefined;
+								assertExists(body.d[0]);
 								expect(body.d[0]).to.have.property(
 									'api_heartbeat_state',
 									DeviceOnlineStates.Offline,
@@ -485,7 +485,7 @@ export default () => {
 									.get(`/${version}/device(${device.id})`)
 									.expect(200);
 
-								expect(body.d[0]).to.not.be.undefined;
+								assertExists(body.d[0]);
 								expect(body.d[0]).to.have.property(
 									'api_heartbeat_state',
 									DeviceOnlineStates.Online,

--- a/test/09_contracts.ts
+++ b/test/09_contracts.ts
@@ -15,6 +15,7 @@ import type { RepositoryInfo } from '../src/features/contracts/index.js';
 import { synchronizeContracts } from '../src/features/contracts/index.js';
 import { sbvrUtils, permissions } from '@balena/pinejs';
 import type { DeviceType, DeviceTypeAlias } from '../src/balena-model.js';
+import { assertExists } from './test-lib/common.js';
 
 const contractRepository: RepositoryInfo = {
 	owner: 'balena-io',
@@ -81,8 +82,9 @@ export default () => {
 					const contracts = await getContracts('hw.device-type');
 
 					expect(contracts).to.have.length(16);
-					expect(contracts.find((contract) => contract.slug === 'raspberrypi3'))
-						.to.not.be.undefined;
+					assertExists(
+						contracts.find((contract) => contract.slug === 'raspberrypi3'),
+					);
 				});
 
 				it('should merge multiple contracts repos', async () => {
@@ -99,9 +101,9 @@ export default () => {
 					const contracts = await getContracts('hw.device-type');
 
 					expect(contracts).to.have.length(17);
-					expect(
+					assertExists(
 						contracts.find((contract) => contract.slug === 'other-contract-dt'),
-					).to.not.be.undefined;
+					);
 				});
 
 				it('should normalize the assets included with the contracts', async () => {
@@ -166,7 +168,7 @@ export default () => {
 					);
 
 					expect(contracts).to.have.length(17);
-					expect(newDt).to.not.be.undefined;
+					assertExists(newDt);
 					expect(finDt).to.have.property('name', 'Fin');
 				});
 			});
@@ -235,7 +237,7 @@ export default () => {
 					);
 
 					expect(dbDeviceTypes).to.have.length(17);
-					expect(newDt).to.not.be.undefined;
+					assertExists(newDt);
 					expect(finDt).to.have.property('name', 'Fin');
 					expect(finDt).to.have.deep.property(
 						'contract',

--- a/test/15_target-hostapp.ts
+++ b/test/15_target-hostapp.ts
@@ -8,6 +8,7 @@ import { supertest } from './test-lib/supertest.js';
 import * as versions from './test-lib/versions.js';
 import type { Application, Device } from '../src/balena-model.js';
 import { expectResourceToMatch } from './test-lib/api-helpers.js';
+import { assertExists } from './test-lib/common.js';
 
 export default () => {
 	versions.test((version, pineTest) => {
@@ -503,13 +504,11 @@ export default () => {
 						`/${version}/device(${noMatchDevice.id})?$select=should_be_operated_by__release`,
 					)
 					.expect(200);
-				expect(body.d[0]).to.not.be.undefined;
-				expect(body.d[0]).to.have.property(
-					'should_be_operated_by__release',
-					null,
-				);
-				expect(body.d[0]['os_version']).to.be.not.null;
-				expect(body.d[0]['os_variant']).to.be.not.null;
+				assertExists(body.d[0]);
+				expect(body.d[0]).to.have.property('should_be_operated_by__release')
+					.that.is.null;
+				expect(body.d[0]).to.not.have.property('os_version');
+				expect(body.d[0]).to.not.have.property('os_variant');
 			});
 
 			(

--- a/test/19_apps.ts
+++ b/test/19_apps.ts
@@ -7,6 +7,7 @@ import type { Application, Release } from '../src/balena-model.js';
 import { expectResourceToMatch } from './test-lib/api-helpers.js';
 import type { PineTest } from 'pinejs-client-supertest';
 import * as versions from './test-lib/versions.js';
+import { assertExists } from './test-lib/common.js';
 
 export default () => {
 	versions.test((version, pineTest) => {
@@ -85,6 +86,7 @@ export default () => {
 						.that.is.an('object');
 					const supervisorApp1 =
 						state[deviceWithSupervisor.uuid].apps?.[supervisorApp.uuid];
+					assertExists(supervisorApp1);
 					expect(supervisorApp1).to.have.property(
 						'name',
 						supervisorApp.app_name,
@@ -99,8 +101,6 @@ export default () => {
 						.to.have.property('services')
 						.that.has.property('resin-supervisor')
 						.that.is.an('object');
-
-					expect(supervisorApp1, 'supervisor is undefined').to.not.be.undefined;
 				});
 
 				it('should not have a supervisor app if not managed by release', async () => {
@@ -187,6 +187,7 @@ export default () => {
 						.that.is.an('object');
 					const stateGetHostApp =
 						state[deviceWithHostApp.uuid].apps?.[intelNucHostApp.uuid];
+					assertExists(stateGetHostApp);
 					expect(stateGetHostApp).to.have.property(
 						'name',
 						intelNucHostApp.app_name,
@@ -203,8 +204,6 @@ export default () => {
 						.that.is.an('object')
 						.and.has.property('labels')
 						.that.has.property('io.balena.image.store', 'root');
-
-					expect(stateGetHostApp, 'hostApp is undefined').to.not.be.undefined;
 				});
 
 				it('should not have a host app if not operated by a release', async () => {

--- a/test/test-lib/common.ts
+++ b/test/test-lib/common.ts
@@ -99,5 +99,5 @@ export const itExpectsError = (
 };
 
 export function assertExists(v: unknown): asserts v is NonNullable<typeof v> {
-	expect(v).to.not.be.null;
+	expect(v).to.exist;
 }


### PR DESCRIPTION
This allows us to remove assertions/optional chaining as it makes typescript aware that we've proven it's not nullish

Change-type: patch