### PR TITLE
Logs: differentiate between internal/output logs to reduce processing

### DIFF
--- a/src/features/device-logs/lib/struct.ts
+++ b/src/features/device-logs/lib/struct.ts
@@ -8,16 +8,22 @@ export interface LokiLogContext extends LogContext {
 	readonly appId: string;
 }
 
-// This is the format we store and that we output to consumers
-export interface DeviceLog {
+// This is the base format that we receive from consumers after validation
+interface DeviceLog {
 	message: string;
-	nanoTimestamp: bigint;
-	// These 2 dates are timestamps including milliseconds
-	createdAt: number;
+	// This is a timestamp including milliseconds
 	timestamp: number;
 	isSystem: boolean;
 	isStdErr: boolean;
 	serviceId?: number;
+}
+// This is the format we use internally
+export interface InternalDeviceLog extends DeviceLog {
+	nanoTimestamp: bigint;
+}
+// This is the format that we output to consumers
+export interface OutputDeviceLog extends DeviceLog {
+	createdAt: number;
 }
 
 // This is the format we get from new supervisors
@@ -42,15 +48,15 @@ export interface OldSupervisorLog {
 	image_id?: number;
 }
 
-export type Subscription = (log: DeviceLog) => void;
+export type Subscription = (log: OutputDeviceLog) => void;
 
 export interface DeviceLogsBackend {
-	history(ctx: LogContext, count: number): Promise<DeviceLog[]>;
+	history(ctx: LogContext, count: number): Promise<OutputDeviceLog[]>;
 	available: boolean;
 	/**
 	 * `logs` will be mutated to empty and so must be handled synchronously
 	 */
-	publish(ctx: LogContext, logs: DeviceLog[]): Promise<any>;
+	publish(ctx: LogContext, logs: InternalDeviceLog[]): Promise<any>;
 	subscribe(ctx: LogContext, subscription: Subscription): void;
 	unsubscribe(ctx: LogContext, subscription: Subscription): void;
 }

--- a/src/features/device-logs/lib/supervisor.ts
+++ b/src/features/device-logs/lib/supervisor.ts
@@ -2,13 +2,17 @@ import _ from 'lodash';
 
 import { errors } from '@balena/pinejs';
 
-import type { DeviceLog, OldSupervisorLog, SupervisorLog } from './struct.js';
+import type {
+	InternalDeviceLog,
+	OldSupervisorLog,
+	SupervisorLog,
+} from './struct.js';
 import { getNanoTimestamp } from '../../../lib/utils.js';
 
 const MAX_LOGS_PER_BATCH = 10;
 
 export class Supervisor {
-	public convertLogs(logs: SupervisorLog[]): DeviceLog[] {
+	public convertLogs(logs: SupervisorLog[]): InternalDeviceLog[] {
 		if (logs.length > MAX_LOGS_PER_BATCH) {
 			throw new errors.BadRequestError(
 				`Batches cannot include more than ${MAX_LOGS_PER_BATCH} logs`,
@@ -22,7 +26,7 @@ export class Supervisor {
 			.value();
 	}
 
-	private convertAnyLog(log: SupervisorLog): DeviceLog | undefined {
+	private convertAnyLog(log: SupervisorLog): InternalDeviceLog | undefined {
 		if (this.isOldLog(log)) {
 			// Old format supervisor logs are no longer supported
 			throw new errors.BadRequestError();
@@ -32,7 +36,7 @@ export class Supervisor {
 
 	public convertLog(log: {
 		[key in keyof SupervisorLog]: unknown;
-	}): DeviceLog | undefined {
+	}): InternalDeviceLog | undefined {
 		// see struct.ts for explanation on this
 		if (log.uuid) {
 			return;
@@ -43,9 +47,8 @@ export class Supervisor {
 		if (typeof log.timestamp !== 'number') {
 			throw new errors.BadRequestError('DeviceLog timestamp must be number');
 		}
-		const validatedLog: DeviceLog = {
+		const validatedLog: InternalDeviceLog = {
 			nanoTimestamp: getNanoTimestamp(),
-			createdAt: Date.now(),
 			timestamp: log.timestamp,
 			isSystem: log.isSystem === true,
 			isStdErr: log.isStdErr === true,


### PR DESCRIPTION
This avoids adding the `createdAt`/`nanoTimestamp` timestamps at points
when they are not actually necessary/expected

Change-type: patch
