### PR TITLE
Fix v6 image.image_size no longer being a number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@balena/env-parsing": "^1.2.0",
         "@balena/es-version": "^1.0.3",
         "@balena/node-metrics-gatherer": "^6.0.3",
-        "@balena/pinejs": "^19.0.0",
+        "@balena/pinejs": "^19.0.2",
         "@balena/pinejs-webresource-cloudfront": "^0.2.1",
         "@sentry/node": "^8.30.0",
         "@types/basic-auth": "^1.1.8",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@balena/env-parsing": "^1.2.0",
     "@balena/es-version": "^1.0.3",
     "@balena/node-metrics-gatherer": "^6.0.3",
-    "@balena/pinejs": "^19.0.0",
+    "@balena/pinejs": "^19.0.2",
     "@balena/pinejs-webresource-cloudfront": "^0.2.1",
     "@sentry/node": "^8.30.0",
     "@types/basic-auth": "^1.1.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,10 @@ export const envVarsConfig = {
 	DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES,
 };
 
+// Needed so that the augmented `@balena/sbvr-types` typings
+// automatically become available to consumer projects.
+import './translations/v6/numeric-big-integer-hack.js';
+
 export const translations = {
 	v7: {
 		getTranslations: getV7Translations,

--- a/src/translations/v6/numeric-big-integer-hack.ts
+++ b/src/translations/v6/numeric-big-integer-hack.ts
@@ -1,0 +1,31 @@
+import SbvrTypes from '@balena/sbvr-types';
+import type * as TypeUtils from '@balena/sbvr-types/out/type-utils.js';
+
+// We use the TsTypes as the type name here so that it doesn't conflict later
+// when we augment the @balena/sbvr-types Types type.
+type TsTypes = TypeUtils.TsTypes<number, number>;
+export { TsTypes as Types };
+export type DbWriteType = number;
+
+// Augmenting is necessary so that the TS v6-model.ts compiles properly
+declare module '@balena/sbvr-types' {
+	export interface Types {
+		'Numeric Big Integer': TsTypes;
+	}
+}
+
+// @ts-expect-error we are augmenting SbvrTypes w/ Numeric Big Integer
+SbvrTypes.default['Numeric Big Integer'] = {
+	...SbvrTypes.default['Big Integer'],
+
+	fetchProcessing(data) {
+		const processedData =
+			SbvrTypes.default['Big Integer'].fetchProcessing(data);
+		if (processedData == null) {
+			return processedData;
+		}
+		return parseInt(processedData, 10);
+	},
+
+	validate: SbvrTypes.default.Integer.validate,
+} satisfies TypeUtils.SbvrType<TsTypes['Read'], TsTypes['Write'], DbWriteType>;

--- a/src/translations/v6/v6.ts
+++ b/src/translations/v6/v6.ts
@@ -1,3 +1,5 @@
+import './numeric-big-integer-hack.js';
+
 import type { ConfigLoader } from '@balena/pinejs';
 import {
 	aliasFields,
@@ -28,6 +30,13 @@ overrideFieldType(v6AbstractSqlModel, 'application', 'actor', 'Integer');
 for (const resource of ['device', 'application']) {
 	renameResourceField(v6AbstractSqlModel, resource, 'env var name', 'name');
 }
+
+overrideFieldType(
+	v6AbstractSqlModel,
+	'image',
+	'image size',
+	'Numeric Big Integer',
+);
 
 export const getV6Translations = (abstractSqlModel = v6AbstractSqlModel) => {
 	const deviceFieldSet = new Set(

--- a/test/fixtures/07-releases/images.json
+++ b/test/fixtures/07-releases/images.json
@@ -1,0 +1,11 @@
+{
+	"release1_image1": {
+		"user": "admin",
+		"service": "app1_service1",
+		"releases": [ "release1" ],
+		"image_size": "75123123123",
+		"project_type": "Dockerfile.template",
+		"build_log": "This is also the build log",
+		"status": "success"
+	}
+}

--- a/test/fixtures/07-releases/services.json
+++ b/test/fixtures/07-releases/services.json
@@ -1,0 +1,7 @@
+{
+	"app1_service1": {
+		"user": "admin",
+		"application": "app1",
+		"service_name": "app1_service1"
+	}
+}


### PR DESCRIPTION
Change-type: patch
See: https://github.com/balena-io/open-balena-api/pull/1730
See: https://github.com/balena-io-modules/sbvr-types/pull/106
See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/v6.20image.2Eimage_size.20is.20now.20a.20string/near/465509436
See: https://balena.fibery.io/Work/Project/Fix-image-delta-size-no-longer-being-a-number-in-versions-v6-810