### PR TITLE
Change the /device-types/v1/:deviceType/images/:version/download-size endpoint to use release_assets when they exist

### DIFF
--- a/src/features/device-types/device-types.ts
+++ b/src/features/device-types/device-types.ts
@@ -158,6 +158,17 @@ export const getImageSize = async (
 		options: {
 			$top: parsedOsVersion === 'latest' ? 1 : 2,
 			$select: ['semver', 'variant'],
+			$expand: {
+				release_asset: {
+					$select: ['asset_key', 'asset'],
+					$filter: {
+						$and: [
+							{ asset_key: { $startswith: 'compressed/' } },
+							{ asset_key: { $endswith: '.deflate' } },
+						],
+					},
+				},
+			},
 			$filter: {
 				belongs_to__application: {
 					$any: {
@@ -215,24 +226,31 @@ export const getImageSize = async (
 		throw new UnknownVersionError(slug, buildId);
 	}
 
-	// The key prefix on S3 matches the semver (w/o draft parts) that the OS team used.
-	buildId =
-		release.variant !== ''
-			? `${release.semver}.${release.variant}`
-			: release.semver;
+	if (release.release_asset.length === 0) {
+		// The key prefix on S3 matches the semver (w/o draft parts) that the OS team used.
+		buildId =
+			release.variant !== ''
+				? `${release.semver}.${release.variant}`
+				: release.semver;
 
-	const hasDeviceTypeJson = await getDeviceTypeJson(normalizedSlug, buildId);
-	if (!hasDeviceTypeJson) {
-		throw new UnknownVersionError(slug, buildId);
+		const hasDeviceTypeJson = await getDeviceTypeJson(normalizedSlug, buildId);
+		if (!hasDeviceTypeJson) {
+			throw new UnknownVersionError(slug, buildId);
+		}
+
+		try {
+			return await getCompressedSize(normalizedSlug, buildId);
+		} catch (err) {
+			captureException(
+				err,
+				`Failed to get device type ${slug} compressed size for version ${buildId}`,
+			);
+			throw err;
+		}
 	}
 
-	try {
-		return await getCompressedSize(normalizedSlug, buildId);
-	} catch (err) {
-		captureException(
-			err,
-			`Failed to get device type ${slug} compressed size for version ${buildId}`,
-		);
-		throw err;
-	}
+	return release.release_asset.reduce(
+		(sum, ra) => sum + (ra.asset?.size ?? 0),
+		0,
+	);
 };

--- a/test/02_device-types.ts
+++ b/test/02_device-types.ts
@@ -353,6 +353,13 @@ export default () => {
 				expect(res.body).to.deep.equal({ size: 1117921014 });
 			});
 
+			it('should return the file size estimate of an OS release that has release_assets and no S3 artifacts, counting only the .deflate files', async () => {
+				const res = await supertest()
+					.get('/device-types/v1/generic-amd64/images/6.8.0/download-size')
+					.expect(200);
+				expect(res.body).to.deep.equal({ size: 1106214629 });
+			});
+
 			it('should return the file size estimate of the latest OS release', async () => {
 				const resLatest = await supertest()
 					.get('/device-types/v1/generic-amd64/images/latest/download-size')

--- a/test/fixtures/02-device-types/release_asset.json
+++ b/test/fixtures/02-device-types/release_asset.json
@@ -1,0 +1,162 @@
+{
+	"releaseAmd64_6_8_0/device-type.json": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "device-type.json",
+		"asset": {
+			"filename": "device-type.json",
+			"content_type": "application/json",
+			"size": 2971
+		}
+	},
+	"releaseAmd64_6_8_0/image.json": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "image.json",
+		"asset": {
+			"filename": "image.json",
+			"content_type": "application/json",
+			"size": 1469
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-0.deflate": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-0.deflate",
+		"asset": {
+			"filename": "part-0.deflate",
+			"content_type": "application/octet-stream",
+			"size": 4452
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-1.deflate": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-1.deflate",
+		"asset": {
+			"filename": "part-1.deflate",
+			"content_type": "application/octet-stream",
+			"size": 717889
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-2.deflate": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-2.deflate",
+		"asset": {
+			"filename": "part-2.deflate",
+			"content_type": "application/octet-stream",
+			"size": 1105466701
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-3.deflate": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-3.deflate",
+		"asset": {
+			"filename": "part-3.deflate",
+			"content_type": "application/octet-stream",
+			"size": 4828
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-4.deflate": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-4.deflate",
+		"asset": {
+			"filename": "part-4.deflate",
+			"content_type": "application/octet-stream",
+			"size": 4085
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-5.deflate": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-5.deflate",
+		"asset": {
+			"filename": "part-5.deflate",
+			"content_type": "application/octet-stream",
+			"size": 15300
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-6.deflate": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-6.deflate",
+		"asset": {
+			"filename": "part-6.deflate",
+			"content_type": "application/octet-stream",
+			"size": 1374
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-0.deflate.enc": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-0.deflate.enc",
+		"asset": {
+			"filename": "part-0.deflate.enc",
+			"content_type": "application/octet-stream",
+			"size": 4480
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-1.deflate.enc": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-1.deflate.enc",
+		"asset": {
+			"filename": "part-1.deflate.enc",
+			"content_type": "application/octet-stream",
+			"size": 717920
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-2.deflate.enc": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-2.deflate.enc",
+		"asset": {
+			"filename": "part-2.deflate.enc",
+			"content_type": "application/octet-stream",
+			"size": 1105466720
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-3.deflate.enc": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-3.deflate.enc",
+		"asset": {
+			"filename": "part-3.deflate.enc",
+			"content_type": "application/octet-stream",
+			"size": 4848
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-4.deflate.enc": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-4.deflate.enc",
+		"asset": {
+			"filename": "part-4.deflate.enc",
+			"content_type": "application/octet-stream",
+			"size": 4112
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-5.deflate.enc": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-5.deflate.enc",
+		"asset": {
+			"filename": "part-5.deflate.enc",
+			"content_type": "application/octet-stream",
+			"size": 15328
+		}
+	},
+	"releaseAmd64_6_8_0/compressed/part-6.deflate.enc": {
+		"user": "admin",
+		"release": "releaseAmd64_6_8_0release_assets_only",
+		"asset_key": "compressed/part-6.deflate.enc",
+		"asset": {
+			"filename": "part-6.deflate.enc",
+			"content_type": "application/octet-stream",
+			"size": 1392
+		}
+	}
+}

--- a/test/fixtures/02-device-types/releases.json
+++ b/test/fixtures/02-device-types/releases.json
@@ -55,6 +55,14 @@
 		"is_final": false,
 		"user": "admin"
 	},
+	"releaseAmd64_6_8_0release_assets_only": {
+		"application": "generic-amd64",
+		"composition": {},
+		"source": "cloud",
+		"status": "success",
+		"semver": "6.8.0",
+		"user": "admin"
+	},
 	"releaseAmd64_6_8_1": {
 		"application": "generic-amd64",
 		"composition": {},

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -242,11 +242,32 @@ const loaders: types.Dictionary<LoaderFunc> = {
 		req = req.field('release', release.id);
 		req = req.field('asset_key', jsonData.asset_key);
 		req = req.attach('asset', Buffer.from([1, 2, 3]), {
-			filename: jsonData.asset,
 			contentType: 'image/png',
+			...(typeof jsonData.asset === 'string'
+				? { filename: jsonData.asset }
+				: jsonData.asset),
 		});
-
 		const res = await req.expect(201);
+
+		if (
+			typeof jsonData.asset === 'object' &&
+			typeof jsonData.asset.size === 'number'
+		) {
+			// Manually set the mocked size, so that we can still send slim payloads to s3minio during tests
+			await api.resin.patch({
+				resource: 'release_asset',
+				passthrough: { req: permissions.root },
+				id: res.body.id,
+				body: {
+					asset: {
+						...res.body.asset,
+						size: jsonData.asset.size,
+					},
+				},
+			});
+			res.body.asset.size = jsonData.asset.size;
+		}
+
 		return res.body;
 	},
 	release_tags: async (jsonData, fixtures) => {


### PR DESCRIPTION
On top of https://github.com/balena-io/open-balena-api/pull/2292

Change-type: patch
See: https://balena.fibery.io/Work/Improvement/Stop-relying-on-device-types-v1-device-type.json-for-unrelated-things-257
See: https://balena.fibery.io/Work/Project/2470