### PR TITLE
Registry: Delete repository _manifests directory

### DIFF
--- a/src/features/images/tasks/delete-registry-images.ts
+++ b/src/features/images/tasks/delete-registry-images.ts
@@ -1,11 +1,7 @@
 import { permissions, sbvrUtils, tasks } from '@balena/pinejs';
 import type { FromSchema } from 'json-schema-to-ts';
 import PQueue from 'p-queue';
-import {
-	deleteImage,
-	generateDeleteToken,
-	s3Client,
-} from '../../../features/registry/registry.js';
+import { s3Client } from '../../../features/registry/registry.js';
 import {
 	ASYNC_TASK_ATTEMPT_LIMIT,
 	ASYNC_TASK_DELETE_REGISTRY_IMAGES_CONCURRENCY,
@@ -13,6 +9,8 @@ import {
 	ASYNC_TASK_DELETE_REGISTRY_IMAGES_MAX_TIME_MS,
 } from '../../../lib/config.js';
 
+// Shared across invocations as a global cap on concurrent registry deletions.
+// If a task times out waiting for a slot, it just re-enqueues the remaining work.
 const queue = new PQueue({
 	concurrency: ASYNC_TASK_DELETE_REGISTRY_IMAGES_CONCURRENCY,
 });
@@ -65,8 +63,12 @@ if (ASYNC_TASK_DELETE_REGISTRY_IMAGES_ENABLED) {
 	);
 }
 
-// Delete all manifests within a given registry repository.
-const subject = `task:${handlerName}`;
+// Delete all manifests within a given registry repository (and its multi-stage
+// build cache repositories) by removing the entire `_manifests` directory.
+// We delete the directory directly rather than marking each manifest for
+// deletion via the registry API, as the API leaves behind legacy signature
+// links that keep the `_manifests` directory (and thus the repository in the
+// catalog list) alive.
 async function deleteRepo(
 	s3: NonNullable<typeof s3Client>,
 	repo: string,
@@ -74,16 +76,7 @@ async function deleteRepo(
 ): Promise<void> {
 	const cacheRepos = await s3.listCacheRepos(repo);
 	for (const target of [...cacheRepos, repo]) {
-		signal.throwIfAborted();
-		const digests = await s3.listRepoDigests(target);
-		if (digests.length === 0) {
-			continue;
-		}
-		const token = generateDeleteToken(subject, target);
-		for (const digest of digests) {
-			signal.throwIfAborted();
-			await deleteImage(token, target, digest);
-		}
+		await s3.deleteRepoManifests(target, signal);
 	}
 }
 

--- a/src/features/registry/registry.ts
+++ b/src/features/registry/registry.ts
@@ -804,14 +804,6 @@ class S3Client {
 		return digests;
 	}
 
-	// List all existing manifest digests (tagged and untagged) for a given
-	// repository by listing objects in the registry's S3 bucket directly.
-	async listRepoDigests(repo: string) {
-		return await this.listDigestsAt(
-			`${this.rootPath}/repositories/${repo}/_manifests/revisions/sha256/`,
-		);
-	}
-
 	// List all manifest digests ever associated with a given tag of a
 	// repository (current and historical) by listing objects in the
 	// registry's S3 bucket directly.
@@ -827,6 +819,50 @@ class S3Client {
 		return (await this.listChildPrefixes(`${reposPath}${repo}-`)).map((child) =>
 			child.replace(reposPath, '').replace(/\/$/, ''),
 		);
+	}
+
+	// Delete a repository's entire `_manifests` directory (revisions, tags, legacy
+	// signature links, etc). Docker Distribution's API doesn't provide the tools
+	// to guarantee the removal of all manifest data.
+	async deleteRepoManifests(repo: string, signal?: AbortSignal) {
+		const prefix = `${this.rootPath}/repositories/${repo}/_manifests/`;
+		let continuationToken: string | undefined;
+		do {
+			// Stop cleanly between pages when an (optional) signal aborts.
+			signal?.throwIfAborted();
+			const res = await this.s3
+				.listObjectsV2({
+					Bucket: this.bucket,
+					Prefix: prefix,
+					ContinuationToken: continuationToken,
+				})
+				.promise();
+
+			const objects = (res.Contents ?? []).flatMap(({ Key }) =>
+				Key != null ? [{ Key }] : [],
+			);
+
+			if (objects.length > 0) {
+				// deleteObjects responds with a 200 even when individual keys
+				// fail, reporting them in the `Errors` array, so check it.
+				const deleteRes = await this.s3
+					.deleteObjects({
+						Bucket: this.bucket,
+						Delete: { Objects: objects },
+					})
+					.promise();
+				if (deleteRes.Errors != null && deleteRes.Errors.length > 0) {
+					const [err] = deleteRes.Errors;
+					throw new Error(
+						`Failed to delete ${deleteRes.Errors.length} object(s) under '${prefix}': [${err.Code}] ${err.Message}`,
+					);
+				}
+			}
+
+			continuationToken = res.IsTruncated
+				? res.NextContinuationToken
+				: undefined;
+		} while (continuationToken);
 	}
 }
 

