### PR TITLE
Device logs: add a 55s delay before responding to deleted/frozen devices

### DIFF
--- a/src/features/device-logs/index.ts
+++ b/src/features/device-logs/index.ts
@@ -9,6 +9,7 @@ import { read } from './lib/read.js';
 import { store, storeStream } from './lib/store.js';
 import type { SetupOptions } from '../../index.js';
 import { resolveOrDenyDevicesWithStatus } from '../device-state/middleware.js';
+import { DELETED_FROZEN_DEVICE_LOGS_DELAY_MS } from '../../lib/config.js';
 
 // Rate limit for device log creation, a maximum of 15 batches every 10 second window
 const deviceLogsRateLimiter = createRateLimitMiddleware(
@@ -34,14 +35,22 @@ export const setup = (
 	);
 	app.post(
 		'/device/v2/:uuid/logs',
-		resolveOrDenyDevicesWithStatus(401),
+		resolveOrDenyDevicesWithStatus(
+			401,
+			undefined,
+			DELETED_FROZEN_DEVICE_LOGS_DELAY_MS,
+		),
 		deviceLogsRateLimiter('params.uuid'),
 		middleware.authenticatedApiKey,
 		store,
 	);
 	app.post(
 		'/device/v2/:uuid/log-stream',
-		resolveOrDenyDevicesWithStatus(401),
+		resolveOrDenyDevicesWithStatus(
+			401,
+			undefined,
+			DELETED_FROZEN_DEVICE_LOGS_DELAY_MS,
+		),
 		middleware.authenticatedApiKey,
 		storeStream(onLogWriteStreamInitialized),
 	);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -508,6 +508,14 @@ export const EMPTY_DEVICE_STATE_GET_DELAY_SECONDS = intVar(
 	DEFAULT_SUPERVISOR_POLL_INTERVAL / SECONDS,
 );
 
+/**
+ * The delay before responding to deleted/frozen devices device logs requests as a sort of backoff mechanism
+ */
+export const DELETED_FROZEN_DEVICE_LOGS_DELAY_MS = intVar(
+	'DELETED_FROZEN_DEVICE_LOGS_DELAY_MS',
+	55 * SECONDS,
+);
+
 // Cache timeouts
 export const IMAGE_INSTALL_CACHE_TIMEOUT_SECONDS = intVar(
 	'IMAGE_INSTALL_CACHE_TIMEOUT_SECONDS',


### PR DESCRIPTION
This will act as somewhat of a throttle to reduce how often they retry

Change-type: patch