### PR TITLE
Avoid setting the device.os_variant to null when only an os_version without a variant suffix is reported

### DIFF
--- a/src/features/devices/hooks/defaults-validation.ts
+++ b/src/features/devices/hooks/defaults-validation.ts
@@ -62,6 +62,7 @@ hooks.addPureHook('PATCH', 'resin', 'device', {
 			);
 		}
 		// Parse and set `os_variant` from `os_version` if not explicitly given
+		// Early v2.0.0 OS releases eg 'Resin OS 2.0.0+rev5 (prod)' included the variant as part of the os_version
 		if (
 			request.values.os_version != null &&
 			request.values.os_variant == null
@@ -69,8 +70,6 @@ hooks.addPureHook('PATCH', 'resin', 'device', {
 			const match = /^.*\((.+)\)$/.exec(request.values.os_version);
 			if (match != null) {
 				request.values.os_variant = match[1];
-			} else {
-				request.values.os_variant = null;
 			}
 		}
 


### PR DESCRIPTION
Restores the behavior we had in
https://github.com/balena-io/balena-api/pull/993
before the seemingly accidental change
which was introduced as part of
https://github.com/balena-io/balena-api/pull/896

Change-type: patch
See: https://github.com/balena-io/balena-api/pull/166
See: https://github.com/balena-io/balena-api/pull/993
See: https://github.com/balena-io/balena-api/pull/896/files#diff-34d0c0cba8e6d7cfe616269d2cef0304255a9d3f384e823e416118293769e6d6R183
See: https://balena.fibery.io/Work/Project/1704