### PR TITLE
Add the device.should_be_running__release computed term to the balena model

### DIFF
--- a/src/balena-model.ts
+++ b/src/balena-model.ts
@@ -735,6 +735,11 @@ export interface Device {
 			| [Release['Read']]
 			| []
 			| null;
+		should_be_running__release:
+			| { __id: Release['Read']['id'] }
+			| [Release['Read']]
+			| []
+			| null;
 		should_be_operated_by__release:
 			| { __id: Release['Read']['id'] }
 			| [Release['Read']]
@@ -807,6 +812,7 @@ export interface Device {
 		api_secret: Types['Short Text']['Write'] | null;
 		is_managed_by__service_instance: ServiceInstance['Write']['id'] | null;
 		is_pinned_on__release: Release['Write']['id'] | null;
+		should_be_running__release: Release['Write']['id'] | null;
 		should_be_operated_by__release: Release['Write']['id'] | null;
 		should_be_managed_by__release: Release['Write']['id'] | null;
 		is_web_accessible: Types['Boolean']['Write'] | null;
@@ -1013,6 +1019,7 @@ export interface Release {
 		release_image?: Array<ImageIsPartOfRelease['Read']>;
 		contains__image?: Array<ImageIsPartOfRelease['Read']>;
 		should_be_running_on__application?: Array<Application['Read']>;
+		should_be_running_on__device?: Array<Device['Read']>;
 		is_running_on__device?: Array<Device['Read']>;
 		is_pinned_to__device?: Array<Device['Read']>;
 		should_operate__device?: Array<Device['Read']>;

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -581,6 +581,10 @@ Fact type: device is managed by service instance
 Fact type: device is pinned on release
 	Synonymous Form: release is pinned to device
 	Necessity: each device is pinned on at most one release
+Fact type: device should be running release
+	Synonymous Form: release should be running on device
+	Necessity: each device should be running at most one release
+	Note: Computed as device is pinned on release ?? application should be running release.
 Fact type: device should be operated by release
 	Synonymous Form: release should operate device
 	Necessity: each device should be operated by at most one release

--- a/src/features/devices/models/device-additions.ts
+++ b/src/features/devices/models/device-additions.ts
@@ -428,4 +428,40 @@ export const addToModel = (abstractSql: AbstractSqlModel) => {
 			],
 		],
 	});
+
+	const deviceShouldBeRunningReleaseField = abstractSql.tables[
+		'device'
+	].fields.find((f) => f.fieldName === 'should be running-release');
+	if (deviceShouldBeRunningReleaseField == null) {
+		throw new Error(
+			"Could not find 'should be running-release' field in device model",
+		);
+	}
+	deviceShouldBeRunningReleaseField.computed = [
+		'Case',
+		[
+			'When',
+			['Exists', ['ReferencedField', 'device', 'is pinned on-release']],
+			['ReferencedField', 'device', 'is pinned on-release'],
+		],
+		[
+			'Else',
+			[
+				'SelectQuery',
+				[
+					'Select',
+					[['ReferencedField', 'application', 'should be running-release']],
+				],
+				['From', ['Table', 'application']],
+				[
+					'Where',
+					[
+						'Equals',
+						['ReferencedField', 'application', 'id'],
+						['ReferencedField', 'device', 'belongs to-application'],
+					],
+				],
+			],
+		],
+	];
 };

--- a/test/fixtures/24-device-additions/applications.json
+++ b/test/fixtures/24-device-additions/applications.json
@@ -12,5 +12,15 @@
 		"device_type": "raspberry-pi",
 		"commit": "deadbeef",
 		"should_track_latest_release": 1
+	},
+	"app3": {
+		"user": "admin",
+		"app_name": "test_app",
+		"device_type": "raspberry-pi"
+	},
+	"appWoRelease": {
+		"user": "admin",
+		"app_name": "test_no_releases",
+		"device_type": "raspberry-pi"
 	}
 }

--- a/test/fixtures/24-device-additions/devices.json
+++ b/test/fixtures/24-device-additions/devices.json
@@ -150,5 +150,36 @@
 		"os_version": "Resin OS 2.11.0+rev1",
 		"supervisor_version": "6.4.2",
 		"provisioning_state": "Post-Provisioning"
