### PR TITLE
fix: re-export zod's `z` namespace so consumers can use `z.infer`

### DIFF
--- a/src/infra/validation/index.ts
+++ b/src/infra/validation/index.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from 'express';
 import type { ParamsDictionary } from 'express-serve-static-core';
-import type { z } from 'zod';
-export { z } from 'zod';
+import { z } from 'zod';
+export { z };
 
 export function createValidatedRequestHandler(
 	handler: RequestHandler<


### PR DESCRIPTION
Previously, the import type + re-export did not reliably carried the zod namespace

Change-type: patch