--- a/test/26_registry-image-deletion.ts
+++ b/test/26_registry-image-deletion.ts
@@ -162,15 +162,13 @@ export default () => {
 				await expectSettledTasks([imageA]);
 			});
 
-			it('should retry on registry API errors', async () => {
-				// We have the mock return 500 on the next delete request
-				// which will cause the first task attempt to fail, but
-				// the second attempt should succeed.
-				registryMock.setNextDeleteResponseCode(500);
+			it('should retry on registry storage errors', async () => {
+				// Make the first storage delete fail, which causes the first task
+				// attempt to fail, but the retry attempt should then succeed.
+				registryMock.setNextDeleteObjectsError('mock error');
 				const consoleSpy = sinon.spy(console, 'error');
 				try {
 					const image = await createImage(ctx.service1.id);
-					const [cache] = image.cacheImages;
 					await pineUser.delete({
 						resource: 'image',
 						id: image.dbImage.id,
@@ -187,9 +185,7 @@ export default () => {
 						sinon.match.has(
 							'message',
 							sinon.match(
-								new RegExp(
-									`Failed to mark ${cache.repository}/${cache.digest} for deletion: \\[500\\].*mock error`,
-								),
+								/Failed to delete \d+ object\(s\) under .*mock error/,
 							),
 						),
 					);
@@ -270,58 +266,29 @@ export default () => {
 				await expectSettledTasks([image]);
 			});
 
-			it('should create a follow-up task when deletion takes too long', async () => {
-				const originalMaxTime =
-					config.ASYNC_TASK_DELETE_REGISTRY_IMAGES_MAX_TIME_MS;
-				config.TEST_MOCK_ONLY.ASYNC_TASK_DELETE_REGISTRY_IMAGES_MAX_TIME_MS = 50;
+			it('should remove the _manifests directory', async () => {
+				const image = await createImage(ctx.service1.id, { stages: 2 });
+				expect(registryMock.getManifestObjectKeys(image.repository)).to.not.be
+					.empty;
 
-				const consoleSpy = sinon.spy(console, 'info');
-				const images = await Promise.all(
-					Array.from({ length: 50 }, () => createImage(ctx.service1.id)),
-				);
+				await pineUser.delete({
+					resource: 'image',
+					id: image.dbImage.id,
+				});
 
-				try {
-					await pineUser.delete({
-						resource: 'image',
-						options: {
-							$filter: {
-								id: { $in: images.map((i) => i.dbImage.id) },
-							},
-						},
-					});
-					await waitFor({
-						delayMs: 500,
-						checkFn: () => checkIsDeleted(images),
-					});
+				await waitFor({
+					delayMs: 500,
+					checkFn: () => checkIsDeleted([image]),
+				});
+				await expectSettledTasks([image]);
 
-					sinon.assert.calledWithMatch(
-						consoleSpy,
-						sinon.match(
-							'[delete_registry_images_task] Task took too long. Created a new task for the remaining images',
-						),
-					);
-
-					// The original task plus follow-up task(s) should together
-					// process every image exactly once.
-					let totalProcessed = 0;
-					for (const callArgs of consoleSpy.args) {
-						const msg = callArgs[0];
-						if (typeof msg !== 'string') {
-							continue;
-						}
-						const match = msg.match(
-							/\[delete_registry_images_task\] Processed (\d+)\/\d+ images/,
-						);
-						if (match) {
-							totalProcessed += parseInt(match[1], 10);
-						}
-					}
-					expect(totalProcessed).to.equal(images.length);
-				} finally {
-					consoleSpy.restore();
-					config.TEST_MOCK_ONLY.ASYNC_TASK_DELETE_REGISTRY_IMAGES_MAX_TIME_MS =
-						originalMaxTime;
-					await resetLatestTaskIds('delete_registry_images');
+				// The entire _manifests directory should be gone for both the
+				// repo and its multi-stage cache repos.
+				expect(registryMock.getManifestObjectKeys(image.repository)).to.be
+					.empty;
+				for (const cache of image.cacheImages) {
+					expect(registryMock.getManifestObjectKeys(cache.repository)).to.be
+						.empty;
 				}
 			});
 

--- a/test/test-lib/aws-mock.ts
+++ b/test/test-lib/aws-mock.ts
@@ -33,6 +33,24 @@ export function addListObjectsV2Resolver(resolver: ListObjectsV2Resolver) {
 	};
 }
 
+type DeleteObjectsResolver = (
+	params: AWS.S3.Types.DeleteObjectsRequest,
+) => AWS.S3.Types.DeleteObjectsOutput | undefined;
+
+const deleteObjectsResolvers: DeleteObjectsResolver[] = [];
+
+// Allow test libraries to add specific resolvers.
+// Return a disposer function to keep things clean.
+export function addDeleteObjectsResolver(resolver: DeleteObjectsResolver) {
+	deleteObjectsResolvers.push(resolver);
+	return () => {
+		const idx = deleteObjectsResolvers.indexOf(resolver);
+		if (idx !== -1) {
+			deleteObjectsResolvers.splice(idx, 1);
+		}
+	};
+}
+
 export default (
 	$getObjectMocks: Record<
 		string,
@@ -222,6 +240,20 @@ export default (
 				);
 			}
 			return toReturnType<AWS.S3['listObjectsV2']>(mock);
+		}
+
+		public deleteObjects(
+			params: AWS.S3.Types.DeleteObjectsRequest,
+		): ReturnType<AWS.S3['deleteObjects']> {
+			for (const resolver of deleteObjectsResolvers) {
+				const result = resolver(params);
+				if (result != null) {
+					return toReturnType<AWS.S3['deleteObjects']>(result);
+				}
+			}
+			throw new Error(
+				`aws mock: deleteObjects could not find a resolver for ${params.Bucket}`,
+			);
 		}
 	}
 

--- a/test/test-lib/registry-mock.ts
+++ b/test/test-lib/registry-mock.ts
@@ -1,27 +1,56 @@
-import {
-	REGISTRY2_HOST,
-	REGISTRY_STORAGE_ROOT_PATH,
-} from '../../src/lib/config.js';
-import { getMockServer } from './mockttp-server.js';
-import { strict } from 'node:assert';
+import { REGISTRY_STORAGE_ROOT_PATH } from '../../src/lib/config.js';
 import { randomUUID } from 'node:crypto';
-import { addListObjectsV2Resolver } from './aws-mock.js';
+import {
+	addDeleteObjectsResolver,
+	addListObjectsV2Resolver,
+} from './aws-mock.js';
 
 interface RegistryImage {
 	repository: string;
 	digest: string;
 	isDeleted: boolean;
 	tags?: string[];
+	// Digest of the legacy schema1 signature link stored alongside the manifest
+	// revision. The registry's delete API can't remove it, so it's exactly the
+	// kind of object that deleting the whole `_manifests` directory must clear.
+	signatureDigest: string;
 }
+
+const reposPath = `${REGISTRY_STORAGE_ROOT_PATH}/repositories/`;
 
 const store: {
 	images: RegistryImage[];
+	// Full S3 object keys that currently exist under repositories/.
+	objects: Set<string>;
 } = {
 	images: [],
+	objects: new Set(),
 };
+
+function revisionLinkKey(image: RegistryImage) {
+	const hash = image.digest.replace(/^sha256:/, '');
+	return `${reposPath}${image.repository}/_manifests/revisions/sha256/${hash}/link`;
+}
+
+// All manifest object keys that back a given image.
+function manifestKeysFor(image: RegistryImage) {
+	const base = `${reposPath}${image.repository}/_manifests`;
+	const hash = image.digest.replace(/^sha256:/, '');
+	const signatureHash = image.signatureDigest.replace(/^sha256:/, '');
+	const keys = [
+		revisionLinkKey(image),
+		`${base}/revisions/sha256/${hash}/signatures/sha256/${signatureHash}/link`,
+	];
+	for (const tag of image.tags ?? []) {
+		keys.push(`${base}/tags/${tag}/current/link`);
+		keys.push(`${base}/tags/${tag}/index/sha256/${hash}/link`);
+	}
+	return keys;
+}
 
 export function reset() {
 	store.images = [];
+	store.objects = new Set();
 }
 
 export function genDigest() {
@@ -33,9 +62,13 @@ export function addImage(repository: string, digest: string, tags?: string[]) {
 		repository,
 		digest,
 		isDeleted: false,
+		signatureDigest: genDigest(),
 		...(tags != null && { tags }),
 	};
 	store.images.push(registryImage);
+	for (const key of manifestKeysFor(registryImage)) {
+		store.objects.add(key);
+	}
 	return registryImage;
 }
 
@@ -43,81 +76,40 @@ export function deleteImage(image: RegistryImage) {
 	store.images = store.images.filter(
 		(i) => i.repository !== image.repository || i.digest !== image.digest,
 	);
+	for (const key of manifestKeysFor(image)) {
+		store.objects.delete(key);
+	}
 }
 
-export function getImage(repository: string, digest: string) {
-	return store.images.find(
-		(i) => i.repository === repository && i.digest === digest,
-	);
+// The manifest object keys that currently exist for a given repository.
+// Used by tests to assert that the `_manifests` directory has been cleaned up.
+export function getManifestObjectKeys(repository: string) {
+	const prefix = `${reposPath}${repository}/_manifests/`;
+	return [...store.objects].filter((key) => key.startsWith(prefix));
 }
 
 export function addCacheImages(repository: string, stages: number) {
 	const cacheImages: RegistryImage[] = [];
 	for (let i = 0; i < stages; i++) {
-		const cacheRepo = `${repository}-${i}`;
-		const cacheImage: RegistryImage = {
-			repository: cacheRepo,
-			digest: genDigest(),
-			isDeleted: false,
-		};
-		store.images.push(cacheImage);
-		cacheImages.push(cacheImage);
+		cacheImages.push(addImage(`${repository}-${i}`, genDigest()));
 	}
 	return cacheImages;
 }
 
-let nextDeleteResponseCode: number | null = null;
-export function setNextDeleteResponseCode(code: number | null) {
-	nextDeleteResponseCode = code;
-}
-
-const manifestPathRegex =
-	/\/v2\/([a-zA-Z0-9-/]+)\/manifests\/(sha256:[a-zA-Z0-9]+)/;
-
-async function mockDeleteManifest() {
-	await getMockServer()
-		.forDelete(manifestPathRegex)
-		.forHostname(REGISTRY2_HOST)
-		.always()
-		.thenCallback((req) => {
-			if (nextDeleteResponseCode != null) {
-				const code = nextDeleteResponseCode;
-				nextDeleteResponseCode = null;
-				return { statusCode: code, body: 'mock error' };
-			}
-			const matches = req.url.match(manifestPathRegex);
-			const repository = matches?.[1];
-			const digest = matches?.[2];
-			strict(repository && digest);
-			const image = getImage(repository, digest);
-			if (image == null || image.isDeleted === true) {
-				return { statusCode: 404 };
-			}
-			image.isDeleted = true;
-			return { statusCode: 202 };
-		});
+let nextDeleteObjectsError: string | null = null;
+// Make the next deleteObjects call report a storage error, to exercise the
+// task's retry behaviour. Reset after a single call.
+export function setNextDeleteObjectsError(message: string | null) {
+	nextDeleteObjectsError = message;
 }
 
 function registerS3Resolver() {
-	const reposPath = `${REGISTRY_STORAGE_ROOT_PATH}/repositories/`;
-	const digestsPrefixRegex = new RegExp(
-		`^${reposPath}(.+?)/_manifests/revisions/sha256/$`,
-	);
 	const tagDigestsPrefixRegex = new RegExp(
 		`^${reposPath}(.+?)/_manifests/tags/(.+?)/index/sha256/$`,
 	);
+	const manifestsPrefixRegex = new RegExp(`^${reposPath}(.+?)/_manifests/$`);
 	return addListObjectsV2Resolver((params) => {
 		const prefix = params.Prefix ?? '';
-		const digestsMatch = prefix.match(digestsPrefixRegex);
-		if (digestsMatch) {
-			const repo = digestsMatch[1];
-			const commonPrefixes = store.images
-				.filter((i) => i.repository === repo && !i.isDeleted)
-				.map((i) => ({
-					Prefix: `${prefix}${i.digest.replace(/^sha256:/, '')}/`,
-				}));
-			return { IsTruncated: false, CommonPrefixes: commonPrefixes };
-		}
 		const tagDigestsMatch = prefix.match(tagDigestsPrefixRegex);
 		if (tagDigestsMatch) {
 			const repo = tagDigestsMatch[1];
@@ -130,6 +122,15 @@ function registerS3Resolver() {
 					Prefix: `${prefix}${i.digest.replace(/^sha256:/, '')}/`,
 				}));
 			return { IsTruncated: false, CommonPrefixes: commonPrefixes };
+		}
+		// Non-delimited listing of a repo's `_manifests` directory, used when
+		// deleting the directory. Returns every object key under the prefix.
+		if (params.Delimiter == null && manifestsPrefixRegex.test(prefix)) {
+			const contents = [...store.objects]
+				.filter((key) => key.startsWith(prefix))
+				.sort()
+				.map((Key) => ({ Key }));
+			return { IsTruncated: false, Contents: contents };
 		}
 		if (prefix.startsWith(reposPath) && prefix !== reposPath) {
 			const repoPrefix = prefix.replace(reposPath, '');
@@ -147,15 +148,49 @@ function registerS3Resolver() {
 	});
 }
 
-let disposeS3Resolver: (() => void) | undefined;
+function registerDeleteObjectsResolver() {
+	return addDeleteObjectsResolver((params) => {
+		const objects = params.Delete.Objects;
+		if (nextDeleteObjectsError != null) {
+			const message = nextDeleteObjectsError;
+			nextDeleteObjectsError = null;
+			return {
+				Errors: objects.map(({ Key }) => ({
+					Key,
+					Code: 'InternalError',
+					Message: message,
+				})),
+			};
+		}
+		for (const { Key } of objects) {
+			if (Key != null) {
+				store.objects.delete(Key);
+			}
+		}
+		// Reflect the removed objects onto image deletion state: an image is
+		// considered deleted once its manifest revision link is gone.
+		for (const image of store.images) {
+			if (!store.objects.has(revisionLinkKey(image))) {
+				image.isDeleted = true;
+			}
+		}
+		return { Deleted: objects.map(({ Key }) => ({ Key })) };
+	});
+}
 
+let disposeS3Resolver: (() => void) | undefined;
+let disposeDeleteObjectsResolver: (() => void) | undefined;
+
+// eslint-disable-next-line @typescript-eslint/require-await -- kept async to match the mock lifecycle contract used by init-tests.
 export async function start() {
-	await mockDeleteManifest();
 	disposeS3Resolver = registerS3Resolver();
+	disposeDeleteObjectsResolver = registerDeleteObjectsResolver();
 }
 
 export function stop() {
 	reset();
 	disposeS3Resolver?.();
 	disposeS3Resolver = undefined;
+	disposeDeleteObjectsResolver?.();
+	disposeDeleteObjectsResolver = undefined;
 }


### PR DESCRIPTION
Instead of using Docker Distribution's delete endpoint, we need to delete the entire _manifests directory via the s3 client. This is because the delete endpoint could leave some things behind that can cause deleted images to still be listed in the registry's catalog.

Change-type: patch

---

See: https://balena.fibery.io/Work/Project/Mark-existing-registry-trash-data-for-deletion-via-a-migration-2245

ToDo: Should probably avoid removing exported functions for now.