### PR TITLE
Add @swc/core to the dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@opentelemetry/sdk-node": "^0.57.2",
         "@sentry/node": "^9.42.0",
         "@swc-node/register": "^1.10.10",
+        "@swc/core": "^1.13.3",
         "@types/basic-auth": "^1.1.8",
         "@types/cache-manager": "^4.0.6",
         "@types/cache-manager-ioredis": "^2.0.7",
@@ -4761,7 +4762,6 @@
       "integrity": "sha512-ZaDETVWnm6FE0fc+c2UE8MHYVS3Fe91o5vkmGfgwGXFbxYvAjKSqxM/j4cRc9T7VZNSJjriXq58XkfCp3Y6f+w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.23"
@@ -4806,7 +4806,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4823,7 +4822,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4840,7 +4838,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4857,7 +4854,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4874,7 +4870,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4891,7 +4886,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4908,7 +4902,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4925,7 +4918,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4942,7 +4934,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4959,7 +4950,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4968,15 +4958,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.24.tgz",
       "integrity": "sha512-tjTMh3V4vAORHtdTprLlfoMptu1WfTZG9Rsca6yOKyNYsRr+MUXutKmliB17orgSZk5DpnDxs8GUdd/qwYxOng==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@opentelemetry/sdk-node": "^0.57.2",
     "@sentry/node": "^9.42.0",
     "@swc-node/register": "^1.10.10",
+    "@swc/core": "^1.13.3",
     "@types/basic-auth": "^1.1.8",
     "@types/cache-manager": "^4.0.6",
     "@types/cache-manager-ioredis": "^2.0.7",


### PR DESCRIPTION
This avoids having `npm i` remove the
platform specific `@swc/core-*` packages,
which was happening b/c they are optional
dependencies of @swc/core, which is a peer
dependency of @swc-node/register .

Change-type: patch