### PR TITLE
logs/redis: Delete references of cancelled heartbeat subscriptions

### DIFF
--- a/src/features/device-logs/lib/backends/redis.ts
+++ b/src/features/device-logs/lib/backends/redis.ts
@@ -215,6 +215,7 @@ export class RedisBackend implements DeviceLogsBackend {
 			const subscribersKey = this.getKey(ctx, 'subscribers');
 			// Clear the heartbeat
 			clearInterval(this.subscriptionHeartbeats[key]);
+			delete this.subscriptionHeartbeats[key];
 			// And decrement the subscribers counter
 			void redis.decrSubscribers(subscribersKey).then((n) => {
 				if (n < 0) {


### PR DESCRIPTION
Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/API.20pods.20in.20Error.2FSatusUnknown.20state/near/449102603