### PR TITLE
Export registry generateToken function

### DIFF
--- a/src/features/registry/registry.ts
+++ b/src/features/registry/registry.ts
@@ -553,7 +553,7 @@ const authorizeRequest = async (
 	);
 };
 
-const generateToken = (
+export const generateToken = (
 	subject = '',
 	audience: string,
 	access: Access[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,7 @@ import {
 	getInstance as getDeviceOnlineStateManager,
 } from './features/device-heartbeat/index.js';
 import { registryAuth } from './features/registry/certs.js';
+import { generateToken } from './features/registry/registry.js';
 import {
 	ALLOWED_NAMES,
 	BLOCKED_NAMES,
@@ -226,6 +227,9 @@ export const auth = {
 	publicKeys,
 	/** @deprecated Will be removed in a future version */
 	refreshToken,
+};
+export const registry = {
+	generateToken,
 };
 export const rateLimiting = {
 	createRateLimitMiddleware,


### PR DESCRIPTION
Change-type: minor

---

See: https://balena.fibery.io/Work/Project/Experimental-build-for-moving-to-a-new-registry-2144

Export the `generateToken()` function so we can call that internally to generate registry tokens as needed, primarily for listing repositories and marking images for deletion.