### PR TITLE
patch: Optional retry logic for requestAsync

### DIFF
--- a/src/features/device-proxy/device-proxy.ts
+++ b/src/features/device-proxy/device-proxy.ts
@@ -15,7 +15,7 @@ import {
 	VPN_CONNECT_PROXY_PORT,
 } from '../../lib/config.js';
 import type { RequestResponse } from '../../infra/request-promise/index.js';
-import { requestAsync } from '../../infra/request-promise/index.js';
+import { requestAsync, withRetry } from '../../infra/request-promise/index.js';
 import { checkInt, throttledForEach } from '../../lib/utils.js';
 import type { Device } from '../../balena-model.js';
 
@@ -293,14 +293,18 @@ async function requestDevices({
 				device.api_port ?? 80
 			}${url}?apikey=${device.api_secret}`;
 			try {
-				return await requestAsync({
-					uri: deviceUrl,
-					json: data,
-					proxy: `http://resin_api:${API_VPN_SERVICE_API_KEY}@${vpnIp}:${VPN_CONNECT_PROXY_PORT}`,
-					tunnel: true,
-					method,
-					timeout: DEVICE_REQUEST_TIMEOUT,
-				});
+				return await withRetry(
+					() =>
+						requestAsync({
+							uri: deviceUrl,
+							json: data,
+							proxy: `http://resin_api:${API_VPN_SERVICE_API_KEY}@${vpnIp}:${VPN_CONNECT_PROXY_PORT}`,
+							tunnel: true,
+							method,
+							timeout: DEVICE_REQUEST_TIMEOUT,
+						}),
+					1, // retry just once
+				);
 			} catch (err) {
 				if (!wait) {
 					// If we don't care about waiting for the request then we just ignore the error and continue

--- a/src/infra/request-promise/index.ts
+++ b/src/infra/request-promise/index.ts
@@ -8,6 +8,28 @@ const defaultRequest = request.defaults({
 	timeout: EXTERNAL_HTTP_TIMEOUT_MS,
 });
 
+const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+export const withRetry = async <T>(
+	fn: () => Promise<T>,
+	retries: number,
+	baseDelay = 1000,
+	attempt = 0,
+): Promise<T> => {
+	try {
+		return await fn();
+	} catch (error) {
+		if (retries <= 0) {
+			throw error;
+		}
+
+		const waitTime = baseDelay * Math.pow(2, attempt);
+
+		await delay(waitTime);
+		return withRetry(fn, retries - 1, baseDelay, attempt + 1);
+	}
+};
+
 export const requestAsync = (
 	arg1:
 		| (request.UriOptions & request.CoreOptions)


### PR DESCRIPTION
Adds exponential backoff retry to requestAsync with default 0 retries. Adds a single retry to device proxy, as a workaround for dev. env. virtual devices sometimes missing the initial target state notification.

https://balena.fibery.io/Work/Project/Capture-data-to-build-the-balena-reliability-pipeline-1422