### PR TITLE
Properly run the hostApp hooks when the os_version & os_variant are not updated together

### DIFF
--- a/src/features/hostapp/hooks/target-hostapp.ts
+++ b/src/features/hostapp/hooks/target-hostapp.ts
@@ -8,7 +8,6 @@ import * as semver from 'balena-semver';
 import type { SemVer } from 'semver';
 import type { ReleaseTag, Release } from '../../../balena-model.js';
 import type { PickDeferred } from '@balena/abstract-sql-to-typescript';
-import { groupByMap } from '../../../lib/utils.js';
 import { ThisShouldNeverHappenError } from '../../../infra/error-handling/index.js';
 const { BadRequestError } = pinejsErrors;
 
@@ -174,6 +173,13 @@ hooks.addPureHook('PATCH', 'resin', 'device', {
 	},
 });
 
+const parseOsVariant = (value: string | null | undefined) => {
+	if (value === 'dev' || value === 'prod') {
+		return value;
+	}
+	return null;
+};
+
 /**
  * Enforce the "device.should_be_operated_by__release[0].semver >= device.os_version" invariant.
  * When a device reports its current OS version and the release pointed to by the should_be_operated_by__release
@@ -182,24 +188,22 @@ hooks.addPureHook('PATCH', 'resin', 'device', {
  * Setting the should_be_operated_by__release when it's null has the semantics of pinning the device to its current OS release.
  */
 hooks.addPureHook('PATCH', 'resin', 'device', {
-	async PRERUN(args) {
-		if (
-			args.request.values.os_version != null &&
-			args.request.values.os_variant != null
-		) {
-			const parsedOsVersion = semver.parse(args.request.values.os_version);
+	async POSTRUN(args) {
+		let parsedOsVersion: SemVer | null = null;
+		if (typeof args.request.values.os_version === 'string') {
+			parsedOsVersion = semver.parse(args.request.values.os_version);
 			// If balena-semver can't parse the os_version, then we can be sure
 			// that there is no hostApp release matching it.
 			if (parsedOsVersion == null) {
 				return;
 			}
+		}
+		if (
+			parsedOsVersion != null ||
+			parseOsVariant(args.request.values.os_variant) != null
+		) {
 			const ids = await sbvrUtils.getAffectedIds(args);
-			await setOSReleaseIfNewer(
-				args.api,
-				ids,
-				parsedOsVersion,
-				args.request.values.os_variant,
-			);
+			await progressTargetOSReleaseIfNewer(args.api, ids);
 		}
 	},
 });
@@ -219,9 +223,9 @@ hooks.addPureHook('POST', 'resin', 'device', {
 			}
 			const hostappRelease = await getOSReleaseResource(
 				api,
+				request.values.is_of__device_type,
 				parsedOsVersion,
 				request.values.os_variant,
-				request.values.is_of__device_type,
 			);
 			// since this is a POST, we _know_ the device is being created and has no current/target state, so we can
 			// just append the target after determining which it is (like a preloaded app)
@@ -232,11 +236,9 @@ hooks.addPureHook('POST', 'resin', 'device', {
 	},
 });
 
-async function setOSReleaseIfNewer(
+async function progressTargetOSReleaseIfNewer(
 	api: typeof sbvrUtils.api.resin,
 	deviceIds: number[],
-	newOsVersion: SemVer,
-	newOsVariant: string,
 ) {
 	if (deviceIds.length === 0) {
 		return;
@@ -244,7 +246,7 @@ async function setOSReleaseIfNewer(
 	const devices = await api.get({
 		resource: 'device',
 		options: {
-			$select: ['id', 'is_of__device_type'],
+			$select: ['id', 'is_of__device_type', 'os_version', 'os_variant'],
 			$expand: {
 				should_be_operated_by__release: {
 					$select: 'semver',
@@ -261,28 +263,51 @@ async function setOSReleaseIfNewer(
 			},
 		},
 	});
-	const devicesToUpdate = devices.filter((device) => {
-		const targetHostappRelease = device.should_be_operated_by__release[0];
-		if (targetHostappRelease == null) {
-			return true;
-		}
-		const targetHostappVersion =
-			getBaseVersionFromReleaseSemverOrTag(targetHostappRelease);
-		return (
-			targetHostappVersion == null ||
-			semver.gt(newOsVersion.raw, targetHostappVersion)
-		);
-	});
+	const deviceInfosToUpdate = devices
+		.map((device) => {
+			const newOsVersion = semver.parse(device.os_version);
+			// If balena-semver can't parse the os_version, then we can be sure
+			// that there is no hostApp release matching it.
+			if (newOsVersion == null) {
+				return;
+			}
+			const newOsVariant = parseOsVariant(device.os_variant);
+			if (newOsVariant == null) {
+				return;
+			}
+			return {
+				id: device.id,
+				deviceTypeId: device.is_of__device_type.__id,
+				newOsVersion,
+				newOsVariant,
+				targetHostappRelease: device.should_be_operated_by__release[0],
+			};
+		})
+		.filter((deviceInfo): deviceInfo is NonNullable<typeof deviceInfo> => {
+			if (deviceInfo == null) {
+				return false;
+			}
+			if (deviceInfo.targetHostappRelease == null) {
+				return true;
+			}
+			const targetHostappVersion = getBaseVersionFromReleaseSemverOrTag(
+				deviceInfo.targetHostappRelease,
+			);
+			return (
+				targetHostappVersion == null ||
+				semver.gt(deviceInfo.newOsVersion.raw, targetHostappVersion)
+			);
+		});
 
-	if (devicesToUpdate.length === 0) {
+	if (deviceInfosToUpdate.length === 0) {
 		return;
 	}
 
-	const devicesByDeviceTypeId = groupByMap(
-		devicesToUpdate,
-		(d) => d.is_of__device_type.__id,
+	const groupedDeviceInfos = Map.groupBy(
+		deviceInfosToUpdate,
+		(di) => `${di.deviceTypeId}|${di.newOsVersion.raw}|${di.newOsVariant}`,
 	);
-	if (devicesByDeviceTypeId.size === 0) {
+	if (groupedDeviceInfos.size === 0) {
 		return;
 	}
 
@@ -294,50 +319,51 @@ async function setOSReleaseIfNewer(
 	});
 
 	return Promise.all(
-		devicesByDeviceTypeId
-			.entries()
-			.map(async ([deviceTypeId, affectedDevices]) => {
-				const newOsRelease = await getOSReleaseResource(
-					api,
-					newOsVersion,
-					newOsVariant,
-					deviceTypeId,
+		groupedDeviceInfos.values().map(async (affectedDevices) => {
+			// The devices are grouped by these props, so we can pick them by the first record
+			// since all devices of the group are expected to have the same values.
+			const { deviceTypeId, newOsVersion, newOsVariant } = affectedDevices[0];
+			const newOsRelease = await getOSReleaseResource(
+				api,
+				deviceTypeId,
+				newOsVersion,
+				newOsVariant,
+			);
+
+			if (newOsRelease == null) {
+				// When the newOsRelease is not found, and since we have already checked that
+				// newOsVersion > should_be_operated_by__release, we need to clear the
+				// should_be_operated_by__release of devices that have it set, otherwise the
+				// should_be_operated_by__release >= os_version invariant would be violated.
+				affectedDevices = affectedDevices.filter(
+					(d) => d.targetHostappRelease != null,
 				);
-
-				if (newOsRelease == null) {
-					// When the newOsRelease is not found, and since we have already checked that
-					// newOsVersion > should_be_operated_by__release, we need to clear the
-					// should_be_operated_by__release of devices that have it set, otherwise the
-					// should_be_operated_by__release >= os_version invariant would be violated.
-					affectedDevices = affectedDevices.filter(
-						(d) => d.should_be_operated_by__release[0] != null,
-					);
-					if (affectedDevices.length === 0) {
-						return;
-					}
+				if (affectedDevices.length === 0) {
+					return;
 				}
+			}
 
-				const affectedDeviceIds = affectedDevices.map((d) => d.id);
-				await rootApi.patch({
-					resource: 'device',
-					options: {
-						$filter: {
-							id: { $in: affectedDeviceIds },
-						},
+			const affectedDeviceIds = affectedDevices.map((d) => d.id);
+			await rootApi.patch({
+				resource: 'device',
+				options: {
+					$filter: {
+						id: { $in: affectedDeviceIds },
 					},
-					body: {
-						should_be_operated_by__release: newOsRelease?.id ?? null,
-					},
-				});
-			}),
+				},
+				body: {
+					should_be_operated_by__release: newOsRelease?.id ?? null,
+				},
+			});
+		}),
 	);
 }
 
 async function getOSReleaseResource(
 	api: typeof sbvrUtils.api.resin,
+	deviceTypeId: number,
 	parsedOsVersion: SemVer,
 	osVariant: string,
-	deviceTypeId: number,
 ): Promise<PickDeferred<Release['Read'], 'id' | 'is_final'> | undefined> {
 	const releases = await api.get({
 		resource: 'release',

--- a/test/03_device-state.ts
+++ b/test/03_device-state.ts
@@ -1652,6 +1652,7 @@ export default () => {
 				const deviceFieldMaxSizes = {
 					status: 50,
 					os_version: 70,
+					os_variant: 4,
 					supervisor_version: 20,
 					api_secret: 64,
 					note: 1_000_000,
@@ -1660,7 +1661,11 @@ export default () => {
 				it('should accept excessively long device fields and truncate them to the max allowed size', async () => {
 					const devicePatchBody = {
 						status: 'Running OS update',
-						os_version: 'balenaOS 2.50.1+rev1',
+						// The dot here is so that the added text is addes as a separate semver build part and not considered
+						// part of there revision, since otherwise the API would fail with a malforned url error while trying find
+						// the hostApp release that matches that out of range int revision (eg: revision eq 1.1234567890123457e+50).
+						os_version: `balenaOS 2.50.1+rev${2 ** 31 - 1}.`,
+						os_variant: `prod`,
 						supervisor_version: '11.4.10',
 						api_secret: 'super-secret-thing',
 					};

--- a/test/15_target-hostapp.ts
+++ b/test/15_target-hostapp.ts
@@ -318,11 +318,79 @@ export default () => {
 
 					describe(`provisioning with a ${osTypeTitlePart} OS (using ${provisioningFnTitlePart})`, function () {
 						let registeredDevice: Device['Read'];
+						let gradualOsFieldReportDevice: Device['Read'];
 
 						after(async function () {
 							await fixtures.clean({
 								devices: [registeredDevice],
 							});
+						});
+
+						it(`should provision WITHOUT a linked hostapp when providing an os_variant but no os_version (using ${provisioningFnTitlePart})`, async () => {
+							const { body: testDevice } = await provisionFn({
+								belongs_to__application: applicationId,
+								device_type: 'intel-nuc',
+								os_variant: osVersionVariantParams.os_variant,
+							});
+							await expectResourceToMatch(pineUser, 'device', testDevice.id, {
+								os_version: null,
+								os_variant: osVersionVariantParams.os_variant,
+								should_be_operated_by__release: null,
+							});
+						});
+
+						it(`should provision WITHOUT a linked hostapp when providing an os_version and a null os_variant (using ${provisioningFnTitlePart})`, async () => {
+							const { body: testDevice } = await provisionFn({
+								belongs_to__application: applicationId,
+								device_type: 'intel-nuc',
+								os_version: osVersionVariantParams.os_version,
+								os_variant: null,
+							});
+							await expectResourceToMatch(pineUser, 'device', testDevice.id, {
+								os_version: osVersionVariantParams.os_version,
+								os_variant: null,
+								should_be_operated_by__release: null,
+							});
+						});
+
+						it(`should provision WITHOUT a linked hostapp when providing an os_version but no os_variant (using ${provisioningFnTitlePart})`, async () => {
+							({ body: gradualOsFieldReportDevice } = await provisionFn({
+								belongs_to__application: applicationId,
+								device_type: 'intel-nuc',
+								os_version: osVersionVariantParams.os_version,
+							}));
+							await expectResourceToMatch(
+								pineUser,
+								'device',
+								gradualOsFieldReportDevice.id,
+								{
+									os_version: osVersionVariantParams.os_version,
+									os_variant: null,
+									should_be_operated_by__release: null,
+								},
+							);
+						});
+
+						it(`...should link the hostapp once the os_variant is also set (using ${provisioningFnTitlePart})`, async () => {
+							await pineUser.patch({
+								resource: 'device',
+								id: gradualOsFieldReportDevice.id,
+								body: {
+									os_variant: osVersionVariantParams.os_variant,
+								},
+							});
+							await expectResourceToMatch(
+								pineUser,
+								'device',
+								gradualOsFieldReportDevice.id,
+								{
+									os_version: osVersionVariantParams.os_version,
+									os_variant: osVersionVariantParams.os_variant,
+									should_be_operated_by__release: {
+										__id: getHostAppReleaseId(),
+									},
+								},
+							);
 						});
 
 						it(`should provision with a linked hostapp`, async () => {
@@ -654,7 +722,7 @@ export default () => {
 						);
 				});
 
-				// state PATCH device.should_be_operated_by__release >= device.os_version invariant tests
+				// state PATCH device.os_version <= device.should_be_operated_by__release invariant tests
 
 				it(`should leave the device.should_be_operated_by__release unchanged when the state PATCH reports a rollback to the older os_version (when on a ${higherTitle} release)`, async () => {
 					await device1.patchStateV2({
@@ -668,6 +736,53 @@ export default () => {
 						os_variant: 'prod',
 						should_be_operated_by__release: { __id: higher.getReleaseId() },
 					});
+				});
+
+				it(`should work when a device with an empty should_be_operated_by__release reports a rollback to the older os_version (when on a ${higherTitle} release)`, async () => {
+					const downgradeTestDevice = await fakeDevice.provisionDevice(
+						admin,
+						applicationId,
+					);
+					await downgradeTestDevice.patchStateV2({
+						local: {
+							os_version: higher.osVersion,
+							os_variant: 'prod',
+						},
+					});
+					await pineUser.patch({
+						resource: 'device',
+						id: downgradeTestDevice.id,
+						body: {
+							should_be_operated_by__release: null,
+						},
+					});
+					await expectResourceToMatch(
+						pineUser,
+						'device',
+						downgradeTestDevice.id,
+						{
+							os_version: higher.osVersion,
+							os_variant: 'prod',
+							should_be_operated_by__release: null,
+						},
+					);
+					// run the actual test
+					await downgradeTestDevice.patchStateV2({
+						local: {
+							os_version: lower.osVersion,
+							os_variant: 'prod',
+						},
+					});
+					await expectResourceToMatch(
+						pineUser,
+						'device',
+						downgradeTestDevice.id,
+						{
+							os_version: lower.osVersion,
+							os_variant: 'prod',
+							should_be_operated_by__release: { __id: lower.getReleaseId() },
+						},
+					);
 				});
 
 				it(`should leave the device.should_be_operated_by__release unchanged when the state PATCH reports an older "unknown" os_version w/o a matching hostApp release (when on a ${lowerTitle} release)`, async () => {
@@ -710,7 +825,7 @@ export default () => {
 					);
 				});
 
-				it(`should update the device.should_be_operated_by__release when the state PATCH reports a newer os_version (${lowerTitle} -> ${higherTitle})`, async () => {
+				it(`should update the device.should_be_operated_by__release when the state PATCH reports a newer os_version & os_variant (${lowerTitle} -> ${higherTitle})`, async () => {
 					// if a device is preprovisioned and pinned to a release with a semver
 					// less than the version it initially checks in with, we need to update
 					// the old hostApp release, otherwise the model would imply a scheduled OS downgrade.
@@ -737,6 +852,45 @@ export default () => {
 						local: {
 							os_version: higher.osVersion,
 							os_variant: 'prod',
+						},
+					});
+					await expectResourceToMatch(
+						pineUser,
+						'device',
+						preprovisionedDevice.id,
+						{
+							os_version: higher.osVersion,
+							os_variant: 'prod',
+							should_be_operated_by__release: { __id: higher.getReleaseId() },
+						},
+					);
+				});
+
+				it(`should update the device.should_be_operated_by__release when the state PATCH reports a newer os_version but no os_variant (${lowerTitle} -> ${higherTitle})`, async () => {
+					const preprovisionedDevice = await fakeDevice.provisionDevice(
+						admin,
+						applicationId,
+					);
+					await preprovisionedDevice.patchStateV2({
+						local: {
+							os_version: lower.osVersion,
+							os_variant: 'prod',
+						},
+					});
+					await expectResourceToMatch(
+						pineUser,
+						'device',
+						preprovisionedDevice.id,
+						{
+							os_version: lower.osVersion,
+							os_variant: 'prod',
+							should_be_operated_by__release: { __id: lower.getReleaseId() },
+						},
+					);
+					// run the actual test
+					await preprovisionedDevice.patchStateV2({
+						local: {
+							os_version: higher.osVersion,
 						},
 					});
 					await expectResourceToMatch(


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Project/1704