### PR TITLE
target-hostapp: Move the downgrade check to the POSTRUN phase

### DIFF
--- a/src/features/hostapp/hooks/target-hostapp.ts
+++ b/src/features/hostapp/hooks/target-hostapp.ts
@@ -37,19 +37,23 @@ hooks.addPureHook('PATCH', 'resin', 'device', {
 	/**
 	 * Disallow hostapp downgrades, using the related release resource
 	 */
-	async PRERUN(args) {
+	PRERUN(args) {
 		if (args.request.values.should_be_operated_by__release != null) {
 			// First try to coerce the value to an integer for
 			// moving forward
-			args.request.custom.hostappRelease = parseInt(
+			args.request.custom.hostappReleaseId = parseInt(
 				args.request.values.should_be_operated_by__release,
 				10,
 			);
 			// But let's check we actually got a value
 			// representing an integer
-			if (!Number.isInteger(args.request.custom.hostappRelease)) {
+			if (!Number.isInteger(args.request.custom.hostappReleaseId)) {
 				throw new BadRequestError('Expected an ID for the hostapp release');
 			}
+		}
+	},
+	async POSTRUN(args) {
+		if (typeof args.request.custom.hostappReleaseId === 'number') {
 			// Users shouldn't be able to upgrade to an invalid release, but the platform
 			// should be able to preserve the should_be_operated_by__release > os_version invariant
 			// even if the device reports an os_version that's of an invalidated release.
@@ -62,7 +66,7 @@ hooks.addPureHook('PATCH', 'resin', 'device', {
 			await checkHostappReleaseUpgrades(
 				args.api,
 				ids,
-				args.request.custom.hostappRelease,
+				args.request.custom.hostappReleaseId,
 				allowInvalidated,
 			);
 		}

--- a/test/15_target-hostapp.ts
+++ b/test/15_target-hostapp.ts
@@ -483,8 +483,7 @@ export default () => {
 					})
 					.expect(
 						400,
-						// TODO: This should ideally be: '"It is necessary that each release that should operate a device, has a status that is equal to \\"success\\"."'
-						`"Could not find a hostapp release with this ID ${failedIntelNucHostAppReleaseId}"`,
+						'"It is necessary that each release that should operate a device, has a status that is equal to \\"success\\"."',
 					);
 			});
 
@@ -720,6 +719,41 @@ export default () => {
 							400,
 							'"Attempt to downgrade hostapp, which is not allowed"',
 						);
+				});
+
+				it(`should block queuing a downgrade when the device.should_be_operated_by__release is updated along with os_version & os_variant (when downgrading ${higherTitle} -> ${lowerTitle})`, async () => {
+					const downgradeTestDevice = await fakeDevice.provisionDevice(
+						admin,
+						applicationId,
+					);
+					await downgradeTestDevice.patchStateV2({
+						local: {
+							os_version: lower.osVersion,
+							os_variant: 'prod',
+						},
+					});
+					// run the actual test
+					await supertest(admin)
+						.patch(`/${version}/device(${downgradeTestDevice.id})`)
+						.send({
+							os_version: higher.osVersion,
+							os_variant: 'prod',
+							should_be_operated_by__release: lower.getReleaseId(),
+						})
+						.expect(
+							400,
+							'"Attempt to downgrade hostapp, which is not allowed"',
+						);
+					await expectResourceToMatch(
+						pineUser,
+						'device',
+						downgradeTestDevice.id,
+						{
+							os_version: lower.osVersion,
+							os_variant: 'prod',
+							should_be_operated_by__release: { __id: lower.getReleaseId() },
+						},
+					);
 				});
 
 				// state PATCH device.os_version <= device.should_be_operated_by__release invariant tests


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Project/1704