### PR TITLE
Avoid throwing when `service_install` not found in state-get endpoints

### DIFF
--- a/src/features/device-state/routes/state-get-v2.ts
+++ b/src/features/device-state/routes/state-get-v2.ts
@@ -91,22 +91,14 @@ function buildAppFromRelease(
 			({ service }) => service.__id === image.is_a_build_of__service[0].id,
 		);
 		const svc = image.is_a_build_of__service[0];
-		if (si == null) {
-			throw new Error(
-				`Could not find service install for device: '${
-					application.id
-				}', image: '${image?.id}', service: '${JSON.stringify(
-					svc,
-				)}', service installs: '${JSON.stringify(device.service_install)}'`,
-			);
-		}
-
 		const environment: Dictionary<string> = {};
 		varListInsert(ipr.image_environment_variable, environment);
 		varListInsert(application.application_environment_variable, environment);
 		varListInsert(svc.service_environment_variable, environment);
 		varListInsert(device.device_environment_variable, environment);
-		varListInsert(si.device_service_environment_variable, environment);
+		if (si != null) {
+			varListInsert(si.device_service_environment_variable, environment);
+		}
 
 		const labels: Dictionary<string> = {};
 		for (const { label_name, value } of [

--- a/src/features/device-state/routes/state-get-v3.ts
+++ b/src/features/device-state/routes/state-get-v3.ts
@@ -157,16 +157,9 @@ export function buildAppFromRelease(
 		if (device != null) {
 			varListInsert(device.device_environment_variable, environment);
 			const si = serviceInstallFromImage(device, image);
-			if (si == null) {
-				throw new Error(
-					`Could not find service install for device or application: '${
-						application.uuid
-					}', image: '${image?.id}', service: '${JSON.stringify(
-						svc,
-					)}', service_install: '${JSON.stringify(device.service_install)}'`,
-				);
+			if (si != null) {
+				varListInsert(si.device_service_environment_variable, environment);
 			}
-			varListInsert(si.device_service_environment_variable, environment);
 		}
 
 		const labels: Dictionary<string> = {


### PR DESCRIPTION
A given device does not require that the service_install has been previously created in order for state-get to work.

Change-type: patch