### PR TITLE
Count deleted manifests accurately across retried tasks

### DIFF
--- a/src/features/images/tasks/delete-registry-images.ts
+++ b/src/features/images/tasks/delete-registry-images.ts
@@ -76,8 +76,8 @@ async function deleteRepo(
 	s3: NonNullable<typeof s3Client>,
 	repo: string,
 	signal: AbortSignal,
-): Promise<number> {
-	let manifestsDeleted = 0;
+	onDeleted: () => void,
+): Promise<void> {
 	const cacheRepos = await s3.listCacheRepos(repo);
 	for (const target of [...cacheRepos, repo]) {
 		signal.throwIfAborted();
@@ -89,10 +89,9 @@ async function deleteRepo(
 		for (const digest of digests) {
 			signal.throwIfAborted();
 			await deleteImage(token, target, digest);
-			manifestsDeleted++;
+			onDeleted();
 		}
 	}
-	return manifestsDeleted;
 }
 
 const deleteRegistryImages = async ({
@@ -146,8 +145,9 @@ const deleteRegistryImages = async ({
 						`[${logHeader}] Skipping deletion of image with empty repo: ${location}`,
 					);
 				} else {
-					const manifestsDeleted = await deleteRepo(s3Client!, repo, signal);
-					totalManifestsDeleted += manifestsDeleted;
+					await deleteRepo(s3Client!, repo, signal, () => {
+						totalManifestsDeleted++;
+					});
 				}
 				remaining.delete(location);
 			}),

--- a/test/26_registry-image-deletion.ts
+++ b/test/26_registry-image-deletion.ts
@@ -300,6 +300,22 @@ export default () => {
 							'[delete_registry_images_task] Task took too long. Created a new task for the remaining images',
 						),
 					);
+
+					// Each image contributes 1 main manifest + 1 cache manifest.
+					let totalDeleted = 0;
+					for (const callArgs of consoleSpy.args) {
+						const msg = callArgs[0];
+						if (typeof msg !== 'string') {
+							continue;
+						}
+						const match = msg.match(
+							/\[delete_registry_images_task\] Deleted (\d+) registry manifests/,
+						);
+						if (match) {
+							totalDeleted += parseInt(match[1], 10);
+						}
+					}
+					expect(totalDeleted).to.equal(images.length * 2);
 				} finally {
 					consoleSpy.restore();
 					config.TEST_MOCK_ONLY.ASYNC_TASK_DELETE_REGISTRY_IMAGES_MAX_TIME_MS =

--- a/test/test-lib/registry-mock.ts
+++ b/test/test-lib/registry-mock.ts
@@ -111,7 +111,7 @@ function registerS3Resolver() {
 		if (digestsMatch) {
 			const repo = digestsMatch[1];
 			const commonPrefixes = store.images
-				.filter((i) => i.repository === repo)
+				.filter((i) => i.repository === repo && !i.isDeleted)
 				.map((i) => ({
 					Prefix: `${prefix}${i.digest.replace(/^sha256:/, '')}/`,
 				}));
@@ -122,7 +122,9 @@ function registerS3Resolver() {
 			const repo = tagDigestsMatch[1];
 			const tag = tagDigestsMatch[2];
 			const commonPrefixes = store.images
-				.filter((i) => i.repository === repo && i.tags?.includes(tag))
+				.filter(
+					(i) => i.repository === repo && !i.isDeleted && i.tags?.includes(tag),
+				)
 				.map((i) => ({
 					Prefix: `${prefix}${i.digest.replace(/^sha256:/, '')}/`,
 				}));
@@ -131,7 +133,7 @@ function registerS3Resolver() {
 		if (prefix.startsWith(reposPath) && prefix !== reposPath) {
 			const repoPrefix = prefix.replace(reposPath, '');
 			const commonPrefixes = store.images
-				.filter((i) => i.repository.startsWith(repoPrefix))
+				.filter((i) => i.repository.startsWith(repoPrefix) && !i.isDeleted)
 				.map((i) => ({
 					Prefix: `${reposPath}${i.repository}/`,
 				}));


### PR DESCRIPTION
Change-type: patch

---

See: https://balena.fibery.io/Work/Project/Mark-associated-resources-for-deletion-when-a-release-is-deleted-1779

After testing the deletion of 1000 manifests via this task on staging, I confirmed that while all manifests were correctly deleted from the registry, the numbers in the logs were slightly off. The logs accounted for 989 manifests even though 1000 were deleted, caused by the the count not being returned from `deleteRepo()` when it is aborted due to task execution timeout.