### PR TITLE
Sentry: ignore request body for devices streaming logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@opentelemetry/instrumentation-express": "^0.47.1",
         "@opentelemetry/instrumentation-http": "^0.57.2",
         "@opentelemetry/sdk-node": "^0.57.2",
-        "@sentry/node": "^9.6.1",
+        "@sentry/node": "^9.12.0",
         "@swc-node/register": "^1.10.9",
         "@types/basic-auth": "^1.1.8",
         "@types/cache-manager": "^4.0.6",
@@ -3691,18 +3691,18 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.6.1.tgz",
-      "integrity": "sha512-BHaRxyFF3sNlKP6lNcB5cxFogvfMOtWw0Est6mK/Mbewnim0qEbmqKyuMj67ebfgo+pmUJJc2wgugdxkxvqGRQ==",
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.12.0.tgz",
+      "integrity": "sha512-jOqQK/90uzHmsBvkPTj/DAEFvA5poX4ZRyC7LE1zjg4F5jdOp3+M4W3qCy0CkSTu88Zu5VWBoppCU2Bs34XEqg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.6.1.tgz",
-      "integrity": "sha512-cS05ROvBvAFbooqIdyw+yvPyVJqJ89bcirf/QwtFJm+4REtbI7+UAn3D9l17Zd41G1FtpQynpebkCyMc22jO/Q==",
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.12.0.tgz",
+      "integrity": "sha512-NZHneJovlLOdde85vJAIs7vIki36EfJ234d6YXHUE+874sxKMknB/wrzAZi5XS5nqT3kqIXD5KgjgDTjrhAENQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -3736,8 +3736,8 @@
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.30.0",
         "@prisma/instrumentation": "6.5.0",
-        "@sentry/core": "9.6.1",
-        "@sentry/opentelemetry": "9.6.1",
+        "@sentry/core": "9.12.0",
+        "@sentry/opentelemetry": "9.12.0",
         "import-in-the-middle": "^1.13.0"
       },
       "engines": {
@@ -3745,12 +3745,12 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.6.1.tgz",
-      "integrity": "sha512-KjWOcYEoRiwlHxfWTnEQKErpa4c1BubsJFCezqV64BOTV2vX09AjdJo33PrPjstGopDloLdkqJS60KBhVl49JQ==",
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.12.0.tgz",
+      "integrity": "sha512-jQfI/UmgDDbcWY439r1Jz0Y4mqNn3a2JwruWfCHWzIqQMOgBzkzcp9lbZMx9iU+x1iZTTp9s80Dy5F9nG4KKMQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.6.1"
+        "@sentry/core": "9.12.0"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@opentelemetry/instrumentation-express": "^0.47.1",
     "@opentelemetry/instrumentation-http": "^0.57.2",
     "@opentelemetry/sdk-node": "^0.57.2",
-    "@sentry/node": "^9.6.1",
+    "@sentry/node": "^9.12.0",
     "@swc-node/register": "^1.10.9",
     "@types/basic-auth": "^1.1.8",
     "@types/cache-manager": "^4.0.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -337,6 +337,13 @@ export async function setup(app: Application, options: SetupOptions) {
 			dsn: SENTRY_DSN,
 			release: options.version,
 			environment: NODE_ENV,
+			integrations: [
+				Sentry.httpIntegration({
+					ignoreIncomingRequestBody(url) {
+						return /\/device\/v2\/.*\/log-stream/.test(url);
+					},
+				}),
+			],
 		});
 	}
 


### PR DESCRIPTION
This will avoid using memory to store the request body for these long running requests

Change-type: patch