### PR TITLE
Loki: Use structured metadata for device ids instead of labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "ipaddr.js": "^2.2.0",
         "jsonwebtoken": "^9.0.2",
         "lodash": "^4.17.21",
-        "loki-grpc-client": "^2.0.0",
+        "loki-grpc-client": "^2.2.0",
         "memoizee": "^0.4.17",
         "morgan": "^1.10.0",
         "ndjson": "^2.0.0",
@@ -11072,9 +11072,9 @@
       }
     },
     "node_modules/loki-grpc-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/loki-grpc-client/-/loki-grpc-client-2.1.0.tgz",
-      "integrity": "sha512-pp8JTFEdNocw1ZLqeXUsUIFIp6f7kI0CcmjMIRs2umKhAVd6a3VWuMeZHvti50EfOB6GFhC7d20r4Kxq8QItiQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/loki-grpc-client/-/loki-grpc-client-2.2.0.tgz",
+      "integrity": "sha512-OFHDYrU7Ur15ulvhKwOWZetUCwh/6igWVighLxiIouz3Jb3mREFKd95pneldNMO6wBajzui5wH2aUwV+lht4ZQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "ipaddr.js": "^2.2.0",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
-    "loki-grpc-client": "^2.0.0",
+    "loki-grpc-client": "^2.2.0",
     "memoizee": "^0.4.17",
     "morgan": "^1.10.0",
     "ndjson": "^2.0.0",


### PR DESCRIPTION
Update loki-grpc-client from 2.0.0 to 2.2.0

Change-type: major