### PR TITLE
device-types: Stop keeping in memory the OS versions found on S3

### DIFF
--- a/src/features/device-types/device-types-list.ts
+++ b/src/features/device-types/device-types-list.ts
@@ -21,11 +21,6 @@ import {
 
 const { api } = sbvrUtils;
 
-export interface DeviceTypeInfo {
-	latest: DeviceTypeJson;
-	versions: string[];
-}
-
 function sortBuildIds(ids: string[]): string[] {
 	return ids.sort((a, b) => {
 		return (
@@ -73,9 +68,9 @@ for (const contractPath of CONTRACT_ALLOWLIST) {
 	}
 }
 
-export const getDeviceTypes = multiCacheMemoizee(
-	async (): Promise<Dictionary<DeviceTypeInfo>> => {
-		const result: Dictionary<DeviceTypeInfo> = {};
+export const getDeviceTypeJsons = multiCacheMemoizee(
+	async (): Promise<Dictionary<DeviceTypeJson>> => {
+		const result: Dictionary<DeviceTypeJson> = {};
 		let deviceTypes = await api.resin.get({
 			resource: 'device_type',
 			passthrough: { req: permissions.rootRead },
@@ -105,18 +100,18 @@ export const getDeviceTypes = multiCacheMemoizee(
 					}
 
 					const sortedBuilds = sortBuildIds(builds);
-					const latestDeviceType = await getFirstValidBuild(slug, sortedBuilds);
-					if (!latestDeviceType) {
+					const latestDeviceTypeJson = await getFirstValidBuild(
+						slug,
+						sortedBuilds,
+					);
+					if (!latestDeviceTypeJson) {
 						return;
 					}
 
-					result[slug] = {
-						versions: builds,
-						latest: latestDeviceType,
-					};
+					result[slug] = latestDeviceTypeJson;
 
-					if (latestDeviceType.aliases != null) {
-						for (const alias of latestDeviceType.aliases) {
+					if (latestDeviceTypeJson.aliases != null) {
+						for (const alias of latestDeviceTypeJson.aliases) {
 							result[alias] = result[slug];
 						}
 					}
@@ -135,7 +130,7 @@ export const getDeviceTypes = multiCacheMemoizee(
 		return result;
 	},
 	{
-		cacheKey: 'fetchDeviceTypes',
+		cacheKey: 'getDeviceTypeJsons',
 		promise: true,
 		primitive: true,
 		maxAge: DEVICE_TYPES_CACHE_LOCAL_TIMEOUT,

--- a/src/features/device-types/device-types.ts
+++ b/src/features/device-types/device-types.ts
@@ -9,8 +9,7 @@ import {
 } from '../../infra/error-handling/index.js';
 
 import { getCompressedSize, getDeviceTypeJson } from './build-info-facade.js';
-import { getDeviceTypes } from './device-types-list.js';
-import type { DeviceTypeInfo } from './device-types-list.js';
+import { getDeviceTypeJsons } from './device-types-list.js';
 import type { Release } from '../../balena-model.js';
 import type { Filter } from 'pinejs-client-core';
 const { BadRequestError, NotFoundError } = errors;
@@ -64,19 +63,6 @@ export const getDeviceTypeBySlug = async (
 	return dt;
 };
 
-const findDeviceTypeInfoBySlug = async (
-	resinApi: typeof sbvrUtils.api.resin,
-	slug: string,
-): Promise<DeviceTypeInfo> => {
-	const deviceTypeResource = await getDeviceTypeBySlug(resinApi, slug);
-	const deviceTypeInfos = await getDeviceTypes();
-	const deviceTypeInfo = deviceTypeInfos[deviceTypeResource.slug];
-	if (deviceTypeInfo?.latest == null) {
-		throw new UnknownDeviceTypeError(slug);
-	}
-	return deviceTypeInfo;
-};
-
 export const validateSlug = (slug?: string) => {
 	if (slug == null || !/^[\w-]+$/.test(slug)) {
 		throw new BadRequestError('Invalid device type');
@@ -89,7 +75,7 @@ export const getAccessibleDeviceTypeJsons = async (
 	resinApi: typeof sbvrUtils.api.resin,
 ): Promise<DeviceTypeJson[]> => {
 	const [deviceTypeInfosBySlug, accessibleDeviceTypes] = await Promise.all([
-		getDeviceTypes(),
+		getDeviceTypeJsons(),
 		resinApi.get({
 			resource: 'device_type',
 			options: {
@@ -99,7 +85,7 @@ export const getAccessibleDeviceTypeJsons = async (
 	]);
 
 	return accessibleDeviceTypes
-		.map((dt) => deviceTypeInfosBySlug[dt.slug]?.latest)
+		.map((dt) => deviceTypeInfosBySlug[dt.slug])
 		.filter((dtJson) => dtJson != null);
 };
 
@@ -107,8 +93,15 @@ export const getAccessibleDeviceTypeJsons = async (
 export const getDeviceTypeJsonBySlug = async (
 	resinApi: typeof sbvrUtils.api.resin,
 	slug: string,
-): Promise<DeviceTypeJson> =>
-	(await findDeviceTypeInfoBySlug(resinApi, slug)).latest;
+): Promise<DeviceTypeJson> => {
+	const deviceTypeResource = await getDeviceTypeBySlug(resinApi, slug);
+	const deviceTypeJsons = await getDeviceTypeJsons();
+	const deviceTypeJson = deviceTypeJsons[deviceTypeResource.slug];
+	if (deviceTypeJson == null) {
+		throw new UnknownDeviceTypeError(slug);
+	}
+	return deviceTypeJson;
+};
 
 // Quick way to infer whether a release version looks like an ESR (eg :2020.1.0)
 // TODO: Drop this once we add support for ESR releases to the download size estimate endpoint.

--- a/src/features/device-types/hooks/device-types-cache-invalidation.ts
+++ b/src/features/device-types/hooks/device-types-cache-invalidation.ts
@@ -1,5 +1,5 @@
 import { hooks } from '@balena/pinejs';
-import { getDeviceTypes } from '../device-types-list.js';
+import { getDeviceTypeJsons } from '../device-types-list.js';
 
 hooks.addPureHook('POST', 'resin', 'device_type', {
 	POSTRUN: ({ request, result }) => {
@@ -10,7 +10,7 @@ hooks.addPureHook('POST', 'resin', 'device_type', {
 			`[device-types]: New device_type ${request.values.slug} was created, invalidating device-types cache.`,
 		);
 		// no need to wait for the cache invalidation
-		void getDeviceTypes.delete();
+		void getDeviceTypeJsons.delete();
 	},
 });
 
@@ -21,7 +21,7 @@ hooks.addPureHook('POST', 'resin', 'application', {
 				`[device-types]: New hostApp ${request.values.slug} was created, invalidating device-types cache.`,
 			);
 			// no need to wait for the cache invalidation
-			void getDeviceTypes.delete();
+			void getDeviceTypeJsons.delete();
 		}
 	},
 });
@@ -34,7 +34,7 @@ hooks.addPureHook('PATCH', 'resin', 'application', {
 				`[device-types]: Application(s) ${affectedIds.join(',')} were marked as host, invalidating device-types cache.`,
 			);
 			// no need to wait for the cache invalidation
-			void getDeviceTypes.delete();
+			void getDeviceTypeJsons.delete();
 		}
 	},
 });


### PR DESCRIPTION
On top of https://github.com/balena-io/open-balena-api/pull/1607

Change-type: patch
See: https://balena.fibery.io/Work/Improvement/Stop-relying-on-device-types-v1-device-type.json-for-unrelated-things-257
See: https://balena.fibery.io/Work/Project/2470