### PR TITLE
Use `as const` to improve typings of $expand queries

### DIFF
--- a/src/features/device-state/routes/fleet-state-get-v3.ts
+++ b/src/features/device-state/routes/fleet-state-get-v3.ts
@@ -6,7 +6,6 @@ import {
 	captureException,
 	handleHttpErrors,
 } from '../../../infra/error-handling/index.js';
-import type { Expand } from 'pinejs-client-core';
 
 import { sbvrUtils, errors } from '@balena/pinejs';
 import { getConfig, readTransaction } from '../state-get-utils.js';
@@ -23,7 +22,7 @@ type FleetStateV3 = {
 	};
 };
 
-const fleetExpand: Expand = {
+const fleetExpand = {
 	application_config_variable: {
 		$select: ['name', 'value'],
 	},
@@ -45,7 +44,7 @@ const fleetExpand: Expand = {
 			},
 		},
 	},
-};
+} as const;
 
 const stateQuery = _.once(() =>
 	api.resin.prepare<{ uuid: string }, 'application'>({

--- a/src/features/device-state/routes/state-get-v2.ts
+++ b/src/features/device-state/routes/state-get-v2.ts
@@ -236,7 +236,7 @@ const stateQuery = _.once(() =>
 				},
 			},
 		},
-	}),
+	} as const),
 );
 
 const getStateV2 = async (req: Request, uuid: string): Promise<StateV2> => {

--- a/src/features/device-state/routes/state-get-v3.ts
+++ b/src/features/device-state/routes/state-get-v3.ts
@@ -285,7 +285,7 @@ const stateQuery = _.once(() =>
 			$select: ['device_name', ...getStateEventAdditionalFields],
 			$expand: deviceExpand,
 		},
-	}),
+	} as const),
 );
 
 const getStateV3 = async (req: Request, uuid: string): Promise<StateV3> => {

--- a/src/features/device-state/routes/state-patch-v2.ts
+++ b/src/features/device-state/routes/state-patch-v2.ts
@@ -101,7 +101,7 @@ const appAndReleaseOfDeviceQuery = _.once(() =>
 				},
 			},
 		},
-	}),
+	} as const),
 );
 
 const resolveReleaseId = async (

--- a/src/features/device-state/routes/state-patch-v3.ts
+++ b/src/features/device-state/routes/state-patch-v3.ts
@@ -172,7 +172,7 @@ const fetchData = async (
 						},
 					},
 				},
-			})) as Array<
+			} as const)) as Array<
 				Pick<Release['Read'], 'id' | 'commit'> & {
 					release_image?: Array<{
 						image: Array<

--- a/test/09_contracts.ts
+++ b/test/09_contracts.ts
@@ -223,7 +223,7 @@ export default () => {
 									},
 								},
 							},
-						})
+						} as const)
 						.expect(200);
 
 					const newDt = dbDeviceTypes.find(

--- a/test/15_target-hostapp.ts
+++ b/test/15_target-hostapp.ts
@@ -367,7 +367,7 @@ export default () => {
 												},
 											},
 										},
-									})
+									} as const)
 									.expect(200);
 								expect(serviceInstalls).to.have.lengthOf(1);
 								const [service] = serviceInstalls[0].installs__service;

--- a/test/16_supervisor_releases.ts
+++ b/test/16_supervisor_releases.ts
@@ -171,7 +171,7 @@ export default () => {
 										},
 									},
 								},
-							})
+							} as const)
 							.expect(200);
 						expect(serviceInstalls).to.have.lengthOf(1);
 						const [service] = serviceInstalls[0].installs__service;
@@ -450,7 +450,7 @@ export default () => {
 										},
 									},
 								},
-							})
+							} as const)
 							.expect(200);
 						expect(serviceInstalls).to.have.lengthOf(1);
 						const [service] = serviceInstalls[0].installs__service;
@@ -505,7 +505,7 @@ export default () => {
 										},
 										$orderby: { created_at: 'asc' },
 									},
-								})
+								} as const)
 								.expect(200);
 							expect(serviceInstalls).to.have.lengthOf(2);
 							const [oldService, newService] = serviceInstalls.map(

--- a/test/18_resource_filtering.ts
+++ b/test/18_resource_filtering.ts
@@ -216,7 +216,7 @@ export default () => {
 								},
 							],
 						},
-					});
+					} as const);
 					expect(body).to.be.an('array').to.have.lengthOf(4);
 					expect(body.map((app) => app.app_name)).deep.equal([
 						'appapp2',
@@ -234,7 +234,7 @@ export default () => {
 							$expand: { application_tag: {} },
 							$orderby: `application_tag/$count($filter=value eq '0') desc,app_name asc`,
 						},
-					});
+					} as const);
 					expect(body).to.be.an('array').to.have.lengthOf(4);
 					expect(body.map((app) => app.app_name)).deep.equal([
 						'appapp2',


### PR DESCRIPTION
Typescript doesn't like inferring nested $expand typings so using as const just gives it a helping hand

Change-type: patch