### PR TITLE
Update balena/open-balena-base Docker tag to v21.0.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM balena/open-balena-base:21.0.19-s6-overlay@sha256:4e12dfce462ebd88507c1813cfe3466f0843026d2456bb5599b9a2732348b242 AS runtime
+FROM balena/open-balena-base:21.0.29-s6-overlay@sha256:9409c150d1ef4f2fa521a76468ca8ba76570a06d6baabe7173617893a66f26e4 AS runtime
 
 EXPOSE 80
 

--- a/test/20_supervisor_notification.ts
+++ b/test/20_supervisor_notification.ts
@@ -158,23 +158,28 @@ export default () => {
 				});
 
 				// Just to confirm that such an external request still fails with a 431 Request Header Fields Too Large error
+				// Should either return a 431 or throw an ECONNRESET if the socket is destroyed first.
 				it('should fail when an external request uses a $in with more parameters than the number of binds that PG supports', async function () {
-					await pineUser
-						.delete({
-							resource: 'device_environment_variable',
-							options: {
-								$filter: {
-									device: device.id,
-									name: {
-										$in: Array.from(
-											{ length: testVarSetCount },
-											(_, i) => `testDeviceVar_intenalApiDelete_${i + 1}`,
-										),
+					try {
+						await pineUser
+							.delete({
+								resource: 'device_environment_variable',
+								options: {
+									$filter: {
+										device: device.id,
+										name: {
+											$in: Array.from(
+												{ length: testVarSetCount },
+												(_, i) => `testDeviceVar_intenalApiDelete_${i + 1}`,
+											),
+										},
 									},
 								},
-							},
-						})
-						.expect(431);
+							})
+							.expect(431);
+					} catch (err) {
+						expect((err as { code?: string }).code).to.equal('ECONNRESET');
+					}
 				});
 
 				// Confirm that internal requests are not affected by the PG limitation of using 16 bits to address binds,


### PR DESCRIPTION
Change-type: patch

---

A replacement for https://github.com/balena-io/open-balena-api/pull/2339 to get the consistently failing test to pass