### PR TITLE
Registry: Add method to list tag digests

### DIFF
--- a/src/features/registry/registry.ts
+++ b/src/features/registry/registry.ts
@@ -776,11 +776,8 @@ class S3Client {
 		return children;
 	}
 
-	// List all existing manifest digests (tagged and untagged) for a given
-	// repository by listing objects in the registry's S3 bucket directly.
-	async listRepoDigests(repo: string) {
+	private async listDigestsAt(prefix: string) {
 		const digests: string[] = [];
-		const prefix = `${this.rootPath}/repositories/${repo}/_manifests/revisions/sha256/`;
 		for (const child of await this.listChildPrefixes(prefix)) {
 			const hash = child.replace(prefix, '').replace(/\/$/, '');
 			if (/^[a-f0-9]+$/.test(hash)) {
@@ -788,6 +785,23 @@ class S3Client {
 			}
 		}
 		return digests;
+	}
+
+	// List all existing manifest digests (tagged and untagged) for a given
+	// repository by listing objects in the registry's S3 bucket directly.
+	async listRepoDigests(repo: string) {
+		return await this.listDigestsAt(
+			`${this.rootPath}/repositories/${repo}/_manifests/revisions/sha256/`,
+		);
+	}
+
+	// List all manifest digests ever associated with a given tag of a
+	// repository (current and historical) by listing objects in the
+	// registry's S3 bucket directly.
+	async listTagDigests(repo: string, tag: string) {
+		return await this.listDigestsAt(
+			`${this.rootPath}/repositories/${repo}/_manifests/tags/${tag}/index/sha256/`,
+		);
 	}
 
 	// List all multi-stage build cache image repositories for a given repository.

--- a/test/26_registry-image-deletion.ts
+++ b/test/26_registry-image-deletion.ts
@@ -3,6 +3,8 @@ import * as registryMock from './test-lib/registry-mock.js';
 import { waitFor } from './test-lib/common.js';
 import * as versions from './test-lib/versions.js';
 import * as config from '../src/lib/config.js';
+import { s3Client } from '../src/features/registry/registry.js';
+import { strict as assert } from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { permissions, sbvrUtils } from '@balena/pinejs';
 import {
@@ -360,6 +362,22 @@ export default () => {
 
 			it('should not mark unrelated images for deletion', () => {
 				expect(ctx.notDeletedImage.registryImage.isDeleted).to.be.false;
+			});
+
+			it('should list all digests for a given repo and tag', async () => {
+				assert(s3Client, 's3Client not defined');
+
+				// Add multiple images with the 'latest' tag.
+				const repo = `v2/${randomUUID()}`;
+				const digestA = registryMock.genDigest();
+				const digestB = registryMock.genDigest();
+				registryMock.addImage(repo, digestA, ['latest']);
+				registryMock.addImage(repo, digestB, ['latest']);
+
+				// Confirm that all digests are found.
+				const digests = await s3Client.listTagDigests(repo, 'latest');
+				expect(digests).to.have.lengthOf(2);
+				expect(digests).to.have.members([digestA, digestB]);
 			});
 		});
 	});

--- a/test/test-lib/registry-mock.ts
+++ b/test/test-lib/registry-mock.ts
@@ -13,6 +13,7 @@ interface RegistryImage {
 	repository: string;
 	digest: string;
 	isDeleted: boolean;
+	tags?: string[];
 }
 
 const store: {
@@ -29,11 +30,12 @@ export function genDigest() {
 	return `sha256:${randomUUID().replace(/-/g, '').toLowerCase()}`;
 }
 
-export function addImage(repository: string, digest: string) {
+export function addImage(repository: string, digest: string, tags?: string[]) {
 	const registryImage: RegistryImage = {
 		repository,
 		digest,
 		isDeleted: false,
+		...(tags != null && { tags }),
 	};
 	store.images.push(registryImage);
 	return registryImage;
@@ -100,6 +102,9 @@ function registerS3Resolver() {
 	const digestsPrefixRegex = new RegExp(
 		`^${reposPath}(.+?)/_manifests/revisions/sha256/$`,
 	);
+	const tagDigestsPrefixRegex = new RegExp(
+		`^${reposPath}(.+?)/_manifests/tags/(.+?)/index/sha256/$`,
+	);
 	return addListObjectsV2Resolver((params) => {
 		const prefix = params.Prefix ?? '';
 		const digestsMatch = prefix.match(digestsPrefixRegex);
@@ -107,6 +112,17 @@ function registerS3Resolver() {
 			const repo = digestsMatch[1];
 			const commonPrefixes = store.images
 				.filter((i) => i.repository === repo)
+				.map((i) => ({
+					Prefix: `${prefix}${i.digest.replace(/^sha256:/, '')}/`,
+				}));
+			return { IsTruncated: false, CommonPrefixes: commonPrefixes };
+		}
+		const tagDigestsMatch = prefix.match(tagDigestsPrefixRegex);
+		if (tagDigestsMatch) {
+			const repo = tagDigestsMatch[1];
+			const tag = tagDigestsMatch[2];
+			const commonPrefixes = store.images
+				.filter((i) => i.repository === repo && i.tags?.includes(tag))
 				.map((i) => ({
 					Prefix: `${prefix}${i.digest.replace(/^sha256:/, '')}/`,
 				}));


### PR DESCRIPTION
Change-type: minor

---

See: https://balena.fibery.io/Work/Project/Mark-associated-resources-for-deletion-when-a-release-is-deleted-1779