### PR TITLE
vars-schema/env-vars: Drop "default" setting from power_mode

### DIFF
--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -398,7 +398,7 @@ export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 				type: 'string',
 				description:
 					'Define the device power mode. Supported by OS with Jetpack 6 or higher.',
-				examples: ['low', 'mid', 'high', 'default'],
+				examples: ['low', 'mid', 'high'],
 				will_reboot: true,
 			},
 			BALENA_HOST_CONFIG_fan_profile: {


### PR DESCRIPTION
The 'default' setting is only supported for fan-profile, and not for power mode. Let's drop this from the examples.

Change-type: patch