### PR TITLE
Export registry generateToken function

### DIFF
--- a/src/features/registry/registry.ts
+++ b/src/features/registry/registry.ts
@@ -566,7 +566,7 @@ const authorizeRequest = async (
 	);
 };
 
-const generateToken = (
+export const generateToken = (
 	subject = '',
 	audience: string,
 	access: Access[],


### PR DESCRIPTION
Change-type: minor

---

See: https://balena.fibery.io/Work/Project/Mark-existing-registry-trash-data-for-deletion-via-a-migration-2245

This will allow us to generate a catalog token to query that endpoint via something like:
```typescript
const catalogToken = registry.generateToken(subject, REGISTRY2_HOST, [
    {
        name: 'catalog',
        type: 'registry',
        actions: ['*'],
    },
]);
```