### PR TITLE
Add @balena/abstract-sql-to-typescript as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@balena/abstract-sql-compiler": "^9.2.0",
+        "@balena/abstract-sql-to-typescript": "^3.3.0",
         "@balena/env-parsing": "^1.1.12",
         "@balena/es-version": "^1.0.3",
         "@balena/node-metrics-gatherer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@balena/abstract-sql-compiler": "^9.2.0",
+    "@balena/abstract-sql-to-typescript": "^3.3.0",
     "@balena/env-parsing": "^1.1.12",
     "@balena/es-version": "^1.0.3",
     "@balena/node-metrics-gatherer": "^6.0.3",


### PR DESCRIPTION
Currently we only consume the typings from this library, however, these are used in the model files which might be consumed downstream so this must be a regular dependency

Change-type: patch