### PR TITLE
Switch from custom `Dictionary` type to built in `Record` typing

### DIFF
--- a/src/abstract-sql-utils.ts
+++ b/src/abstract-sql-utils.ts
@@ -246,7 +246,7 @@ export type AliasValidNodeType =
 export const aliasFields = (
 	abstractSqlModel: AbstractSqlModel,
 	resourceName: string,
-	aliases: Dictionary<string | AliasValidNodeType>,
+	aliases: Record<string, string | AliasValidNodeType>,
 ): SelectNode[1] => {
 	const fieldNames = abstractSqlModel.tables[resourceName].fields.map(
 		({ fieldName }) => fieldName,

--- a/src/features/contracts/index.ts
+++ b/src/features/contracts/index.ts
@@ -41,7 +41,7 @@ export interface Contract {
 	type: string;
 	aliases?: string[];
 	name: string;
-	assets?: Dictionary<ContractAsset>;
+	assets?: Record<string, ContractAsset>;
 	data: any;
 }
 

--- a/src/features/device-heartbeat/index.ts
+++ b/src/features/device-heartbeat/index.ts
@@ -99,7 +99,7 @@ const getPollIntervalForParentApplication = _.once(() =>
 
 export const getPollInterval = async (
 	deviceId: number,
-	config?: Dictionary<string>,
+	config?: Record<string, string>,
 ) => {
 	let pollIntervalString: string | undefined;
 	if (config != null) {

--- a/src/features/device-state/index.ts
+++ b/src/features/device-state/index.ts
@@ -74,7 +74,7 @@ export interface Events {
 	'get-state': (
 		deviceId: number,
 		info: Pick<Request, 'apiKey'> & {
-			config?: Dictionary<string>;
+			config?: Record<string, string>;
 			ipAddress: string | undefined;
 			storedDeviceFields: Partial<Device['Read']>;
 		},

--- a/src/features/device-state/routes/fleet-state-get-v3.ts
+++ b/src/features/device-state/routes/fleet-state-get-v3.ts
@@ -119,7 +119,7 @@ const getSuccessfulReleaseForFleetAndCommit = async (
 const getFleetAppsForState = (
 	fleet: ExpandedApplicationWithService,
 	release: ExpandedRelease,
-	config: Dictionary<string>,
+	config: Record<string, string>,
 ): FleetStateV3[string]['apps'] => {
 	return {
 		[fleet.uuid]: {

--- a/src/features/device-state/routes/state-get-v2.ts
+++ b/src/features/device-state/routes/state-get-v2.ts
@@ -68,7 +68,7 @@ function buildAppFromRelease(
 	device: ExpandedDevice,
 	application: ExpandedDevice['belongs_to__application'][number],
 	release: ExpandedDevice['should_be_running__release'][number],
-	config: Dictionary<string>,
+	config: Record<string, string>,
 ): LocalStateApp {
 	let composition: AnyObject = {};
 	const services: LocalStateApp['services'] = {};
@@ -93,7 +93,7 @@ function buildAppFromRelease(
 		const image = ipr.image[0];
 
 		const svc = image.is_a_build_of__service[0];
-		const environment: Dictionary<string> = {};
+		const environment: Record<string, string> = {};
 		varListInsert(ipr.image_environment_variable, environment);
 		varListInsert(application.application_environment_variable, environment);
 		varListInsert(svc.service_environment_variable, environment);
@@ -103,7 +103,7 @@ function buildAppFromRelease(
 			varListInsert(dsevs, environment);
 		}
 
-		const labels: Dictionary<string> = {};
+		const labels: Record<string, string> = {};
 		for (const { label_name, value } of [
 			...ipr.image_label,
 			...svc.service_label,
@@ -296,7 +296,7 @@ const getDevice = getStateDelayingEmpty(
 
 const getUserAppForState = (
 	device: ExpandedDevice,
-	config: Dictionary<string>,
+	config: Record<string, string>,
 ): LocalStateApp => {
 	const userAppFromApi = device.belongs_to__application[0];
 

--- a/src/features/device-state/routes/state-get-v3.ts
+++ b/src/features/device-state/routes/state-get-v3.ts
@@ -98,22 +98,22 @@ export function buildAppFromRelease(
 	device: undefined,
 	application: ExpandedApplicationWithService,
 	release: ExpandedRelease,
-	config: Dictionary<string>,
-	defaultLabels?: Dictionary<string>,
+	config: Record<string, string>,
+	defaultLabels?: Record<string, string>,
 ): NonNullable<LocalStateApp['releases']>;
 export function buildAppFromRelease(
 	device: ExpandedDevice,
 	application: ExpandedApplication,
 	release: ExpandedRelease,
-	config: Dictionary<string>,
-	defaultLabels?: Dictionary<string>,
+	config: Record<string, string>,
+	defaultLabels?: Record<string, string>,
 ): NonNullable<LocalStateApp['releases']>;
 export function buildAppFromRelease(
 	device: ExpandedDevice | undefined,
 	application: ExpandedApplication | ExpandedApplicationWithService,
 	release: ExpandedRelease,
-	config: Dictionary<string>,
-	defaultLabels?: Dictionary<string>,
+	config: Record<string, string>,
+	defaultLabels?: Record<string, string>,
 ): NonNullable<LocalStateApp['releases']> {
 	let composition: AnyObject = {};
 	const services: NonNullable<LocalStateApp['releases']>[string]['services'] =
@@ -157,7 +157,7 @@ export function buildAppFromRelease(
 	for (const ipr of release.release_image) {
 		const image = ipr.image[0];
 		const svc = image.is_a_build_of__service[0];
-		const environment: Dictionary<string> = {};
+		const environment: Record<string, string> = {};
 
 		if ('service' in application) {
 			if (!application.service.some((s) => s.id === svc.id)) {
@@ -179,7 +179,7 @@ export function buildAppFromRelease(
 			}
 		}
 
-		const labels: Dictionary<string> = {
+		const labels: Record<string, string> = {
 			...defaultLabels,
 		};
 		for (const { label_name, value } of [
@@ -446,8 +446,8 @@ const getDevice = getStateDelayingEmpty(
 const getAppState = (
 	device: ExpandedDevice,
 	targetReleaseField: TargetReleaseField,
-	config: Dictionary<string>,
-	defaultLabels?: Dictionary<string>,
+	config: Record<string, string>,
+	defaultLabels?: Record<string, string>,
 ): StateV3[string]['apps'] | null => {
 	let application: ExpandedApplication;
 	let release: ExpandedRelease;

--- a/src/features/device-state/state-get-utils.ts
+++ b/src/features/device-state/state-get-utils.ts
@@ -15,7 +15,9 @@ export const getStateEventAdditionalFields: Array<
 	Exclude<keyof Device['Read'], ExpandableStringKeyOf<Device['Read']>>
 > = [];
 
-const defaultConfigVariableFns: Array<(config: Dictionary<string>) => void> = [
+const defaultConfigVariableFns: Array<
+	(config: Record<string, string>) => void
+> = [
 	function setMinPollInterval(config) {
 		const pollInterval =
 			config.RESIN_SUPERVISOR_POLL_INTERVAL == null
@@ -31,7 +33,9 @@ export const addDefaultConfigVariableFn = (
 ) => {
 	defaultConfigVariableFns.push(fn);
 };
-export const setDefaultConfigVariables = (config: Dictionary<string>): void => {
+export const setDefaultConfigVariables = (
+	config: Record<string, string>,
+): void => {
 	for (const fn of defaultConfigVariableFns) {
 		fn(config);
 	}
@@ -48,7 +52,7 @@ export const getConfig = (
 		| undefined,
 	application = device?.belongs_to__application[0],
 ) => {
-	const config: Dictionary<string> = {};
+	const config: Record<string, string> = {};
 
 	// add any app-specific config values...
 
@@ -104,7 +108,9 @@ export const formatImageLocation = (imageLocation: string) =>
 // be sent to the device.
 //
 // `configVars` should be in the form { [name: string]: string }
-export const filterDeviceConfig = (configVars: Dictionary<string>): void => {
+export const filterDeviceConfig = (
+	configVars: Record<string, string>,
+): void => {
 	// ResinOS >= 2.x has a read-only file system, and this var causes the
 	// supervisor to run `systemctl enable|disable [unit]`, which does not
 	// persist over reboots. This causes the supervisor to go into a reboot
@@ -130,7 +136,7 @@ export const rejectUiConfig = (name: string) =>
 export type EnvVarList = Array<{ name: string; value: string }>;
 export const varListInsert = (
 	varList: EnvVarList,
-	obj: Dictionary<string>,
+	obj: Record<string, string>,
 	filterFn: (name: string) => boolean = () => true,
 ) => {
 	for (const { name, value } of varList) {

--- a/src/features/device-types/device-types-list.ts
+++ b/src/features/device-types/device-types-list.ts
@@ -82,8 +82,8 @@ for (const contractPath of CONTRACT_ALLOWLIST) {
 }
 
 export const getDeviceTypeJsons = multiCacheMemoizee(
-	async (): Promise<Dictionary<DeviceTypeJson>> => {
-		const result: Dictionary<DeviceTypeJson> = {};
+	async (): Promise<Record<string, DeviceTypeJson>> => {
+		const result: Record<string, DeviceTypeJson> = {};
 		const deviceTypes = await api.resin.get({
 			resource: 'device_type',
 			passthrough: { req: permissions.rootRead },

--- a/src/features/vars-schema/env-vars.ts
+++ b/src/features/vars-schema/env-vars.ts
@@ -62,7 +62,7 @@ export const INVALID_NEWLINE_REGEX = /\r|\n/;
 
 const getDefinitionWithMinimumSupervisorVersion = (
 	dtsPerSupervisorVersion: { [supervisorVersion: string]: string[] },
-	definitions: Dictionary<ConfigVarDefinition>,
+	definitions: Record<string, ConfigVarDefinition>,
 ) => {
 	return Object.entries(dtsPerSupervisorVersion).map(([version, dts]) => {
 		return {
@@ -145,7 +145,7 @@ export const SUPERVISOR_CONFIG_VAR_PROPERTIES: {
 
 export const DEVICE_TYPE_SPECIFIC_CONFIG_VAR_PROPERTIES: Array<{
 	capableDeviceTypes: string[];
-	properties: Dictionary<ConfigVarDefinition>;
+	properties: Record<string, ConfigVarDefinition>;
 }> = [
 	{
 		capableDeviceTypes: [

--- a/src/infra/auth/permissions.ts
+++ b/src/infra/auth/permissions.ts
@@ -205,7 +205,7 @@ export async function createAllPermissions(
 		})
 		.then(async (perms) => {
 			const permissionsMap = _(perms).keyBy('name').mapValues('id').value();
-			const result: Dictionary<number | Promise<number>> = {};
+			const result: Record<string, Resolvable<number>> = {};
 			for (const permissionName of permissionNames) {
 				if (permissionsMap[permissionName] != null) {
 					result[permissionName] = permissionsMap[permissionName];

--- a/src/typings/common.ts
+++ b/src/typings/common.ts
@@ -4,7 +4,6 @@ declare global {
 	type AnyObject = types.AnyObject;
 	type Resolvable<R> = types.Resolvable<R>;
 	type Tx = dbModule.Tx;
-	type Dictionary<T> = types.Dictionary<T>;
 
 	type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 	type Writable<T> = { -readonly [K in keyof T]: T[K] };

--- a/test/03_device-state.ts
+++ b/test/03_device-state.ts
@@ -1288,7 +1288,7 @@ export default () => {
 				let release2: AnyObject;
 				let release1Image1: AnyObject;
 				let release1Image2: AnyObject;
-				let servicesById: Dictionary<PickDeferred<Service['Read']>>;
+				let servicesById: Record<string, PickDeferred<Service['Read']>>;
 				let device: fakeDevice.Device;
 				let stateKey: string;
 				const getMetricsRecentlyUpdatedCacheKey = (uuid: string) =>

--- a/test/scenarios/unpin-device-after-release.ts
+++ b/test/scenarios/unpin-device-after-release.ts
@@ -1,5 +1,3 @@
-import type _ from 'lodash';
-
 import { expect } from 'chai';
 import * as fakeDevice from '../test-lib/fake-device.js';
 import type { UserObjectParam } from '../test-lib/supertest.js';
@@ -30,8 +28,8 @@ export default () => {
 		let admin: UserObjectParam;
 		let applicationId: number;
 		let device: fakeDevice.Device;
-		const releases: _.Dictionary<number> = {};
-		const services: _.Dictionary<number> = {};
+		const releases: Record<string, number> = {};
+		const services: Record<string, number> = {};
 
 		before('Setup the application and initial release', async function () {
 			fx = await fixtures.load('unpin-device-after-release');

--- a/test/test-lib/api-helpers.ts
+++ b/test/test-lib/api-helpers.ts
@@ -118,14 +118,14 @@ export const expectResourceToMatch = async <
 			| string
 			| number
 			| boolean
-			| Dictionary<any>
+			| Record<string, any>
 			| ((chaiPropertyAssertion: Chai.Assertion, value: unknown) => void)
 		>
 	>,
 	expandExpectations?: Partial<
 		Record<
 			ExpandableStringKeyOf<T>,
-			Array<Dictionary<null | string | number | boolean>>
+			Array<Record<string, null | string | number | boolean>>
 		>
 	>,
 ): Promise<
@@ -371,7 +371,7 @@ const expectTasks = async (
 	return tasks;
 };
 
-const latestTaskIdByHandler: Dictionary<string | undefined> = {};
+const latestTaskIdByHandler: Record<string, string | undefined> = {};
 
 export const expectNewTasks = async (
 	handler: string,

--- a/test/test-lib/aws-mock.ts
+++ b/test/test-lib/aws-mock.ts
@@ -34,14 +34,16 @@ export function addListObjectsV2Resolver(resolver: ListObjectsV2Resolver) {
 }
 
 export default (
-	$getObjectMocks: Dictionary<
+	$getObjectMocks: Record<
+		string,
 		| (Omit<AWS.S3.Types.GetObjectOutput, 'LastModified' | 'Body'> & {
 				LastModified?: string;
 				Body?: string;
 		  })
 		| MockedError
 	>,
-	$listObjectsV2Mocks: Dictionary<
+	$listObjectsV2Mocks: Record<
+		string,
 		| (Omit<AWS.S3.Types.ListObjectsV2Output, 'Contents'> & {
 				Contents?: Array<
 					Omit<AWS.S3.Types.ListObjectsV2Output['Contents'], 'LastModified'> & {
@@ -55,27 +57,30 @@ export default (
 	// AWS S3 Client getObject results have a Buffer on their Body prop
 	// and a Date on their LastModified prop so we have to reconstruct
 	// them from the strings that the mock object holds
-	const getObjectMocks: Dictionary<AWS.S3.Types.GetObjectOutput | MockedError> =
-		_.mapValues(
-			$getObjectMocks,
-			(
-				getObjectMock: (typeof $getObjectMocks)[keyof typeof $getObjectMocks],
-			): AWS.S3.Types.GetObjectOutput | MockedError => {
-				return {
-					...getObjectMock,
+	const getObjectMocks: Record<
+		string,
+		AWS.S3.Types.GetObjectOutput | MockedError
+	> = _.mapValues(
+		$getObjectMocks,
+		(
+			getObjectMock: (typeof $getObjectMocks)[keyof typeof $getObjectMocks],
+		): AWS.S3.Types.GetObjectOutput | MockedError => {
+			return {
+				...getObjectMock,
 
-					Body:
-						'Body' in getObjectMock && getObjectMock.Body
-							? Buffer.from(getObjectMock.Body)
-							: undefined,
-					LastModified:
-						'LastModified' in getObjectMock && getObjectMock.LastModified
-							? new Date(getObjectMock.LastModified)
-							: undefined,
-				};
-			},
-		);
-	const listObjectsV2Mocks: Dictionary<
+				Body:
+					'Body' in getObjectMock && getObjectMock.Body
+						? Buffer.from(getObjectMock.Body)
+						: undefined,
+				LastModified:
+					'LastModified' in getObjectMock && getObjectMock.LastModified
+						? new Date(getObjectMock.LastModified)
+						: undefined,
+			};
+		},
+	);
+	const listObjectsV2Mocks: Record<
+		string,
 		AWS.S3.Types.ListObjectsV2Output | MockedError
 	> = _.mapValues(
 		$listObjectsV2Mocks,
@@ -173,7 +178,7 @@ export default (
 		public headObject(
 			params: AWS.S3.Types.HeadObjectRequest,
 		): ReturnType<AWS.S3['headObject']> {
-			const mock = getObjectMocks[params.Key as keyof typeof getObjectMocks];
+			const mock = getObjectMocks[params.Key];
 			if (mock) {
 				const trimmedMock = _.omit(mock, 'Body', 'ContentRange', 'TagCount');
 				return toReturnType<AWS.S3['headObject']>(trimmedMock);
@@ -192,7 +197,7 @@ export default (
 		public getObject(
 			params: AWS.S3.Types.GetObjectRequest,
 		): ReturnType<AWS.S3['getObject']> {
-			const mock = getObjectMocks[params.Key as keyof typeof getObjectMocks];
+			const mock = getObjectMocks[params.Key];
 			if (!mock) {
 				throw new Error(
 					`aws mock: getObject could not find a mock for ${params.Key}`,
@@ -210,8 +215,7 @@ export default (
 					return toReturnType<AWS.S3['listObjectsV2']>(result);
 				}
 			}
-			const mock =
-				listObjectsV2Mocks[params.Prefix as keyof typeof listObjectsV2Mocks];
+			const mock = listObjectsV2Mocks[params.Prefix!];
 			if (!mock) {
 				throw new Error(
 					`aws mock: listObjectsV2 could not find a mock for ${params.Prefix}`,

--- a/test/test-lib/device-type.ts
+++ b/test/test-lib/device-type.ts
@@ -8,7 +8,8 @@ export const loadDefaultFixtures = () => {
 	setDefaultFixtures(
 		'deviceTypes',
 		new Proxy<
-			Dictionary<
+			Record<
+				string,
 				Promise<Pick<DeviceType['Read'], 'id' | 'slug' | 'name'> | undefined>
 			>
 		>(

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -22,13 +22,15 @@ const version = 'resin';
 export const fakeTx = undefined as any as Tx;
 export const fakeSbvrUtils = undefined as any as typeof sbvrUtils;
 
-type PendingFixtures = types.Dictionary<
-	PromiseLike<types.Dictionary<PromiseLike<any>>>
+type PendingFixtures = Record<
+	string,
+	PromiseLike<Record<string, PromiseLike<any>>>
 >;
-type PartiallyAppliedFixtures = types.Dictionary<
-	types.Dictionary<PromiseLike<any>>
+type PartiallyAppliedFixtures = Record<
+	string,
+	Record<string, PromiseLike<any>>
 >;
-export type Fixtures = types.Dictionary<types.Dictionary<any>>;
+export type Fixtures = Record<string, Record<string, any>>;
 
 type LoaderFunc = (
 	jsonData: types.AnyObject,
@@ -72,7 +74,7 @@ const createResource = async (args: {
 	return await response.json();
 };
 
-const loaders: types.Dictionary<LoaderFunc> = {
+const loaders: Record<string, LoaderFunc> = {
 	applications: async (jsonData, fixtures) => {
 		const user = await fixtures.users[jsonData.user];
 		if (user == null) {
@@ -671,7 +673,8 @@ const deleteForResource =
 // Make sure this list only contains top-level resources, ie. those
 // that aren't expected to be cascade deleted by the api itself.
 // The order of the properties dictates the order the unloaders run.
-const unloaders: Dictionary<
+const unloaders: Record<
+	string,
 	(objs: Array<{ id: number }>) => PromiseLike<void>
 > = {
 	// Devices need to be deleted before their linked hostApp & supervisor releases/apps
@@ -701,8 +704,9 @@ const unloaders: Dictionary<
 };
 
 export const clean = async (
-	fixtures: types.Dictionary<
-		types.Dictionary<{ id: number }> | Array<{ id: number }>
+	fixtures: Record<
+		string,
+		Record<string, { id: number }> | Array<{ id: number }>
 	>,
 ) => {
 	if (fixtures == null) {
@@ -728,7 +732,7 @@ const defaultFixtures: PendingFixtures = {};
 
 export const setDefaultFixtures = (
 	type: string,
-	value: types.Dictionary<PromiseLike<any>>,
+	value: Record<string, PromiseLike<any>>,
 ) => {
 	defaultFixtures[type] = Promise.resolve(value);
 };


### PR DESCRIPTION
This reduces the number of custom typings we maintain/need to know about

Change-type: patch