### PR TITLE
Pin minio/minio and minio/mc versions

### DIFF
--- a/docker-compose.test-custom.yml
+++ b/docker-compose.test-custom.yml
@@ -21,7 +21,7 @@ services:
     networks:
       - local-test
   minio-server:
-    image: minio/minio
+    image: minio/minio:RELEASE.2024-09-22T00-33-43Z
     environment:
       MINIO_ROOT_USER: USERNAME
       MINIO_ROOT_PASSWORD: PASSWORD
@@ -32,7 +32,7 @@ services:
     networks:
       - local-test
   minio-client:
-    image: minio/mc
+    image: minio/mc:RELEASE.2024-07-22T20-02-49Z
     depends_on:
       - minio-server
     entrypoint: >


### PR DESCRIPTION
This is necessary as the minio latest version is triggering for yet unknown reasons "Bucket not found" errors.

Change-type: patch