### PR TITLE
Remove usage of service_install resource on state get v2

### DIFF
--- a/src/features/device-state/routes/state-get-v2.ts
+++ b/src/features/device-state/routes/state-get-v2.ts
@@ -87,18 +87,16 @@ function buildAppFromRelease(
 		// extract the per-image information
 		const image = ipr.image[0];
 
-		const si = device.service_install.find(
-			({ service }) => service.__id === image.is_a_build_of__service[0].id,
-		);
 		const svc = image.is_a_build_of__service[0];
 		const environment: Dictionary<string> = {};
 		varListInsert(ipr.image_environment_variable, environment);
 		varListInsert(application.application_environment_variable, environment);
 		varListInsert(svc.service_environment_variable, environment);
 		varListInsert(device.device_environment_variable, environment);
-		if (si != null) {
-			varListInsert(si.device_service_environment_variable, environment);
-		}
+		const dsev = device.device_service_environment_variable.filter(
+			({ service }) => service.__id === svc.id,
+		);
+		varListInsert(dsev, environment);
 
 		const labels: Dictionary<string> = {};
 		for (const { label_name, value } of [
@@ -208,13 +206,8 @@ const stateQuery = _.once(() =>
 							},
 						},
 					},
-					service_install: {
-						$select: ['id', 'service'],
-						$expand: {
-							device_service_environment_variable: {
-								$select: ['name', 'value'],
-							},
-						},
+					device_service_environment_variable: {
+						$select: ['name', 'value', 'service'],
 					},
 					belongs_to__application: {
 						$select: ['id', 'app_name'],

--- a/test/03_device-state.ts
+++ b/test/03_device-state.ts
@@ -1135,6 +1135,7 @@ export default () => {
 							name_svc: 'value_app',
 							name_device: 'value_device',
 							name_si: 'value_device',
+							name_si_3: 'value_si_3',
 						};
 
 						if (stateVersion === 'v2') {

--- a/test/fixtures/03-device-state/device_service_environment_variables.json
+++ b/test/fixtures/03-device-state/device_service_environment_variables.json
@@ -5,5 +5,19 @@
 		"service": "app1_service1",
 		"name": "name_si",
 		"value": "value_si"
+	},
+	"si2_svc": {
+		"user": "admin",
+		"device": "device2",
+		"service": "app1_service1",
+		"name": "name_si_2",
+		"value": "value_si_2"
+	},
+	"si3_svc2": {
+		"user": "admin",
+		"device": "device1",
+		"service": "app1_service2",
+		"name": "name_si_3",
+		"value": "value_si_3"
 	}
 }

--- a/test/fixtures/03-device-state/devices.json
+++ b/test/fixtures/03-device-state/devices.json
@@ -5,5 +5,12 @@
 		"belongs_to__user": "admin",
 		"uuid": "c47e4dec05f76ee37c4b8e805c35c1eee54335803b3a40458928f8afce618c",
 		"is_pinned_on__release": "release1"
+	},
+	"device2": {
+		"belongs_to__application": "app1",
+		"device_type": "raspberry-pi",
+		"belongs_to__user": "admin",
+		"uuid": "b47e4dec05f76ee37c4b8e805c35c1eee54335803b3a40458928f8afce618c",
+		"is_pinned_on__release": "release1"
 	}
 }


### PR DESCRIPTION
This is an alternative approach to https://github.com/balena-io/open-balena-api/pull/1853 which I think it is better as it does use a bit more of API cpu but should reduce DB read cpu in favor of it.

Change-type: patch