### PR TITLE
Test $orderby using a nullable navigation resource

### DIFF
--- a/test/fixtures/18-resource-filtering/applications.json
+++ b/test/fixtures/18-resource-filtering/applications.json
@@ -1,0 +1,7 @@
+{
+	"app0": {
+		"user": "admin",
+		"device_type": "intel-nuc",
+		"app_name": "appapp0"
+	}
+}

--- a/test/fixtures/18-resource-filtering/images.json
+++ b/test/fixtures/18-resource-filtering/images.json
@@ -1,0 +1,11 @@
+{
+	"release1_image1": {
+		"user": "admin",
+		"service": "app0_service1",
+		"releases": [ "release1" ],
+		"image_size": 2048,
+		"project_type": "Dockerfile.template",
+		"build_log": "This is also the build log",
+		"status": "success"
+	}
+}

--- a/test/fixtures/18-resource-filtering/releases.json
+++ b/test/fixtures/18-resource-filtering/releases.json
@@ -1,0 +1,36 @@
+{
+	"release1": {
+		"user": "admin",
+		"application": "app0",
+		"commit": "deadc0de",
+		"status": "success",
+		"composition": {
+			"services": {
+				"image1": {
+					"build": "./image1/"
+				},
+				"image2": {
+					"build": "./image2/"
+				}
+			}
+		},
+		"source": "cloud"
+	},
+	"release2": {
+		"user": "admin",
+		"application": "app0",
+		"commit": "deadc0d3",
+		"status": "success",
+		"composition": {
+			"services": {
+				"image1": {
+					"build": "./image1/"
+				},
+				"image2": {
+					"build": "./image2/"
+				}
+			}
+		},
+		"source": "cloud"
+	}
+}

--- a/test/fixtures/18-resource-filtering/services.json
+++ b/test/fixtures/18-resource-filtering/services.json
@@ -1,0 +1,12 @@
+{
+	"app0_service1": {
+		"user": "admin",
+		"application": "app0",
+		"service_name": "app1_service1"
+	},
+	"app0_service2": {
+		"user": "admin",
+		"application": "app0",
+		"service_name": "app1_service2"
+	}
+}


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Project/Fix-removal-of-rows-with-null-values-when-sorting-by-an-associated-resource-984