### PR TITLE
Add support for power mode & fan profile boot configs

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -382,6 +382,34 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 			},
 		},
 	),
+	...getDefinitionWithMinimumSupervisorVersion(
+		{
+			'16.10.0': [
+				'jetson-agx-orin-devkit',
+				'jetson-agx-orin-devkit-64gb',
+				'jetson-orin-nano-devkit-nvme',
+				'jetson-orin-nano-seeed-j3010',
+				'jetson-orin-nx-seeed-j4012',
+				'jetson-orin-nx-xavier-nx-devkit',
+			],
+		},
+		{
+			BALENA_HOST_CONFIG_power_mode: {
+				type: 'string',
+				description:
+					'Define the device power mode. Supported by OS with Jetpack 6 or higher.',
+				examples: ['low', 'mid', 'high', 'default'],
+				will_reboot: true,
+			},
+			BALENA_HOST_CONFIG_fan_profile: {
+				type: 'string',
+				description:
+					'Define the device fan profile. Supported by OS with Jetpack 6 or higher.',
+				examples: ['quiet', 'cool', 'default'],
+				will_reboot: false,
+			},
+		},
+	),
 ];
 
 const startsWithAny = (ns: string[], name: string) => {


### PR DESCRIPTION
The boot configs will apply to devices with Jetpack 6 OS's initially, and require Supervisor v16.10.0 or newer. This may change in the future if we add support for older Jetpack versions.

See: https://github.com/balena-os/balena-supervisor/pull/2379
See: https://github.com/balena-os/balena-jetson-orin/pull/513

Change-type: minor