### PR TITLE
minor: add secureboot to device-config endpoint

### DIFF
--- a/src/features/device-config/device-config.ts
+++ b/src/features/device-config/device-config.ts
@@ -150,5 +150,13 @@ export const generateConfig = async (
 		config.developmentMode = true;
 	}
 
+	const securebootInstaller = getBodyOrQueryParam(
+		req,
+		'secureboot',
+	)?.toString();
+	if (['true', 'on', '1'].includes(securebootInstaller || '')) {
+		config.installer = { secureboot: true };
+	}
+
 	return config;
 };

--- a/test/05_device-config.ts
+++ b/test/05_device-config.ts
@@ -111,6 +111,22 @@ export default () => {
 					expect(body).to.have.a.property('logsEndpoint');
 					expect(body.logsEndpoint).to.match(/^https:\/\//);
 				});
+
+				it('should contain installer: secureboot in response config if asked for secureboot', async function () {
+					const { body } = await supertest(this.user)
+						.post('/download-config')
+						.send({
+							appId: this.application.id,
+							version: 'v2.24.0',
+							deviceType: 'raspberrypi3',
+							secureboot: true,
+						})
+						.expect(200)
+						.expect('content-type', /^application\/json/);
+
+					expect(body).to.have.a.property('installer');
+					expect(body.installer).to.have.a.property('secureboot', true);
+				});
 			});
 		});
 	});


### PR DESCRIPTION
To provision device with secureboot, we need the config.json to contain the secureboot installer entry.

- [FIBERY](https://balena.fibery.io/Work/Improvement/Update-the-device-config-backend-for-config.json-2609)