### PR TITLE
device-types: Sync only device-types with DB device_type records

### DIFF
--- a/src/features/device-types/device-types-list.ts
+++ b/src/features/device-types/device-types-list.ts
@@ -1,5 +1,5 @@
 import type { DeviceTypeJson } from './device-type-json.js';
-import { errors } from '@balena/pinejs';
+import { errors, permissions, sbvrUtils } from '@balena/pinejs';
 import * as semver from 'balena-semver';
 const { InternalRequestError } = errors;
 
@@ -18,6 +18,8 @@ import {
 	CONTRACT_ALLOWLIST,
 	IMAGE_STORAGE_DEBUG_REQUEST_ERRORS,
 } from '../../lib/config.js';
+
+const { api } = sbvrUtils;
 
 export interface DeviceTypeInfo {
 	latest: DeviceTypeJson;
@@ -61,25 +63,41 @@ const getFirstValidBuild = async (
 	}
 };
 
+const ALLOWLISTED_DT_SLUGS: string[] = [];
+for (const contractPath of CONTRACT_ALLOWLIST) {
+	const allowListedDtSlug = /^hw.device-type\/([\w-]+)$/.exec(
+		contractPath,
+	)?.[1];
+	if (allowListedDtSlug != null) {
+		ALLOWLISTED_DT_SLUGS.push(allowListedDtSlug);
+	}
+}
+
 export const getDeviceTypes = multiCacheMemoizee(
 	async (): Promise<Dictionary<DeviceTypeInfo>> => {
 		const result: Dictionary<DeviceTypeInfo> = {};
-		let slugs = await listFolders(IMAGE_STORAGE_PREFIX);
+		let deviceTypes = await api.resin.get({
+			resource: 'device_type',
+			passthrough: { req: permissions.rootRead },
+			options: {
+				$select: 'slug',
+				...(ALLOWLISTED_DT_SLUGS.length > 0 && {
+					$filter: {
+						slug: { $in: ALLOWLISTED_DT_SLUGS },
+					},
+				}),
+			},
+		});
 
-		// If there are explicit includes, then everything else is excluded so we need to
-		// filter the slugs list to include only contracts that are in the CONTRACT_ALLOWLIST map
-		if (CONTRACT_ALLOWLIST.size > 0) {
-			const before = slugs.length;
-			slugs = slugs.filter((slug) =>
-				CONTRACT_ALLOWLIST.has(`hw.device-type/${slug}`),
-			);
-			console.log(
-				`CONTRACT_ALLOWLIST reduced device type slugs from ${before} to ${slugs.length}`,
-			);
+		if (deviceTypes.length > 0) {
+			// This is an optimization to avoid multiple 404 queries for DTs that
+			// have a DB record but do not have an OS release published yet.
+			const s3DtSlugs = new Set(await listFolders(IMAGE_STORAGE_PREFIX));
+			deviceTypes = deviceTypes.filter(({ slug }) => s3DtSlugs.has(slug));
 		}
 
 		await Promise.all(
-			slugs.map(async (slug) => {
+			deviceTypes.map(async ({ slug }) => {
 				try {
 					const builds = await listFolders(getImageKey(slug));
 					if (builds.length === 0) {
@@ -111,7 +129,7 @@ export const getDeviceTypes = multiCacheMemoizee(
 			}),
 		);
 
-		if (slugs.length > 0 && Object.keys(result).length === 0) {
+		if (deviceTypes.length > 0 && Object.keys(result).length === 0) {
 			throw new InternalRequestError('Could not retrieve any device type');
 		}
 		return result;

--- a/src/features/device-types/hooks/device-types-cache-invalidation.ts
+++ b/src/features/device-types/hooks/device-types-cache-invalidation.ts
@@ -2,10 +2,13 @@ import { hooks } from '@balena/pinejs';
 import { getDeviceTypes } from '../device-types-list.js';
 
 hooks.addPureHook('POST', 'resin', 'device_type', {
-	POSTRUN: ({ result }) => {
+	POSTRUN: ({ request, result }) => {
 		if (typeof result !== 'number') {
 			return;
 		}
+		console.log(
+			`[device-types]: New device_type ${request.values.slug} was created, invalidating device-types cache.`,
+		);
 		// no need to wait for the cache invalidation
 		void getDeviceTypes.delete();
 	},
@@ -14,6 +17,9 @@ hooks.addPureHook('POST', 'resin', 'device_type', {
 hooks.addPureHook('POST', 'resin', 'application', {
 	POSTRUN: ({ request }) => {
 		if (request.values.is_host) {
+			console.log(
+				`[device-types]: New hostApp ${request.values.slug} was created, invalidating device-types cache.`,
+			);
 			// no need to wait for the cache invalidation
 			void getDeviceTypes.delete();
 		}
@@ -24,6 +30,9 @@ hooks.addPureHook('PATCH', 'resin', 'application', {
 	POSTRUN: ({ request }) => {
 		const affectedIds = request.affectedIds!;
 		if (request.values.is_host && affectedIds.length !== 0) {
+			console.log(
+				`[device-types]: Application(s) ${affectedIds.join(',')} were marked as host, invalidating device-types cache.`,
+			);
 			// no need to wait for the cache invalidation
 			void getDeviceTypes.delete();
 		}

--- a/src/features/device-types/hooks/device-types-cache-invalidation.ts
+++ b/src/features/device-types/hooks/device-types-cache-invalidation.ts
@@ -1,6 +1,16 @@
 import { hooks } from '@balena/pinejs';
 import { getDeviceTypes } from '../device-types-list.js';
 
+hooks.addPureHook('POST', 'resin', 'device_type', {
+	POSTRUN: ({ result }) => {
+		if (typeof result !== 'number') {
+			return;
+		}
+		// no need to wait for the cache invalidation
+		void getDeviceTypes.delete();
+	},
+});
+
 hooks.addPureHook('POST', 'resin', 'application', {
 	POSTRUN: ({ request }) => {
 		if (request.values.is_host) {


### PR DESCRIPTION
Fixes: #1696
Fixes: #1433
Fixes: #1060

Change-type: patch
See: https://balena.fibery.io/Work/Project/Migrate-legacy-hostapp-S3-artifacts-to-web-resources-1674
See: https://balena.fibery.io/Work/Project/2470