### PR TITLE
patch: fasttest: Stop syncing @swc, @oxc-resolver and oxc-resolver th…

### DIFF
--- a/docker-compose.test-custom.yml
+++ b/docker-compose.test-custom.yml
@@ -146,6 +146,9 @@ services:
         - /usr/src/app/node_modules/nan
         - /usr/src/app/node_modules/node-addon-api
         - /usr/src/app/node_modules/@napi-rs
+        - /usr/src/app/node_modules/@swc
+        - /usr/src/app/node_modules/@oxc-resolver
+        - /usr/src/app/node_modules/oxc-resolver
         - ./package.json:/usr/src/app/package.json
         - ./package-lock.json:/usr/src/app/package-lock.json
         - ./config.ts:/usr/src/app/config.ts


### PR DESCRIPTION
fasttest: Stop syncing @swc, @oxc-resolver and oxc-resolver that have a native build step

related to: https://github.com/balena-io/balena-api/pull/5630/commits/f0b2b516756ad5d1286ee32324cebfb6c3cc860c