### PR TITLE
is_pinned_on__release: drop device "should_be_running__release" column if exist

### DIFF
--- a/src/migrations/00091-drop-device-should-be-running-release-column.sql
+++ b/src/migrations/00091-drop-device-should-be-running-release-column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "device"
+DROP COLUMN IF EXISTS "should be running-release";


### PR DESCRIPTION
is_pinned_on__release: remove device "should_be_running__release" index and column if they exist

Project: https://balena.fibery.io/Work/Project/Server-side-pagination-for-devices-Cycle-3-539#Project/Server-side-pagination-for-devices-Cycle-4-673

Change-type: patch