### PR TITLE
Use $bypass for image_installs in the v6 device.overall_status computed term

### DIFF
--- a/src/translations/v6/v6.ts
+++ b/src/translations/v6/v6.ts
@@ -147,7 +147,11 @@ export const getV6Translations = (abstractSqlModel = v6AbstractSqlModel) => {
 								'From',
 								[
 									'Alias',
-									['Resource', `device-installs-image$${toVersion}`],
+									// The `Resource`+$bypass avoids adding extra permissions checks,
+									// similarly to how `Table` is working in the balena model.
+									// Without it, requests that have permissions to access the device resource,
+									// but do not have permissions to access image_installs would start failing.
+									['Resource', `device-installs-image$${toVersion}$bypass`],
 									'image install',
 								],
 							],


### PR DESCRIPTION
Follow-up of #1708.
Before #1708 we were using `Table` directly, so switching to `Resource` added more permissions checks to the query,
which also unintentionally broke device requests from actors don't have permissions to access the image_installs.
See: https://github.com/balena-io/balena-api/actions/runs/9879846964/job/27287119278?pr=5177

Change-type: patch
See: https://github.com/balena-io/open-balena-api/pull/1708