### PR TITLE
tests: Increase the timeout of the supervisor notification test when deleting 2^16 env vars

### DIFF
--- a/test/20_supervisor_notification.ts
+++ b/test/20_supervisor_notification.ts
@@ -164,6 +164,8 @@ export default () => {
 				});
 
 				it(`should notify the supervisor after deleting ${testVarsCount} device_environment_variables`, async function () {
+					// Use the request timeout, since this is going to delete MAX_SAFE_SQL_BINDS+1 rows
+					this.timeout(59000);
 					await connectDeviceAndWaitForUpdate(
 						device.uuid,
 						version,


### PR DESCRIPTION
Change-type: patch