### PR TITLE
Add test cases for different environment_variables scopes in state get

### DIFF
--- a/test/fixtures/03-device-state/application_environment_variables.json
+++ b/test/fixtures/03-device-state/application_environment_variables.json
@@ -1,0 +1,26 @@
+{
+	"app1_app": {
+		"user": "admin",
+		"application": "app1",
+		"name": "name_app",
+		"value": "value_app"
+	},
+	"app1_svc": {
+		"user": "admin",
+		"application": "app1",
+		"name": "name_svc",
+		"value": "value_app"
+	},
+	"app1_device": {
+		"user": "admin",
+		"application": "app1",
+		"name": "name_device",
+		"value": "value_app"
+	},
+	"app1_si": {
+		"user": "admin",
+		"application": "app1",
+		"name": "name_si",
+		"value": "value_app"
+	}
+}

--- a/test/fixtures/03-device-state/device_environment_variables.json
+++ b/test/fixtures/03-device-state/device_environment_variables.json
@@ -1,0 +1,14 @@
+{
+	"device1_device": {
+		"user": "admin",
+		"device": "device1",
+		"name": "name_device",
+		"value": "value_device"
+	},
+	"device1_si": {
+		"user": "admin",
+		"device": "device1",
+		"name": "name_si",
+		"value": "value_device"
+	}
+}

--- a/test/fixtures/03-device-state/device_service_environment_variables.json
+++ b/test/fixtures/03-device-state/device_service_environment_variables.json
@@ -1,0 +1,9 @@
+{
+	"si1_svc": {
+		"user": "admin",
+		"device": "device1",
+		"service": "app1_service1",
+		"name": "name_si",
+		"value": "value_si"
+	}
+}

--- a/test/fixtures/03-device-state/devices.json
+++ b/test/fixtures/03-device-state/devices.json
@@ -1,0 +1,9 @@
+{
+	"device1": {
+		"belongs_to__application": "app1",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"uuid": "c47e4dec05f76ee37c4b8e805c35c1eee54335803b3a40458928f8afce618c",
+		"is_pinned_on__release": "release1"
+	}
+}

--- a/test/fixtures/03-device-state/image_environment_variables.json
+++ b/test/fixtures/03-device-state/image_environment_variables.json
@@ -1,0 +1,32 @@
+{
+	"release1_image1_img": {
+		"user": "admin",
+		"image": "release1_image1",
+		"name": "name_img",
+		"value": "value_img"
+	},
+	"release1_image1_app": {
+		"user": "admin",
+		"image": "release1_image1",
+		"name": "name_app",
+		"value": "value_img"
+	},
+	"release1_image1_svc": {
+		"user": "admin",
+		"image": "release1_image1",
+		"name": "name_svc",
+		"value": "value_img"
+	},
+	"release1_image1_device": {
+		"user": "admin",
+		"image": "release1_image1",
+		"name": "name_device",
+		"value": "value_img"
+	},
+	"release1_image1_si": {
+		"user": "admin",
+		"image": "release1_image1",
+		"name": "name_si",
+		"value": "value_img"
+	}
+}

--- a/test/fixtures/03-device-state/service_environment_variables.json
+++ b/test/fixtures/03-device-state/service_environment_variables.json
@@ -1,0 +1,20 @@
+{
+	"svc1_svc": {
+		"user": "admin",
+		"service": "app1_service1",
+		"name": "name_svc",
+		"value": "value_svc"
+	},
+	"svc1_device": {
+		"user": "admin",
+		"service": "app1_service1",
+		"name": "name_device",
+		"value": "value_svc"
+	},
+	"svc1_si": {
+		"user": "admin",
+		"service": "app1_service1",
+		"name": "name_si",
+		"value": "value_svc"
+	}
+}


### PR DESCRIPTION
https://github.com/balena-io/open-balena-api/pull/1762 should use a different pass (not via service_install) to find the `service` env vars and service labels. We currently have no tests for the correct behaviour of env var overwriting. 

Change-type: patch