### PR TITLE
Service installs: Fix creating two tasks when moving a device

### DIFF
--- a/src/features/ci-cd/hooks/service-installs.ts
+++ b/src/features/ci-cd/hooks/service-installs.ts
@@ -287,18 +287,18 @@ hooks.addPureHook('PATCH', 'resin', 'device', {
 		const affectedIds = await sbvrUtils.getAffectedIds(args);
 		if (affectedIds.length !== 0) {
 			await deleteServiceInstallsForCurrentApp(args.api, newAppId, affectedIds);
-			await createAppServiceInstalls(args.api, newAppId, affectedIds, args.tx);
 		}
 	},
-});
-
-hooks.addPureHook('PATCH', 'resin', 'device', {
 	POSTRUN: async ({ api, request, tx }) => {
 		const affectedIds = request.affectedIds!;
-		if (
-			request.values.is_pinned_on__release !== undefined &&
-			affectedIds.length !== 0
-		) {
+		if (affectedIds.length === 0) {
+			return;
+		}
+		const newAppId = request.values.belongs_to__application;
+		if (newAppId != null) {
+			await createAppServiceInstalls(api, newAppId, affectedIds, tx);
+		}
+		if (request.values.is_pinned_on__release !== undefined) {
 			// If the device was preloaded, and then pinned, service_installs do not exist
 			// for this device+release combination. We need to create these
 			if (request.values.is_pinned_on__release != null) {

--- a/src/features/ci-cd/hooks/service-installs.ts
+++ b/src/features/ci-cd/hooks/service-installs.ts
@@ -296,7 +296,14 @@ hooks.addPureHook('PATCH', 'resin', 'device', {
 		}
 		const newAppId = request.values.belongs_to__application;
 		if (newAppId != null) {
+			// We could also have an optimization for the case that `values.is_pinned_on__release != null`
+			// to make the part that finds the target release faster, but chose to keep this simpler since:
+			// a) We expect that in the majority of device move requests users will not be also be pinning
+			//    the device at the same time.
+			// b) Only the sync approach would benefit from it, since creating the service installs via tasks
+			//    (which is going to be the default), only accepts the deviceIds as a parameter,
 			await createAppServiceInstalls(api, newAppId, affectedIds, tx);
+			return;
 		}
 		if (request.values.is_pinned_on__release !== undefined) {
 			// If the device was preloaded, and then pinned, service_installs do not exist

--- a/test/25_service-installs.ts
+++ b/test/25_service-installs.ts
@@ -8,6 +8,7 @@ import * as fixtures from './test-lib/fixtures.js';
 import { assertExists, expectToEventually } from './test-lib/common.js';
 import * as config from '../src/lib/config.js';
 import { supertest } from './test-lib/supertest.js';
+import { expectNewTasks, resetLatestTaskIds } from './test-lib/api-helpers.js';
 
 export default () => {
 	versions.test((version, pineTest) => {
@@ -45,6 +46,8 @@ export default () => {
 
 					config.TEST_MOCK_ONLY.ASYNC_TASK_CREATE_SERVICE_INSTALLS_ENABLED =
 						isServiceInstallEnabled;
+
+					await resetLatestTaskIds('create_service_installs');
 				});
 
 				after(async () => {
@@ -74,6 +77,19 @@ export default () => {
 							ctx.app1Service1.id,
 						);
 					});
+					await expectNewTasks(
+						'create_service_installs',
+						isServiceInstallEnabled
+							? [
+									{
+										is_executed_with__parameter_set: {
+											devices: [ctx.device.id],
+										},
+										status: 'succeeded',
+									},
+								]
+							: [],
+					);
 				});
 
 				it('for pinning an application to a release', async () => {
@@ -104,6 +120,19 @@ export default () => {
 							ctx.app1Service2.id,
 						);
 					});
+					await expectNewTasks(
+						'create_service_installs',
+						isServiceInstallEnabled
+							? [
+									{
+										is_executed_with__parameter_set: {
+											devices: [ctx.device.id],
+										},
+										status: 'succeeded',
+									},
+								]
+							: [],
+					);
 				});
 
 				it('when a device is pinned on a different release', async () => {
@@ -133,6 +162,19 @@ export default () => {
 							ctx.app1Service3.id,
 						);
 					});
+					await expectNewTasks(
+						'create_service_installs',
+						isServiceInstallEnabled
+							? [
+									{
+										is_executed_with__parameter_set: {
+											devices: [ctx.device.id],
+										},
+										status: 'succeeded',
+									},
+								]
+							: [],
+					);
 				});
 
 				it('when device is moved to different application', async () => {
@@ -170,6 +212,27 @@ export default () => {
 							ctx.app2Service1.id,
 						);
 					});
+					await expectNewTasks(
+						'create_service_installs',
+						isServiceInstallEnabled
+							? [
+									// the first one is from unpinning
+									{
+										is_executed_with__parameter_set: {
+											devices: [ctx.device.id],
+										},
+										status: 'succeeded',
+									},
+									// the second one is from moving application
+									{
+										is_executed_with__parameter_set: {
+											devices: [ctx.device.id],
+										},
+										status: 'succeeded',
+									},
+								]
+							: [],
+					);
 				});
 
 				it('should be able to use service_install to create a device_service_environment_variable', async () => {


### PR DESCRIPTION
Before this, we had two device PATCH hooks, (a) one handling device moves, and (b) one handling device pinning&unpinning, but we also have (c) a separate hook that unpins devices when moved. As a result when moving a device (c) would change the values so that the payload includes both `belongs_to__application` & `is_pinned_on__release`, hence both (a) & (b) hook would run and try to create any missing service install, which other than the extra work, it also means that if task based service install creation was enabled, would cause two tasks to be added.

Change-type: patch