+	},
+	"deviceInAppWoReleases": {
+		"belongs_to__application": "appWoRelease",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"is_online": true,
+		"api_heartbeat_state": "online",
+		"os_variant": "prod",
+		"os_version": "Resin OS 2.11.0+rev1",
+		"supervisor_version": "6.4.2"
+	},
+	"deviceTrackingLatest": {
+		"belongs_to__application": "app3",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"is_online": true,
+		"api_heartbeat_state": "online",
+		"os_variant": "prod",
+		"os_version": "Resin OS 2.11.0+rev1",
+		"supervisor_version": "6.4.2"
+	},
+	"devicePinned": {
+		"belongs_to__application": "app3",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"is_pinned_on__release": "release1app3",
+		"is_online": true,
+		"api_heartbeat_state": "online",
+		"os_variant": "prod",
+		"os_version": "Resin OS 2.11.0+rev1",
+		"supervisor_version": "6.4.2"
 	}
 }

--- a/test/fixtures/24-device-additions/images.json
+++ b/test/fixtures/24-device-additions/images.json
@@ -16,5 +16,23 @@
 		"project_type": "Dockerfile.template",
 		"build_log": "This is also the build log",
 		"status": "success"
+	},
+	"image1app3": {
+		"user": "admin",
+		"service": "service1app3",
+		"releases": [ "release1app3" ],
+		"image_size": 12345678,
+		"project_type": "Dockerfile.template",
+		"build_log": "this is the build log",
+		"status": "success"
+	},
+	"image2app3": {
+		"user": "admin",
+		"service": "service1app3",
+		"releases": [ "release2app3" ],
+		"image_size": 12345678,
+		"project_type": "Dockerfile.template",
+		"build_log": "this is the build log",
+		"status": "success"
 	}
 }

--- a/test/fixtures/24-device-additions/releases.json
+++ b/test/fixtures/24-device-additions/releases.json
@@ -15,5 +15,34 @@
 		},
 		"status": "success",
 		"source": "cloud"
+	},
+	"release1app3": {
+		"user": "admin",
+		"application": "app3",
+		"commit": "deadc0de1",
+		"composition": {
+			"services": {
+				"image1app3": {
+					"build": "./image1app3/"
+				}
+			}
+		},
+		"status": "success",
+		"source": "cloud"
+	},
+	"release2app3": {
+		"createAfterRelease": "release1app3",
+		"user": "admin",
+		"application": "app3",
+		"commit": "deadc0de2",
+		"composition": {
+			"services": {
+				"image2app3": {
+					"build": "./image2app3/"
+				}
+			}
+		},
+		"status": "success",
+		"source": "cloud"
 	}
 }

--- a/test/fixtures/24-device-additions/services.json
+++ b/test/fixtures/24-device-additions/services.json
@@ -8,5 +8,10 @@
 		"service_name": "service2",
 		"application": "app1",
 		"user": "admin"
+	},
+	"service1app3": {
+		"service_name": "service1app3",
+		"application": "app3",
+		"user": "admin"
 	}
 }

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -486,12 +486,23 @@ const loaders: types.Dictionary<LoaderFunc> = {
 
 		const deviceType = await fixtures.deviceTypes[jsonData.device_type];
 
+		let release: AnyObject | null = null;
+		if (jsonData.is_pinned_on__release != null) {
+			release = await fixtures.releases[jsonData.is_pinned_on__release];
+			if (release == null) {
+				logErrorAndThrow(
+					`Could not find release: ${jsonData.is_pinned_on__release}`,
+				);
+			}
+		}
+
 		return await createResource({
 			resource: 'device',
 			body: {
 				belongs_to__application: application.id,
 				belongs_to__user: user.id,
 				is_of__device_type: deviceType.id,
+				is_pinned_on__release: release?.id ?? null,
 				..._.pick(
 					jsonData,
 					'custom_latitude',


### PR DESCRIPTION
```
device.should_be_running__release := device.is_pinned_on__release ?? application.should_be_running__release
```

Depends-on: https://github.com/balena-io/open-balena-api/pull/1717
Change-type: minor
See: https://balena.fibery.io/Work/Project/Server-side-pagination-for-devices-Cycle-3-539