### PR TITLE
Abstract-sql: avoid unnecessary `ELSE NULL` for `CASE` statements

### DIFF
--- a/src/abstract-sql-utils.ts
+++ b/src/abstract-sql-utils.ts
@@ -172,7 +172,7 @@ export const joinTextParts = (
 		...(parts.map(
 			([showPart, partValue]): CastNode => [
 				'Cast',
-				['Case', ['When', showPart, partValue], ['Else', ['Null']]],
+				['Case', ['When', showPart, partValue]],
 				'Text',
 			],
 		) as [CastNode, ...CastNode[]]),

--- a/src/features/devices/models/device-additions.ts
+++ b/src/features/devices/models/device-additions.ts
@@ -413,11 +413,7 @@ export const addToModel = (abstractSql: AbstractSqlModel) => {
 					],
 				],
 			],
-			[
-				// And if we haven't found any download progress yet we return null
-				'Else',
-				['Null'],
-			],
+			// And if we haven't found any download progress yet then the default ELSE returns null
 		],
 	});
 


### PR DESCRIPTION
They default to `NULL` when omitted so this will reduce the size of the generated SQL and hence the memory usage by cache and network usage to transmit the queries

Change-type: patch