### PR TITLE
Run customs tests on self-hosted runners

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -31,5 +31,11 @@ jobs:
           "linux/amd64": ["self-hosted","X64"],
           "linux/arm64": ["self-hosted","ARM64"]
         }
+      custom_test_matrix: >
+        {
+          "os": [
+            ["self-hosted"]
+          ]
+        }
       # This allows external PRs to run custom actions so the custom actions must be safe to run in that context
       restrict_custom_actions: false


### PR DESCRIPTION
Currently, the open-balena-cli customs test CI step is running on github shared ubuntu runners, these are being slow enough to cause some tests to fail most of the times (about only 10% success runs). Initial investigation seems to indicate that the CPU required by the DB container on tests inserting several hundred thousands of lines in one go might be slow enough to cause everything to timeout on those runners.

Change-type: patch