### PR TITLE
Switch the v6 conversion of string contracts to JSON into the validator

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -7,10 +7,13 @@ import config from './config.js';
 import packageJson from './package.json' with { type: 'json' };
 import { promises as fs } from 'fs';
 import { TRUST_PROXY, PORT } from './src/lib/config.js';
+import * as v6 from './src/translations/v6/v6.js';
 
 const getUrl = (req: express.Request) => req.url;
 
 async function onInitModel() {
+	v6.extendValidators();
+
 	const { updateOrInsertModel } =
 		await import('./src/infra/pinejs-client-helpers/index.js');
 	const appTypes =

--- a/src/abstract-sql-utils.ts
+++ b/src/abstract-sql-utils.ts
@@ -20,6 +20,7 @@ import type {
 
 import { sbvrUtils } from '@balena/pinejs';
 import * as AbstractSqlCompiler from '@balena/abstract-sql-compiler';
+import type { validation } from './index.js';
 
 export const { optimizeSchema } = AbstractSqlCompiler.postgres;
 
@@ -271,4 +272,26 @@ export const aliasFields = (
 			return ['ReferencedField', resourceName, fieldName];
 		},
 	);
+};
+
+/**
+ * This follows the behavior of zod.extend where the validator for the given properties will be replaced if it already exists.
+ */
+export const extendValidator = (
+	vocabulary: string,
+	resourceName: string,
+	extension: Record<string, validation.z.ZodType>,
+) => {
+	const request = {
+		vocabulary,
+		resourceName,
+	};
+	const abstractSqlModel = sbvrUtils.getAbstractSqlModel(request);
+	const synonym = sbvrUtils.resolveSynonym(request);
+
+	const { validator } = abstractSqlModel.tables[synonym];
+	for (const key of Object.keys(extension)) {
+		// We have to mutate the validator because tables are frozen and so trying to replace it (via `.extend`) will throw
+		validator!.shape[key] = extension[key];
+	}
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ import { getApplicationSlug } from './features/applications/index.js';
 import * as deviceAdditions from './features/devices/models/device-additions.js';
 import { addToModel as addReleaseAdditionsToModel } from './features/ci-cd/models/release-additions.js';
 import { model as balenaModel } from './balena.js';
-import { getV6Translations } from './translations/v6/v6.js';
+import * as v6 from './translations/v6/v6.js';
 import { getV7Translations } from './translations/v7/v7.js';
 
 export * as tags from './features/tags/validation.js';
@@ -282,7 +282,8 @@ export const translations = {
 		loadHooks: () => import('./translations/v7/hooks.js'),
 	},
 	v6: {
-		getTranslations: getV6Translations,
+		getTranslations: v6.getV6Translations,
+		extendValidators: v6.extendValidators,
 		loadHooks: () => import('./translations/v6/hooks.js'),
 	},
 };

--- a/src/translations/v6/hooks.ts
+++ b/src/translations/v6/hooks.ts
@@ -105,24 +105,6 @@ addReadOnlyHook(['PUT', 'POST', 'PATCH'], 'release', {
 	},
 });
 
-addReadOnlyHook(['PUT', 'POST', 'PATCH'], 'release', {
-	POSTPARSE({ request }) {
-		if (!Object.hasOwn(request.values, 'contract')) {
-			return;
-		}
-		try {
-			request.values.contract =
-				typeof request.values.contract === 'object'
-					? request.values.contract
-					: JSON.parse(request.values.contract);
-		} catch {
-			throw new errors.BadRequestError(
-				'Failed to parse provided release.contract value',
-			);
-		}
-	},
-});
-
 addReadOnlyHook(['all'], 'all', {
 	PRERESPOND({ response }) {
 		// Use the default body message for the status code when the body is empty

--- a/src/translations/v6/v6.ts
+++ b/src/translations/v6/v6.ts
@@ -4,12 +4,15 @@ import type { ConfigLoader } from '@balena/pinejs';
 import {
 	aliasFields,
 	aliasTable,
+	extendValidator,
 	generateAbstractSqlModel,
 	overrideFieldType,
 	renameResourceField,
 } from '../../abstract-sql-utils.js';
 import * as userHasDirectAccessToApplication from '../../features/applications/models/user__has_direct_access_to__application.js';
 import * as DeviceAdditions from '../../features/devices/models/device-additions.js';
+import { sbvrUtils } from '@balena/pinejs';
+import { z } from '../../infra/validation/index.js';
 
 export const toVersion = 'v7';
 
@@ -238,4 +241,22 @@ export const getV6Translations = (abstractSqlModel = v6AbstractSqlModel) => {
 			],
 		},
 	} satisfies ConfigLoader.Model['translations'];
+};
+
+export const extendValidators = () => {
+	extendValidator('v6', 'release', {
+		// In v6 we also accept contract as a string that we automatically parse, this used to be via a hook but we can now do it directly in the validator
+		contract: z
+			.preprocess((value) => {
+				if (typeof value === 'string') {
+					try {
+						return JSON.parse(value);
+					} catch {
+						// ignore
+					}
+				}
+				return value;
+			}, sbvrUtils.sbvrTypes.JSON.schema)
+			.optional(),
+	});
 };


### PR DESCRIPTION
This is also necessary as otherwise the pinejs validation will reject the invalid type before ever getting to the hook that does the conversion

https://balena.fibery.io/Work/Project/1002

Change-type: patch