### PR TITLE
Update balena-semver to use the getRevision helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "avsc": "^5.7.9",
         "aws-sdk": "^2.1693.0",
         "balena-device-config": "^6.3.1",
-        "balena-semver": "^4.0.2",
+        "balena-semver": "^4.1.0",
         "basic-auth": "^2.0.1",
         "body-parser": "^2.2.2",
         "bufferutil": "^4.1.0",
@@ -7476,9 +7476,9 @@
       }
     },
     "node_modules/balena-semver": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/balena-semver/-/balena-semver-4.0.18.tgz",
-      "integrity": "sha512-+FLhHaIPZalAmxn7rOK09MTU5IM330y0bNTsP0E7FP/GBlV15sPzSgRbhbIhPQ9lD6VympZHqI8KaUjtXXNKbA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/balena-semver/-/balena-semver-4.1.0.tgz",
+      "integrity": "sha512-53iMAxDWZE2AjqKgd0QzMRLlhW2wZhMTW6ymUmeVZi790BFOEqrCmXtdsCUm3Q1eV4pcJAhI+xLtyudWLezkrw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/memoizee": "^0.4.12",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "avsc": "^5.7.9",
     "aws-sdk": "^2.1693.0",
     "balena-device-config": "^6.3.1",
-    "balena-semver": "^4.0.2",
+    "balena-semver": "^4.1.0",
     "basic-auth": "^2.0.1",
     "body-parser": "^2.2.2",
     "bufferutil": "^4.1.0",

--- a/src/features/hostapp/hooks/target-hostapp.ts
+++ b/src/features/hostapp/hooks/target-hostapp.ts
@@ -395,7 +395,7 @@ async function getOSReleaseResource(
 						semver_prerelease: parsedOsVersion.prerelease.join('.'),
 						semver_build: parsedOsVersion.build.join('.'),
 						$or: [
-							{ revision: getRevisionFromSemver(parsedOsVersion) ?? 0 },
+							{ revision: semver.getRevision(parsedOsVersion) ?? 0 },
 							// Matching with NULL as well, allows provisioning devices to draft OS releases
 							{ revision: null },
 						],
@@ -488,17 +488,6 @@ async function getOSReleaseResource(
 	}
 
 	return release;
-}
-
-function getRevisionFromSemver(parsedOsVersion: SemVer): number | undefined {
-	const revisionRegex = /^rev(\d+)$/;
-	for (const buildPart of parsedOsVersion.build) {
-		const match = buildPart.match(revisionRegex)?.[1];
-		if (match != null) {
-			return parseInt(match, 10);
-		}
-	}
-	return;
 }
 
 function normalizeVariantToLongForm(variant: string) {


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Improvement/Stop-relying-on-device-types-v1-device-type.json-for-unrelated-things-257