### PR TITLE
Fix pinning devices to draft supervisor releases during provisioning when a finalized exists

### DIFF
--- a/src/features/supervisor-app/hooks/supervisor-app.ts
+++ b/src/features/supervisor-app/hooks/supervisor-app.ts
@@ -173,7 +173,16 @@ async function getSupervisorReleaseResource(
 					},
 				},
 			},
-			$orderby: { revision: 'desc' },
+			// Prefer the latest revision of finalized releases matching the semver
+			// otherwise (if there isn't such a version) pick the latest draft.
+			$orderby: [
+				// Even though OData v4 specifies that `revision: desc` should  be returning nulls
+				// after non-nulls w/o the need of sorting on is_final, atm pine relies on the
+				// default sorting of PG, which would put nulls first if we remove the sorting on is_final.
+				{ is_final: 'desc' },
+				{ revision: 'desc' },
+				{ created_at: 'desc' },
+			],
 		},
 	});
 }

--- a/test/16_supervisor_releases.ts
+++ b/test/16_supervisor_releases.ts
@@ -4,6 +4,7 @@ import * as fakeDevice from './test-lib/fake-device.js';
 import { supertest } from './test-lib/supertest.js';
 import * as versions from './test-lib/versions.js';
 import { assertExists, expectToEventually } from './test-lib/common.js';
+import { expectResourceToMatch } from './test-lib/api-helpers.js';
 
 export default () => {
 	versions.test((version, pineTest) => {
@@ -250,6 +251,32 @@ export default () => {
 					expect(res.body)
 						.to.have.nested.property('d[0].should_be_managed_by__release.__id')
 						.that.equals(ctx.supervisorReleases['8.0.1'].id);
+				});
+
+				it('should provision to a succesful release with the latest revision matching the semver', async () => {
+					expect(ctx.supervisorReleases['8.0.4-draft']).to.have.property(
+						'revision',
+						null,
+					);
+
+					await supertest(ctx.admin)
+						.patch(`/${version}/device(${device.id})`)
+						.send({
+							supervisor_version: null,
+							should_be_managed_by__release: null,
+						})
+						.expect(200);
+					await supertest(ctx.admin)
+						.patch(`/${version}/device(${device.id})`)
+						.send({
+							supervisor_version: '8.0.4',
+						})
+						.expect(200);
+					await expectResourceToMatch(pineUser, 'device', device.id, {
+						should_be_managed_by__release: {
+							__id: ctx.supervisorReleases['8.0.4+rev1'].id,
+						},
+					});
 				});
 
 				it('should provision to an invalidated release', async () => {

--- a/test/fixtures/16-supervisor-app/releases.json
+++ b/test/fixtures/16-supervisor-app/releases.json
@@ -76,6 +76,68 @@
 			}
 		}
 	},
+	"8.0.4-draft": {
+		"user": "admin",
+		"application": "amd64_supervisor_app",
+		"semver": "8.0.4",
+		"is_final": false,
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image7": {
+					"build": "./image7/"
+				}
+			}
+		}
+	},
+	"8.0.4": {
+		"user": "admin",
+		"application": "amd64_supervisor_app",
+		"semver": "8.0.4",
+		"revision": 0,
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image7": {
+					"build": "./image7/"
+				}
+			}
+		}
+	},
+	"8.0.4+rev1": {
+		"user": "admin",
+		"application": "amd64_supervisor_app",
+		"semver": "8.0.4",
+		"revision": 1,
+		"createAfterRelease": "8.0.4",
+		"status": "success",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image7": {
+					"build": "./image7/"
+				}
+			}
+		}
+	},
+	"8.0.4+rev2-failed": {
+		"user": "admin",
+		"application": "amd64_supervisor_app",
+		"semver": "8.0.4",
+		"revision": 2,
+		"createAfterRelease": "8.0.4+rev1",
+		"status": "failed",
+		"source": "cloud",
+		"composition": {
+			"services": {
+				"image7": {
+					"build": "./image7/"
+				}
+			}
+		}
+	},
 	"8.1.1": {
 		"user": "admin",
 		"application": "amd64_supervisor_app",

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -171,10 +171,6 @@ const loaders: types.Dictionary<LoaderFunc> = {
 			logErrorAndThrow(`Could not find application: ${jsonData.application}`);
 		}
 
-		if (jsonData.revision > 1) {
-			// TODO: Add support for any
-			throw new Error('Fixtures do not support using release revision > 1');
-		}
 		if (jsonData.revision > 0) {
 			const lowerRevRelease = await fixtures.releases[jsonData.semver];
 			if (lowerRevRelease == null) {


### PR DESCRIPTION
…

Change-type: patch
See: https://balena.fibery.io/Work/Project/Fix-devices-being-pinned-to-a-draft-supervisor-release-during-provisioning-when-a-finalized-exists-e-1810