### PR TITLE
Add fleet-wide application profiles activations model

### DIFF
--- a/src/balena-model.ts
+++ b/src/balena-model.ts
@@ -538,9 +538,16 @@ export interface Application {
 		service?: Array<Service['Read']>;
 		application__has__tag_key?: Array<ApplicationTag['Read']>;
 		application_tag?: Array<ApplicationTag['Read']>;
+		application__activates__profile_name__on__application?: Array<
+			ApplicationProfile['Read']
+		>;
+		application_profile?: Array<ApplicationProfile['Read']>;
 		updates__application?: Array<Application['Read']>;
 		owns__device?: Array<Device['Read']>;
 		owns__release?: Array<Release['Read']>;
+		activates__profile_name__on__application?: Array<
+			ApplicationProfile['Read']
+		>;
 		is_directly_accessible_by__user?: Array<
 			UserHasDirectAccessToApplication['Read']
 		>;
@@ -1335,6 +1342,26 @@ export interface ReleaseAsset {
 	};
 }
 
+export interface ApplicationProfile {
+	Read: {
+		created_at: Types['Date Time']['Read'];
+		modified_at: Types['Date Time']['Read'];
+		application: { __id: Application['Read']['id'] } | [Application['Read']];
+		activates__profile_name: Types['Short Text']['Read'];
+		on__application:
+			{ __id: Application['Read']['id'] } | [Application['Read']];
+		id: Types['Serial']['Read'];
+	};
+	Write: {
+		created_at: Types['Date Time']['Write'];
+		modified_at: Types['Date Time']['Write'];
+		application: Application['Write']['id'];
+		activates__profile_name: Types['Short Text']['Write'];
+		on__application: Application['Write']['id'];
+		id: Types['Serial']['Write'];
+	};
+}
+
 export interface UserHasDirectAccessToApplication {
 	Read: {
 		id: Types['Big Integer']['Read'];
@@ -1393,6 +1420,7 @@ export default interface $Model {
 	user__has__public_key: UserHasPublicKey;
 	device_type__is_referenced_by__alias: DeviceTypeAlias;
 	release__has__asset_key: ReleaseAsset;
+	application__activates__profile_name__on__application: ApplicationProfile;
 	user__has_direct_access_to__application: UserHasDirectAccessToApplication;
 	// Synonyms
 	user_role: UserHasRole;
@@ -1418,4 +1446,5 @@ export default interface $Model {
 	user_public_key: UserHasPublicKey;
 	device_type_alias: DeviceTypeAlias;
 	release_asset: ReleaseAsset;
+	application_profile: ApplicationProfile;
 }

--- a/src/balena.sbvr
+++ b/src/balena.sbvr
@@ -998,6 +998,12 @@ Fact Type: scheduled job run has status
 	Definition: "running" or "success" or "error"
 	Necessity: each scheduled job run that has a status that is equal to "success", has an end timestamp.
 
+Fact type: application1 activates profile name on application2
+	Term Form: application profile
+	Database Table Name: application profile
+	Necessity: each application profile has a profile name that has a Length (Type) that is greater than 1 and is less than or equal to 100.
+	Necessity: each application profile has an application2 that is host and is of a class that is not equal to "block".
+
 
 -- Rules
 
@@ -1016,3 +1022,4 @@ Rule: It is necessary that each release that should manage a device, has a statu
 Rule: It is necessary that each release that should manage a device that is of a device type1, belongs to an application that is public and is not host and has a slug that is equal to "balena_os/aarch64-supervisor" or "balena_os/amd64-supervisor" or "balena_os/armv7hf-supervisor" or "balena_os/i386-supervisor" or "balena_os/i386-nlp-supervisor" or "balena_os/rpi-supervisor" and is for a device type2 that is of a cpu architecture that is supported by the device type1.
 Rule: It is necessary that each application that is not host, is updated by no application.
 Rule: It is necessary that each application that is of a class that is not equal to "block", updates no application.
+Rule: It is necessary that each application1 that activates a profile name on an application2, is of a class that is equal to "fleet".

--- a/src/features/cascade-delete/hooks.ts
+++ b/src/features/cascade-delete/hooks.ts
@@ -11,6 +11,7 @@ setupDeleteCascade('application', {
 	application_config_variable: 'application',
 	application_environment_variable: 'application',
 	application_tag: 'application',
+	application_profile: ['application', 'on__application'],
 	release: 'belongs_to__application',
 	service: 'application',
 });

--- a/src/features/profiles/hooks.ts
+++ b/src/features/profiles/hooks.ts
@@ -1,18 +1,37 @@
 import { hooks } from '@balena/pinejs';
 import { withValidatedValues, z } from '../../infra/validation/index.js';
+import type Model from '../../balena-model.js';
 
 // Matches docker-compose profile name semantics, see
 // https://docs.docker.com/compose/how-tos/profiles/
 const PROFILE_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9_.-]+$/;
 
-const profileNameSchema = z.looseObject({
-	profile_name: z.string().regex(PROFILE_NAME_REGEX),
+const profileName = z.string().regex(PROFILE_NAME_REGEX);
+
+const imageProfileSchema = z.looseObject({
+	profile_name: profileName,
 });
 
-const imageProfileHook: hooks.Hooks = {
-	POSTPARSE: withValidatedValues(profileNameSchema),
+const applicationProfileSchema = z.looseObject({
+	activates__profile_name: profileName,
+});
+
+type ProfileResource = Extract<
+	keyof Model,
+	'image_profile' | 'application_profile'
+>;
+
+const registerProfileValidation = (
+	resource: ProfileResource,
+	schema: z.ZodType<AnyObject>,
+) => {
+	const hook: hooks.Hooks = {
+		POSTPARSE: withValidatedValues(schema),
+	};
+	hooks.addPureHook('POST', 'resin', resource, hook);
+	hooks.addPureHook('PUT', 'resin', resource, hook);
+	hooks.addPureHook('PATCH', 'resin', resource, hook);
 };
 
-hooks.addPureHook('POST', 'resin', 'image_profile', imageProfileHook);
-hooks.addPureHook('PUT', 'resin', 'image_profile', imageProfileHook);
-hooks.addPureHook('PATCH', 'resin', 'image_profile', imageProfileHook);
+registerProfileValidation('image_profile', imageProfileSchema);
+registerProfileValidation('application_profile', applicationProfileSchema);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -63,6 +63,7 @@ export const ROLES: {
 		'resin.image_install.all',
 		'resin.image_label.all',
 		'resin.image_profile.all',
+		'resin.application_profile.all',
 		'resin.organization.read',
 		'resin.organization_membership.read',
 		'resin.release.all',
@@ -146,6 +147,8 @@ export const DEVICE_API_KEY_PERMISSIONS = [
 
 	'resin.image_label.read?release_image/canAccess()',
 	'resin.image_profile.read?release_image/canAccess()',
+
+	'resin.application_profile.read?application/canAccess()',
 
 	'resin.service_label.read?service/canAccess()',
 

--- a/src/migrations/00114-add-application-profile.sql
+++ b/src/migrations/00114-add-application-profile.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS "application profile" (
+	"created at" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"modified at" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
+,	"application" INTEGER NOT NULL
+,	"activates-profile name" VARCHAR(255) NOT NULL
+,	"on-application" INTEGER NOT NULL
+,	"id" SERIAL NOT NULL PRIMARY KEY
+,	FOREIGN KEY ("application") REFERENCES "application" ("id")
+,	FOREIGN KEY ("on-application") REFERENCES "application" ("id")
+,	UNIQUE("application", "activates-profile name", "on-application")
+,	-- It is necessary that each application profile has a profile name that has a Length (Type) that is greater than 1 and is less than or equal to 100.
+CONSTRAINT "application profile$k/Bekz9Smd13LHmP3Y6oPtMhUi8unEjtt/fuIVmA7M4" CHECK (1 < LENGTH("activates-profile name")
+AND LENGTH("activates-profile name") <= 100
+AND LENGTH("activates-profile name") IS NOT NULL
+AND "activates-profile name" IS NOT NULL)
+);
+
+DO
+$$
+BEGIN
+	IF NOT EXISTS(
+		SELECT 1
+		FROM "information_schema"."triggers"
+		WHERE "event_object_table" = 'application profile'
+		AND "trigger_name" = 'application profile_trigger_update_modified_at'
+	) THEN
+		CREATE TRIGGER "application profile_trigger_update_modified_at"
+		BEFORE UPDATE ON "application profile"
+		FOR EACH ROW
+		EXECUTE PROCEDURE "trigger_update_modified_at"();
+	END IF;
+END;
+$$;

--- a/test/27_profiles.ts
+++ b/test/27_profiles.ts
@@ -9,13 +9,15 @@ export default () => {
 		if (versions.lt(version, 'resin')) {
 			return;
 		}
-		describe('image profile', function () {
+		describe('profiles', function () {
 			before(async function () {
 				const fx = await fixtures.load('27-profiles');
 
 				this.loadedFixtures = fx;
 				this.user = fx.users.admin;
 				this.app1 = fx.applications.app1;
+				this.hostApp = fx.applications.hostApp;
+				this.blockApp = fx.applications.blockApp;
 				this.release1 = fx.releases.release1;
 				this.releaseImage1 =
 					fx.images.release1_image1.image__is_part_of__release;
@@ -29,221 +31,350 @@ export default () => {
 				await fixtures.clean(this.loadedFixtures);
 			});
 
-			describe('create image profile', function () {
-				it('should succeed with mandatory properties', async function () {
+			describe('image profile', function () {
+				describe('create image profile', function () {
+					it('should succeed with mandatory properties', async function () {
+						const res = await supertest(this.user)
+							.post(`/${version}/image_profile`)
+							.send({
+								release_image: this.releaseImage1.id,
+								profile_name: 'kernel-modules',
+							})
+							.expect(201);
+
+						expect(res.body).to.have.property('id').that.is.a('number');
+						expect(res.body)
+							.to.have.nested.property('release_image.__id')
+							.that.equals(this.releaseImage1.id);
+						expect(res.body.profile_name).to.equal('kernel-modules');
+					});
+
+					it('should fail when using a duplicated profile name for the same release image', async function () {
+						await supertest(this.user)
+							.post(`/${version}/image_profile`)
+							.send({
+								release_image: this.releaseImage1.id,
+								profile_name: 'kernel-modules',
+							})
+							.expect(409);
+					});
+
+					it('should allow the same profile name on a different release image', async function () {
+						const res = await supertest(this.user)
+							.post(`/${version}/image_profile`)
+							.send({
+								release_image: this.releaseImage2.id,
+								profile_name: 'kernel-modules',
+							})
+							.expect(201);
+
+						expect(res.body)
+							.to.have.nested.property('release_image.__id')
+							.that.equals(this.releaseImage2.id);
+					});
+
+					it('should support profile names with letters, numbers, underscores, periods and hyphens', async function () {
+						const res = await supertest(this.user)
+							.post(`/${version}/image_profile`)
+							.send({
+								release_image: this.releaseImage1.id,
+								profile_name: '0Debug_profile.v2-test',
+							})
+							.expect(201);
+
+						expect(res.body.profile_name).to.equal('0Debug_profile.v2-test');
+					});
+				});
+
+				describe('image profile name validation', function () {
+					const expectRejectedProfileName = async (
+						user: UserObjectParam,
+						releaseImageId: number,
+						profileName: string,
+					) => {
+						await supertest(user)
+							.post(`/${version}/image_profile`)
+							.send({
+								release_image: releaseImageId,
+								profile_name: profileName,
+							})
+							.expect(400);
+					};
+
+					it('should reject an empty profile name', async function () {
+						await supertest(this.user)
+							.post(`/${version}/image_profile`)
+							.send({
+								release_image: this.releaseImage1.id,
+								profile_name: '',
+							})
+							.expect(400);
+					});
+
+					for (const invalidProfileName of [
+						'a',
+						'-leading-dash',
+						'.leading-period',
+						'_leading-underscore',
+						'has space',
+						'has/slash',
+						'has$symbol',
+					]) {
+						it(`should reject the invalid profile name '${invalidProfileName}'`, async function () {
+							await expectRejectedProfileName(
+								this.user,
+								this.releaseImage1.id,
+								invalidProfileName,
+							);
+						});
+					}
+
+					it('should reject profile names longer than 100 characters', async function () {
+						await supertest(this.user)
+							.post(`/${version}/image_profile`)
+							.send({
+								release_image: this.releaseImage1.id,
+								profile_name: 'a'.repeat(101),
+							})
+							.expect(400);
+					});
+
+					it('should reject updating a profile name to an invalid one', async function () {
+						await supertest(this.user)
+							.patch(`/${version}/image_profile(${this.metricsProfile.id})`)
+							.send({
+								profile_name: 'not valid',
+							})
+							.expect(400);
+					});
+				});
+
+				describe('retrieve image profile', function () {
+					it('should succeed when retrieving the image profiles of a release image', async function () {
+						const res = await supertest(this.user)
+							.get(
+								`/${version}/image_profile?$select=id,profile_name&$filter=release_image eq ${this.releaseImage2.id}&$orderby=profile_name asc`,
+							)
+							.expect(200);
+
+						expect(res.body).to.have.property('d').that.is.an('array');
+						expect(
+							res.body.d.map(
+								(imageProfile: { profile_name: string }) =>
+									imageProfile.profile_name,
+							),
+						).to.deep.equal(['kernel-modules', 'metrics']);
+					});
+
+					it('should succeed when expanding the image profiles from a release', async function () {
+						const res = await supertest(this.user)
+							.get(
+								`/${version}/release(${this.release1.id})?$select=id&$expand=release_image($select=id;$expand=image_profile($select=id,profile_name))`,
+							)
+							.expect(200);
+
+						expect(res.body).to.have.nested.property('d.length', 1);
+						const profileNames = res.body.d[0].release_image
+							.flatMap((releaseImage: { image_profile: unknown[] }) =>
+								releaseImage.image_profile.map(
+									(imageProfile: any) => imageProfile.profile_name,
+								),
+							)
+							.sort();
+						expect(profileNames).to.deep.equal([
+							'0Debug_profile.v2-test',
+							'kernel-modules',
+							'kernel-modules',
+							'metrics',
+						]);
+					});
+				});
+
+				describe('image profile access', function () {
+					it('should allow guest users to read image profiles associated with public hostapps', async function () {
+						const res = await supertest()
+							.get(
+								`/${version}/image_profile(${this.hostAppProfile.id})?$select=id,profile_name`,
+							)
+							.expect(200);
+
+						expect(res.body).to.have.nested.property('d.length', 1);
+						expect(res.body)
+							.to.have.nested.property('d[0].profile_name')
+							.that.equals('bluetooth');
+					});
+
+					it('should not allow guest users to read image profiles from non-public applications', async function () {
+						const res = await supertest()
+							.get(
+								`/${version}/image_profile(${this.metricsProfile.id})?$select=id`,
+							)
+							.expect(200);
+
+						expect(res.body).to.have.nested.property('d.length', 0);
+					});
+
+					it('should not allow guest users to create image profiles', async function () {
+						await supertest()
+							.post(`/${version}/image_profile`)
+							.send({
+								release_image: this.releaseImage1.id,
+								profile_name: 'guest-profile',
+							})
+							.expect(401);
+					});
+				});
+
+				describe('delete image profile', function () {
+					it('should succeed when deleting an image profile', async function () {
+						const { body: imageProfile } = await supertest(this.user)
+							.post(`/${version}/image_profile`)
+							.send({
+								release_image: this.releaseImage1.id,
+								profile_name: 'to-be-deleted',
+							})
+							.expect(201);
+
+						await supertest(this.user)
+							.delete(`/${version}/image_profile(${imageProfile.id})`)
+							.expect(200);
+
+						const res = await supertest(this.user)
+							.get(`/${version}/image_profile(${imageProfile.id})?$select=id`)
+							.expect(200);
+						expect(res.body).to.have.nested.property('d.length', 0);
+					});
+
+					it('should cascade delete image profiles when their release is deleted', async function () {
+						// Unpin the fleet from the release so that it can be deleted
+						await supertest(this.user)
+							.patch(`/${version}/application(${this.app1.id})`)
+							.send({
+								should_track_latest_release: false,
+								should_be_running__release: null,
+							})
+							.expect(200);
+
+						await supertest(this.user)
+							.delete(`/${version}/release(${this.release1.id})`)
+							.expect(200);
+
+						const res = await supertest(this.user)
+							.get(
+								`/${version}/image_profile?$select=id&$filter=release_image in (${this.releaseImage1.id},${this.releaseImage2.id})`,
+							)
+							.expect(200);
+
+						expect(res.body).to.have.nested.property('d.length', 0);
+					});
+				});
+			});
+
+			describe('application profile', function () {
+				it('should activate a profile of a hostApp for a fleet', async function () {
 					const res = await supertest(this.user)
-						.post(`/${version}/image_profile`)
+						.post(`/${version}/application_profile`)
 						.send({
-							release_image: this.releaseImage1.id,
-							profile_name: 'kernel-modules',
+							application: this.app1.id,
+							activates__profile_name: 'kernel-modules',
+							on__application: this.hostApp.id,
 						})
 						.expect(201);
 
-					expect(res.body).to.have.property('id').that.is.a('number');
 					expect(res.body)
-						.to.have.nested.property('release_image.__id')
-						.that.equals(this.releaseImage1.id);
-					expect(res.body.profile_name).to.equal('kernel-modules');
+						.to.have.nested.property('application.__id')
+						.that.equals(this.app1.id);
+					expect(res.body)
+						.to.have.nested.property('on__application.__id')
+						.that.equals(this.hostApp.id);
+					expect(res.body.activates__profile_name).to.equal('kernel-modules');
 				});
 
-				it('should fail when using a duplicated profile name for the same release image', async function () {
+				it('should reject a duplicated activation for the same fleet/profile/hostApp', async function () {
 					await supertest(this.user)
-						.post(`/${version}/image_profile`)
+						.post(`/${version}/application_profile`)
 						.send({
-							release_image: this.releaseImage1.id,
-							profile_name: 'kernel-modules',
+							application: this.app1.id,
+							activates__profile_name: 'kernel-modules',
+							on__application: this.hostApp.id,
 						})
 						.expect(409);
 				});
 
-				it('should allow the same profile name on a different release image', async function () {
-					const res = await supertest(this.user)
-						.post(`/${version}/image_profile`)
-						.send({
-							release_image: this.releaseImage2.id,
-							profile_name: 'kernel-modules',
-						})
-						.expect(201);
-
-					expect(res.body)
-						.to.have.nested.property('release_image.__id')
-						.that.equals(this.releaseImage2.id);
-				});
-
-				it('should support profile names with letters, numbers, underscores, periods and hyphens', async function () {
-					const res = await supertest(this.user)
-						.post(`/${version}/image_profile`)
-						.send({
-							release_image: this.releaseImage1.id,
-							profile_name: '0Debug_profile.v2-test',
-						})
-						.expect(201);
-
-					expect(res.body.profile_name).to.equal('0Debug_profile.v2-test');
-				});
-			});
-
-			describe('image profile name validation', function () {
-				const expectRejectedProfileName = async (
-					user: UserObjectParam,
-					releaseImageId: number,
-					profileName: string,
-				) => {
-					await supertest(user)
-						.post(`/${version}/image_profile`)
-						.send({
-							release_image: releaseImageId,
-							profile_name: profileName,
-						})
-						.expect(400);
-				};
-
-				it('should reject an empty profile name', async function () {
+				it('should reject an activator that is not a fleet', async function () {
 					await supertest(this.user)
-						.post(`/${version}/image_profile`)
+						.post(`/${version}/application_profile`)
 						.send({
-							release_image: this.releaseImage1.id,
-							profile_name: '',
+							application: this.blockApp.id,
+							activates__profile_name: 'kernel-modules',
+							on__application: this.hostApp.id,
 						})
 						.expect(400);
 				});
 
-				for (const invalidProfileName of [
-					'a',
-					'-leading-dash',
-					'.leading-period',
-					'_leading-underscore',
-					'has space',
-					'has/slash',
-					'has$symbol',
-				]) {
-					it(`should reject the invalid profile name '${invalidProfileName}'`, async function () {
-						await expectRejectedProfileName(
-							this.user,
-							this.releaseImage1.id,
-							invalidProfileName,
-						);
-					});
-				}
-
-				it('should reject profile names longer than 100 characters', async function () {
+				it('should reject a target application that is not a hostApp', async function () {
 					await supertest(this.user)
-						.post(`/${version}/image_profile`)
+						.post(`/${version}/application_profile`)
 						.send({
-							release_image: this.releaseImage1.id,
-							profile_name: 'a'.repeat(101),
+							application: this.app1.id,
+							activates__profile_name: 'kernel-modules',
+							on__application: this.app1.id,
 						})
 						.expect(400);
 				});
 
-				it('should reject updating a profile name to an invalid one', async function () {
+				it('should reject a target application that is a block', async function () {
 					await supertest(this.user)
-						.patch(`/${version}/image_profile(${this.metricsProfile.id})`)
+						.post(`/${version}/application_profile`)
 						.send({
-							profile_name: 'not valid',
+							application: this.app1.id,
+							activates__profile_name: 'kernel-modules',
+							on__application: this.blockApp.id,
 						})
 						.expect(400);
 				});
-			});
 
-			describe('retrieve image profile', function () {
-				it('should succeed when retrieving the image profiles of a release image', async function () {
+				it('should reject an invalid profile name', async function () {
+					await supertest(this.user)
+						.post(`/${version}/application_profile`)
+						.send({
+							application: this.app1.id,
+							activates__profile_name: 'has space',
+							on__application: this.hostApp.id,
+						})
+						.expect(400);
+				});
+
+				it('should retrieve the activations targeting a hostApp', async function () {
 					const res = await supertest(this.user)
 						.get(
-							`/${version}/image_profile?$select=id,profile_name&$filter=release_image eq ${this.releaseImage2.id}&$orderby=profile_name asc`,
+							`/${version}/application_profile?$select=activates__profile_name&$filter=on__application eq ${this.hostApp.id}&$orderby=activates__profile_name asc`,
 						)
 						.expect(200);
 
-					expect(res.body).to.have.property('d').that.is.an('array');
 					expect(
 						res.body.d.map(
-							(imageProfile: { profile_name: string }) =>
-								imageProfile.profile_name,
+							(activation: { activates__profile_name: string }) =>
+								activation.activates__profile_name,
 						),
 					).to.deep.equal(['kernel-modules', 'metrics']);
 				});
 
-				it('should succeed when expanding the image profiles from a release', async function () {
-					const res = await supertest(this.user)
-						.get(
-							`/${version}/release(${this.release1.id})?$select=id&$expand=release_image($select=id;$expand=image_profile($select=id,profile_name))`,
-						)
-						.expect(200);
-
-					expect(res.body).to.have.nested.property('d.length', 1);
-					const profileNames = res.body.d[0].release_image
-						.flatMap((releaseImage: { image_profile: unknown[] }) =>
-							releaseImage.image_profile.map(
-								(imageProfile: any) => imageProfile.profile_name,
-							),
-						)
-						.sort();
-					expect(profileNames).to.deep.equal([
-						'0Debug_profile.v2-test',
-						'kernel-modules',
-						'kernel-modules',
-						'metrics',
-					]);
-				});
-			});
-
-			describe('image profile access', function () {
-				it('should allow guest users to read image profiles associated with public hostapps', async function () {
-					const res = await supertest()
-						.get(
-							`/${version}/image_profile(${this.hostAppProfile.id})?$select=id,profile_name`,
-						)
-						.expect(200);
-
-					expect(res.body).to.have.nested.property('d.length', 1);
-					expect(res.body)
-						.to.have.nested.property('d[0].profile_name')
-						.that.equals('bluetooth');
-				});
-
-				it('should not allow guest users to read image profiles from non-public applications', async function () {
-					const res = await supertest()
-						.get(
-							`/${version}/image_profile(${this.metricsProfile.id})?$select=id`,
-						)
-						.expect(200);
-
-					expect(res.body).to.have.nested.property('d.length', 0);
-				});
-
-				it('should not allow guest users to create image profiles', async function () {
+				it('should not allow guest users to create activations', async function () {
 					await supertest()
-						.post(`/${version}/image_profile`)
+						.post(`/${version}/application_profile`)
 						.send({
-							release_image: this.releaseImage1.id,
-							profile_name: 'guest-profile',
+							application: this.app1.id,
+							activates__profile_name: 'guest-profile',
+							on__application: this.hostApp.id,
 						})
 						.expect(401);
 				});
 			});
 
-			describe('delete image profile', function () {
-				it('should succeed when deleting an image profile', async function () {
-					const { body: imageProfile } = await supertest(this.user)
-						.post(`/${version}/image_profile`)
-						.send({
-							release_image: this.releaseImage1.id,
-							profile_name: 'to-be-deleted',
-						})
-						.expect(201);
-
-					await supertest(this.user)
-						.delete(`/${version}/image_profile(${imageProfile.id})`)
-						.expect(200);
-
-					const res = await supertest(this.user)
-						.get(`/${version}/image_profile(${imageProfile.id})?$select=id`)
-						.expect(200);
-					expect(res.body).to.have.nested.property('d.length', 0);
-				});
-
-				it('should cascade delete image profiles when their release is deleted', async function () {
-					// Unpin the fleet from the release so that it can be deleted
+			describe('cascade delete of runtime profiles', function () {
+				it('should cascade delete application profiles when the application is deleted', async function () {
+					// Unpin so the fleet (and its releases) can be deleted.
 					await supertest(this.user)
 						.patch(`/${version}/application(${this.app1.id})`)
 						.send({
@@ -253,16 +384,18 @@ export default () => {
 						.expect(200);
 
 					await supertest(this.user)
-						.delete(`/${version}/release(${this.release1.id})`)
+						.delete(`/${version}/application(${this.app1.id})`)
 						.expect(200);
 
-					const res = await supertest(this.user)
+					const applicationProfiles = await supertest(this.user)
 						.get(
-							`/${version}/image_profile?$select=id&$filter=release_image in (${this.releaseImage1.id},${this.releaseImage2.id})`,
+							`/${version}/application_profile?$select=id&$filter=application eq ${this.app1.id} or on__application eq ${this.app1.id}`,
 						)
 						.expect(200);
-
-					expect(res.body).to.have.nested.property('d.length', 0);
+					expect(applicationProfiles.body).to.have.nested.property(
+						'd.length',
+						0,
+					);
 				});
 			});
 		});

--- a/test/fixtures/27-profiles/application_profiles.json
+++ b/test/fixtures/27-profiles/application_profiles.json
@@ -1,0 +1,8 @@
+{
+	"app1_metrics_activation": {
+		"user": "admin",
+		"application": "app1",
+		"activates__profile_name": "metrics",
+		"on__application": "hostApp"
+	}
+}

--- a/test/fixtures/27-profiles/applications.json
+++ b/test/fixtures/27-profiles/applications.json
@@ -10,5 +10,11 @@
 		"device_type": "raspberry-pi",
 		"is_host": true,
 		"is_public": true
+	},
+	"blockApp": {
+		"user": "admin",
+		"app_name": "test_profile_block",
+		"device_type": "raspberry-pi",
+		"is_of__class": "block"
 	}
 }

--- a/test/test-lib/fixtures.ts
+++ b/test/test-lib/fixtures.ts
@@ -462,6 +462,34 @@ const loaders: Record<string, LoaderFunc> = {
 			...{ release_image: image.image__is_part_of__release },
 		};
 	},
+	application_profiles: async (jsonData, fixtures) => {
+		const user = await fixtures.users[jsonData.user];
+		if (user == null) {
+			logErrorAndThrow(`Could not find user: ${jsonData.user}`);
+		}
+
+		const application = await fixtures.applications[jsonData.application];
+		if (application == null) {
+			logErrorAndThrow(`Could not find application: ${jsonData.application}`);
+		}
+
+		const onApplication = await fixtures.applications[jsonData.on__application];
+		if (onApplication == null) {
+			logErrorAndThrow(
+				`Could not find on__application: ${jsonData.on__application}`,
+			);
+		}
+
+		return await createResource({
+			resource: 'application_profile',
+			body: {
+				..._.pick(jsonData, 'activates__profile_name'),
+				application: application.id,
+				on__application: onApplication.id,
+			},
+			user,
+		});
+	},
 	services: async (jsonData, fixtures) => {
 		const user = await fixtures.users[jsonData.user];
 		if (user == null) {


### PR DESCRIPTION
See: https://balena.fibery.io/Work/Project/Supporting-docker-compose-profiles-on-balenaCloud-2480
Change-type: minor