### PR TITLE
Simplify image deletion count logic

### DIFF
--- a/src/features/images/tasks/delete-registry-images.ts
+++ b/src/features/images/tasks/delete-registry-images.ts
@@ -49,12 +49,7 @@ if (ASYNC_TASK_DELETE_REGISTRY_IMAGES_ENABLED) {
 		handlerName,
 		async (options) => {
 			try {
-				const totalManifestsDeleted = await deleteRegistryImages(
-					options.params,
-				);
-				console.info(
-					`[${logHeader}] Deleted ${totalManifestsDeleted} registry manifests`,
-				);
+				await deleteRegistryImages(options.params);
 				return {
 					status: 'succeeded',
 				};
@@ -76,7 +71,6 @@ async function deleteRepo(
 	s3: NonNullable<typeof s3Client>,
 	repo: string,
 	signal: AbortSignal,
-	onDeleted: () => void,
 ): Promise<void> {
 	const cacheRepos = await s3.listCacheRepos(repo);
 	for (const target of [...cacheRepos, repo]) {
@@ -89,7 +83,6 @@ async function deleteRepo(
 		for (const digest of digests) {
 			signal.throwIfAborted();
 			await deleteImage(token, target, digest);
-			onDeleted();
 		}
 	}
 }
@@ -135,7 +128,7 @@ const deleteRegistryImages = async ({
 		ASYNC_TASK_DELETE_REGISTRY_IMAGES_MAX_TIME_MS,
 	);
 	const signal = AbortSignal.any([timeoutAbortSignal, errorController.signal]);
-	let totalManifestsDeleted = 0;
+	const initialCount = remaining.size;
 	try {
 		await queue.addAll(
 			Array.from(remaining, (location) => async () => {
@@ -145,9 +138,7 @@ const deleteRegistryImages = async ({
 						`[${logHeader}] Skipping deletion of image with empty repo: ${location}`,
 					);
 				} else {
-					await deleteRepo(s3Client!, repo, signal, () => {
-						totalManifestsDeleted++;
-					});
+					await deleteRepo(s3Client!, repo, signal);
 				}
 				remaining.delete(location);
 			}),
@@ -160,6 +151,10 @@ const deleteRegistryImages = async ({
 			throw err;
 		}
 	}
+
+	console.info(
+		`[${logHeader}] Processed ${initialCount - remaining.size}/${initialCount} images`,
+	);
 
 	// Re-enqueue any remaining images
 	if (remaining.size > 0) {
@@ -178,6 +173,4 @@ const deleteRegistryImages = async ({
 			`[${logHeader}] Task took too long. Created a new task for the remaining images`,
 		);
 	}
-
-	return totalManifestsDeleted;
 };

--- a/test/26_registry-image-deletion.ts
+++ b/test/26_registry-image-deletion.ts
@@ -247,7 +247,7 @@ export default () => {
 					expect(image.registryImage.isDeleted).to.be.false;
 					sinon.assert.calledWithMatch(
 						consoleSpy,
-						'[delete_registry_images_task] Deleted 0 registry manifests',
+						'[delete_registry_images_task] Processed 0/0 images',
 					);
 				} finally {
 					consoleSpy.restore();
@@ -301,21 +301,22 @@ export default () => {
 						),
 					);
 
-					// Each image contributes 1 main manifest + 1 cache manifest.
-					let totalDeleted = 0;
+					// The original task plus follow-up task(s) should together
+					// process every image exactly once.
+					let totalProcessed = 0;
 					for (const callArgs of consoleSpy.args) {
 						const msg = callArgs[0];
 						if (typeof msg !== 'string') {
 							continue;
 						}
 						const match = msg.match(
-							/\[delete_registry_images_task\] Deleted (\d+) registry manifests/,
+							/\[delete_registry_images_task\] Processed (\d+)\/\d+ images/,
 						);
 						if (match) {
-							totalDeleted += parseInt(match[1], 10);
+							totalProcessed += parseInt(match[1], 10);
 						}
 					}
-					expect(totalDeleted).to.equal(images.length * 2);
+					expect(totalProcessed).to.equal(images.length);
 				} finally {
 					consoleSpy.restore();
 					config.TEST_MOCK_ONLY.ASYNC_TASK_DELETE_REGISTRY_IMAGES_MAX_TIME_MS =


### PR DESCRIPTION
Change-type: patch

---

See: https://balena.fibery.io/Work/Project/Mark-associated-resources-for-deletion-when-a-release-is-deleted-1779

Simplify the count logic when images are deleted by the async task. Currently the count can be incorrect if the p-queue task is aborted at the wrong time (due to a task timeout etc). Instead just output how many images were processed by the task by comparing the initial count and the remaining count.