### PR TITLE
Tests: use faster config for postgres

### DIFF
--- a/docker-compose.test-custom.yml
+++ b/docker-compose.test-custom.yml
@@ -7,6 +7,13 @@ services:
       - "5431:5432"
     networks:
       - local-test
+    command:
+      - -c
+      - synchronous_commit=off
+      - -c
+      - fsync=off
+      - -c
+      - full_page_writes=off
   redis:
     image: valkey/valkey:8-alpine
     ports:


### PR DESCRIPTION
These settings are not safe for data we care about as we might lose or corrupt data in the case of power failure, but for test data where that is not an issue they offer a performance benefit

Change-type: patch