### PR TITLE
Fail tests if the minio-client fails to initialize the server

### DIFF
--- a/docker-compose.test-custom.yml
+++ b/docker-compose.test-custom.yml
@@ -37,6 +37,7 @@ services:
       - minio-server
     entrypoint: >
       /bin/sh -c "
+      set -e;
       /usr/bin/mc config host add minio-server http://minio-server:9000 USERNAME PASSWORD;
       /usr/bin/mc mb --ignore-existing minio-server/balena-pine-web-resources;
       sleep infinity;


### PR DESCRIPTION
This catches errors early rather than potentially waiting for runtime failures that could happen much later and be unclear as to the root cause

Change-type: patch