### PR TITLE
Make release asset `asset` property nullable

### DIFF
--- a/src/balena-model.ts
+++ b/src/balena-model.ts
@@ -1260,7 +1260,7 @@ export interface ReleaseAsset {
 		release: { __id: Release['Read']['id'] } | [Release['Read']];
 		asset_key: Types['Short Text']['Read'];
 		id: Types['Serial']['Read'];
-		asset: Types['WebResource']['Read'];
+		asset: Types['WebResource']['Read'] | null;
 	};
 	Write: {
 		created_at: Types['Date Time']['Write'];
@@ -1268,7 +1268,7 @@ export interface ReleaseAsset {
 		release: Release['Write']['id'];
 		asset_key: Types['Short Text']['Write'];
 		id: Types['Serial']['Write'];
-		asset: Types['WebResource']['Write'];
+		asset: Types['WebResource']['Write'] | null;
 	};
 }
 

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -736,7 +736,7 @@ Fact type: release has asset key
 
 -- release asset
 Fact type: release asset has asset
-	Necessity: each release asset has exactly one asset.
+	Necessity: each release asset has at most one asset.
 
 
 -- service environment variable

--- a/src/migrations/00102-make-asset-not-null-on-release-asset.sql
+++ b/src/migrations/00102-make-asset-not-null-on-release-asset.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "release asset"
+ALTER COLUMN "asset" DROP NOT NULL;

--- a/test/23_release_asset.ts
+++ b/test/23_release_asset.ts
@@ -35,6 +35,22 @@ export default () => {
 				const filePath = fileURLToPath(
 					new URL('fixtures/23-release-asset/sample.txt', import.meta.url),
 				);
+
+				it('should succeed with empty asset', async function () {
+					const res = await supertest(this.user)
+						.post(`/${version}/release_asset`)
+						.field('release', this.release1.id)
+						.field('asset_key', 'unique_key_0')
+						.expect(201);
+
+					expect(res.body).to.have.property('id').that.is.a('number');
+					expect(res.body).to.have.property('asset').that.is.null;
+					expect(res.body)
+						.to.have.nested.property('release.__id')
+						.that.equals(this.release1.id);
+					expect(res.body.asset_key).to.equal('unique_key_0');
+				});
+
 				it('should succeed with mandatory properties', async function () {
 					const res = await supertest(this.user)
 						.post(`/${version}/release_asset`)


### PR DESCRIPTION
See: https://balena.fibery.io/search/VIJ6u#Work/Improvement/Make-asset-column-nullable-on-release-asset-2583

Change-type: major