### PR TITLE
Support $orderby based on a unique reverse navigation resource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@balena/env-parsing": "^1.2.0",
         "@balena/es-version": "^1.0.3",
         "@balena/node-metrics-gatherer": "^6.0.3",
-        "@balena/pinejs": "^21.0.3",
+        "@balena/pinejs": "^21.1.0",
         "@balena/pinejs-webresource-cloudfront": "^1.0.2",
         "@balena/pinejs-webresource-s3": "^1.0.4",
         "@opentelemetry/api": "^1.9.0",
@@ -1317,9 +1317,9 @@
       }
     },
     "node_modules/@balena/odata-to-abstract-sql": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@balena/odata-to-abstract-sql/-/odata-to-abstract-sql-7.1.6.tgz",
-      "integrity": "sha512-g8BnpcmrqEA+PVvJmdX8GKVNMsKz5VxOsFNO+n4sTcKPk9siafPvsBxgYgZGclfuiCNjK4bQgypcAnCIqCX9iw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@balena/odata-to-abstract-sql/-/odata-to-abstract-sql-7.2.0.tgz",
+      "integrity": "sha512-g7AyHjMLht213pE4dlUJ1lM86DMw9Uc98f+4+EhPNt+LGPjfd8IjAI2IBuPigr3n+DwG0qYo4J/XGU/eqyxAUg==",
       "license": "BSD",
       "dependencies": {
         "@balena/abstract-sql-compiler": "^10.2.0",
@@ -1337,9 +1337,9 @@
       }
     },
     "node_modules/@balena/pinejs": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@balena/pinejs/-/pinejs-21.0.3.tgz",
-      "integrity": "sha512-4m7wRovbpZdmOsp2xH4OGSsyAnsOzJ8krf0rvQ39SxfcouYUuDTKgQLg7KDlmdESk0tpLFiVm8QgL7WdIHyyMQ==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@balena/pinejs/-/pinejs-21.1.0.tgz",
+      "integrity": "sha512-KuNdsP/7pD9frwYVryLXkDmiGZxYrWxPhUnl7QNMZAYvkTeLDppgQBsafQbZicf+CPURuokNKvtIfJMCz9FIbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/abstract-sql-compiler": "^10.2.3",
@@ -1347,7 +1347,7 @@
         "@balena/env-parsing": "^1.2.4",
         "@balena/lf-to-abstract-sql": "^5.0.3",
         "@balena/odata-parser": "^4.2.2",
-        "@balena/odata-to-abstract-sql": "^7.1.6",
+        "@balena/odata-to-abstract-sql": "^7.2.0",
         "@balena/sbvr-parser": "^1.4.9",
         "@balena/sbvr-types": "^9.2.2",
         "@types/body-parser": "^1.19.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@balena/env-parsing": "^1.2.0",
     "@balena/es-version": "^1.0.3",
     "@balena/node-metrics-gatherer": "^6.0.3",
-    "@balena/pinejs": "^21.0.3",
+    "@balena/pinejs": "^21.1.0",
     "@balena/pinejs-webresource-cloudfront": "^1.0.2",
     "@balena/pinejs-webresource-s3": "^1.0.4",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
Update @balena/pinejs from 21.0.3 to 21.1.0

Depends-on: balena-io-modules/odata-parser#96
Depends-on: https://github.com/balena-io-modules/odata-to-abstract-sql/pull/165
Change-type: minor
See: balena-io/pinejs#824
See: https://balena.fibery.io/Work/Project/Shape--Build-Add-support-for-sorting-on-user-selected-tag-columns-in-the-server-side-paginated-devic-912