### PR TITLE
Sentry: ignore requests on low value paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -341,8 +341,13 @@ export async function setup(app: Application, options: SetupOptions) {
 			environment: NODE_ENV,
 			integrations: [
 				Sentry.httpIntegration({
+					ignoreIncomingRequests(url) {
+						return /^\/(:ping|connectivity-check|csp-report|config\/vars)/.test(
+							url,
+						);
+					},
 					ignoreIncomingRequestBody(url) {
-						return /\/device\/v2\/.*\/log-stream/.test(url);
+						return /^\/device\/v2\/.*\/log-stream/.test(url);
 					},
 				}),
 			],


### PR DESCRIPTION
This reduces processing overhead for these paths that can have high volume but low value

Change-type: patch