### PR TITLE
Only accept fully valid ints in `checkInt`

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,6 +24,10 @@ export const checkInt = (num?: string): number | false => {
 	if (num == null) {
 		return false;
 	}
+	// If the string contains non-integer characters then it's not a valid integer, even if `parseInt` might turn it into one
+	if (!/^-?[0-9]+$/.test(num)) {
+		return false;
+	}
 	const n = parseInt(num, 10);
 	if (Number.isNaN(n)) {
 		return false;


### PR DESCRIPTION
We now reject if the passed in string contains any non-int characters to ensure that it was indeed an int that was passed to us and not just something that could be converted to one even though it is not actually an int

Change-type: patch