### PR TITLE
Disable s6-log blocking mode

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Redirect all future stdout/stderr to s6-log
-exec > >(exec s6-log -b p"api[$$]:" 1 || true) 2>&1
+exec > >(exec s6-log p"api[$$]:" 1 || true) 2>&1
 
 # Change to working directory
 cd /usr/src/app || exit 1


### PR DESCRIPTION
From the s6-log docs: https://skarnet.org/software/s6/s6-log.html

> By default, s6-log keeps reading from stdin even if its buffers
> still contain data. -b is safer, but may slow down your service;
> the default is faster, but may lead to unbound memory use if you
> have a lot of output to write to a slow file system.

Change-type: patch