### PR TITLE
[DRAFT, CLAUDE] Adding dependency track as unit test module

### DIFF
--- a/automation/fasttest.sh
+++ b/automation/fasttest.sh
@@ -58,7 +58,7 @@ if [[ "$preserve_volumes" == "1" ]]; then
 	echo "Preserving volumes from previous run"
 else
 	echo "Recreating volumes"
-	docker compose -f docker-compose.test-custom.yml up --renew-anon-volumes --force-recreate --detach redis db minio-server minio-client loki
+	docker compose -f docker-compose.test-custom.yml up --renew-anon-volumes --force-recreate --detach redis db minio-server minio-client loki dtrack-db-init dtrack
 fi
 if [[ -z "$test_files" ]]; then
 	echo "Running all tests"

--- a/docker-compose.test-custom.yml
+++ b/docker-compose.test-custom.yml
@@ -54,6 +54,55 @@ services:
     networks:
       - local-test
 
+  # Dependency-Track v5 keeps its data in the existing `db` container rather than
+  # in a dedicated one. DT creates its own schema but not the database itself, so
+  # `dependencytrack` has to exist before the apiserver boots. v5 also requires
+  # the pg_trgm extension (Postgres >= 14; open-balena-db 8.0.14 ships PG 18).
+  dtrack-db-init:
+    image: balena/open-balena-db:8.0.14@sha256:60d50900588b3db298961fef2be45d430eb7d9f1f7ace296319ef5af986298a8
+    depends_on:
+      - db
+    environment:
+      PGPASSWORD: docker
+    entrypoint: >
+      /bin/sh -c "
+      until pg_isready -h db -U docker -d postgres; do sleep 1; done;
+      createdb -h db -U docker dependencytrack 2>/dev/null
+      || echo 'database dependencytrack already exists';
+      psql -h db -U docker -d dependencytrack -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm';
+      "
+    networks:
+      - local-test
+
+  dtrack:
+    image: dependencytrack/apiserver:5.0.4
+    depends_on:
+      - db
+      - dtrack-db-init
+    # `depends_on` only orders *starts*, so the apiserver can win the race against
+    # dtrack-db-init and find no database. It exits in that case and the restart
+    # picks it up once the database exists.
+    restart: on-failure
+    environment:
+      # v5 renamed the v4 ALPINE_DATABASE_* properties and no longer accepts them.
+      DT_DATASOURCE_URL: jdbc:postgresql://db:5432/dependencytrack
+      DT_DATASOURCE_USERNAME: docker
+      DT_DATASOURCE_PASSWORD: docker
+      # Tests never need vulnerability data, and mirroring it is what makes DT slow
+      # and memory hungry. Sources are disabled by default (they are enabled from
+      # the UI, i.e. runtime config in the DB), so this only guards against the
+      # recurring jobs firing during a long run. Do NOT reach for
+      # DT_INIT_TASKS_ENABLED here: it also gates schema migration and the seeding
+      # that creates the default admin user, so disabling it breaks DT entirely.
+      DT_TASK_NVD_VULN_DATA_SOURCE_MIRROR_CRON: "0 0 1 1 *"
+      DT_TASK_GITHUB_ADVISORY_VULN_DATA_SOURCE_MIRROR_CRON: "0 0 1 1 *"
+      DT_TASK_OSV_VULN_DATA_SOURCE_MIRROR_CRON: "0 0 1 1 *"
+    mem_limit: 4g
+    ports:
+      - "8081:8080"
+    networks:
+      - local-test
+
   sut: &sut
     build:
       context: ./
@@ -68,10 +117,20 @@ services:
       - "redis"
       - "loki"
       - "minio-client"
+      - "dtrack"
     ports:
       - "9228:9229"
     networks:
-      - local-test
+      local-test:
+        # Dependency-Track delivers webhooks *to* the suite, so it needs a stable
+        # host to post to. Publishing a port would not help — that only exposes a
+        # service to the docker host, whereas container-to-container traffic on
+        # this network already reaches the container port directly. The problem is
+        # naming: `docker compose run` names containers
+        # `<project>-<service>-run-<random>` rather than after the service, so
+        # nothing can address the suite predictably. This alias fixes that.
+        aliases:
+          - sut
     volumes:
       - ./automation/check-model-types-generated.sh:/usr/src/app/automation/check-model-types-generated.sh:ro
     environment: &env
@@ -85,6 +144,8 @@ services:
       DATABASE_URL: postgres://docker:docker@db:5432/postgres
       DEBUG:
       DELTA_HOST: delta_host.com
+      # host:port rather than a full URL, matching how the API consumes it.
+      DEPENDENCY_TRACK_URL: dtrack:8080
       DEPLOYMENT: TEST
       DEVICE_CONFIG_OPENVPN_CA: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNXRENDQWNHZ0F3SUJBZ0lKQVBTeHZhSG5zanVpTUEwR0NTcUdTSWIzRFFFQkJRVUFNRVV4Q3pBSkJnTlYKQkFZVEFrRlZNUk13RVFZRFZRUUlEQXBUYjIxbExWTjBZWFJsTVNFd0h3WURWUVFLREJoSmJuUmxjbTVsZENCWAphV1JuYVhSeklGQjBlU0JNZEdRd0hoY05NVE14TWpFeU1UUTBOelUyV2hjTk1qTXhNakV3TVRRME56VTJXakJGCk1Rc3dDUVlEVlFRR0V3SkJWVEVUTUJFR0ExVUVDQXdLVTI5dFpTMVRkR0YwWlRFaE1COEdBMVVFQ2d3WVNXNTAKWlhKdVpYUWdWMmxrWjJsMGN5QlFkSGtnVEhSa01JR2ZNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0R05BRENCaVFLQgpnUURsTXZRMmp1WnJ6WFJxV3BYN3Q0RlhYTGw0RzhuY05UMXYyTW1UM3BwNnVGNG5rVkd1UjRZdFczYmlwQ0thClRYRnZ5aFp1eEUvN2ZKWUdoYWZNV1pzMjZrUHQ3dnNtaVRSRUVHQytCSHFOUWIwd0ltckxaT0syVzk3R2R1U2UKZThuWmNXU0MzWjhVQ1hSQkg3WmtzNHphRndodGNnZ3ZkSi9Qdzl3MTJ0Tkl6UUlEQVFBQm8xQXdUakFkQmdOVgpIUTRFRmdRVVU0V3FYMmZMeDdnVTJRcFF2VkgwblpOUXNSWXdId1lEVlIwakJCZ3dGb0FVVTRXcVgyZkx4N2dVCjJRcFF2VkgwblpOUXNSWXdEQVlEVlIwVEJBVXdBd0VCL3pBTkJna3Foa2lHOXcwQkFRVUZBQU9CZ1FBWWhUTWQKUHNDQ3hIbHFCak91c3dQNlBZT2c1TXo1QXFnNzBaWmZoTGpFV3lvU0VzclZKTTRlcyt4cnRIQUl0VDI4QXhreQpSUE43cnpMc2QzR2lIOWE2V3phZU5kcFdkWU1TaTMrTnJOYmtPU3ZuTmhHeHUvUUhiMEx0bWV0eHBENlNERmZQCkoxMUVuTjM0dldHMUpCWUh2NVNvditFOTkzclJKdkU0VUV1bFpRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
       DEVICE_CONFIG_SSH_AUTHORIZED_KEYS: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCc5cLVsu7b52tzxwa8A6cs4LC2I+IMtyKeVZFVAWdhfEWGEJL78rn0tC4YmHBSWW0hBeZmn8f7ZKcZ/r1W2RpuH7wpUc56/3hffJ0GoktMOX69pjNsE3rWr8/cZbl/LaJjeHBpyFZ6VimYl5KiYyHJH7RZwlEYYiJ2YDCbte51jvmotFTqiOJNPCM3SXWFjsUGDOWwNi7GDxG+ulb0cBnYzyYlHTj5dS/uya0v8S267TYO2jZ9lUvZHYYQBilYoN3qT79B/lRJq/AKsaSPI2VWkwoAWLObJRjQjoIsClxcfaSfRg6fgdezv3saeorVMIdEYAj3CQVmLszCNGC8dgqB9OoKdjd/OUG/bFUc86S+y0dZX3vqKBfZjE1dHNzNkQeulsbRj0FGFTxFYL0Ng7jlr98iXusnNg236LGsBTeod2MLfMRsrOc0Utfc5Pq2Zkyak4aJ6URBFqZnKlJwvI3AFznxvHD1PmIrwzCCmLA409v3WbXEK4KZrUIs81wlQWAK3919ViozdnR23f4hZtq3P5M6AbnMMdIOB1jDjPK//eaTMf3erHVa0nTMMwScBDnrT86yJBBEwpUVpIp6YUBFaVMQscX3gBTd+RyOU9jOvyinGjosJfF38qsMJTNHh48zgic5sSLhtPQgkUjWhpcnfjqrLRewKbVd+VZQc1WsdQ=="

--- a/src/features/sbom-management/index.ts
+++ b/src/features/sbom-management/index.ts
@@ -1,0 +1,67 @@
+import type { Application } from 'express';
+import {
+	createValidatedRequestHandler,
+	z,
+} from '../../infra/validation/index.js';
+
+export const DEPENDENCY_TRACK_NOTIFICATION_ROUTE =
+	'/sbom/v1/dependency-track/notification';
+
+/**
+ * Dependency-Track wraps every outbound webhook in a `notification` envelope.
+ * The shape of the payload below it varies per notification group, and the
+ * templates producing it are editable from the UI, so only the envelope is
+ * described here and everything else is carried through untouched.
+ */
+const dependencyTrackNotificationSchema = z.object({
+	notification: z.looseObject({
+		group: z.string(),
+		level: z.string(),
+		scope: z.string(),
+		title: z.string().optional(),
+		content: z.string().optional(),
+		timestamp: z.string().optional(),
+	}),
+});
+
+export type DependencyTrackNotification = z.infer<
+	typeof dependencyTrackNotificationSchema
+>;
+
+// Bounded, so that a chatty sender cannot grow this without limit.
+const MAX_RECORDED_NOTIFICATIONS = 100;
+const receivedNotifications: DependencyTrackNotification[] = [];
+
+export const getReceivedNotifications =
+	(): readonly DependencyTrackNotification[] => receivedNotifications;
+
+export const clearReceivedNotifications = () => {
+	receivedNotifications.length = 0;
+};
+
+export const setup = (app: Application) => {
+	// A mock receiver: it records deliveries so tests can assert that
+	// Dependency-Track reached the api, and does nothing else with them.
+	//
+	// It is deliberately unauthenticated, which is only acceptable because it is
+	// never mounted outside a test deployment. On a public api host this would
+	// let anyone post forged vulnerability notifications, so the guard below is
+	// load bearing — a real receiver needs authentication before it can ship.
+	if (process.env.DEPLOYMENT !== 'TEST') {
+		return;
+	}
+
+	app.post(
+		DEPENDENCY_TRACK_NOTIFICATION_ROUTE,
+		createValidatedRequestHandler(
+			{ body: dependencyTrackNotificationSchema },
+			(req, res) => {
+				receivedNotifications.push(req.body);
+				if (receivedNotifications.length > MAX_RECORDED_NOTIFICATIONS) {
+					receivedNotifications.shift();
+				}
+				res.status(204).end();
+			},
+		),
+	);
+};

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -14,6 +14,7 @@ import * as deviceState from './features/device-state/index.js';
 import * as deviceProvisioning from './features/device-provisioning/index.js';
 import * as deviceProxy from './features/device-proxy/index.js';
 import * as vpn from './features/vpn/index.js';
+import * as sbomManagement from './features/sbom-management/index.js';
 
 export const setup = (
 	app: Application,
@@ -40,4 +41,5 @@ export const setup = (
 	hostOSAccess.setup(app);
 	deviceTypes.setup(app);
 	osConfig.setup(app);
+	sbomManagement.setup(app);
 };

--- a/test/28_dependency-track.ts
+++ b/test/28_dependency-track.ts
@@ -1,0 +1,346 @@
+import { expect } from 'chai';
+import { setTimeout } from 'timers/promises';
+import * as fixtures from './test-lib/fixtures.js';
+import { supertest } from './test-lib/supertest.js';
+import {
+	analyzeProject,
+	createApiWebhookNotificationRule,
+	createVulnPolicy,
+	dependencyTrackFetch,
+	dependencyTrackUrl,
+	getDependencyTrackApiKey,
+	getComponents,
+	getFindings,
+	getNotificationRules,
+	getVulnerability,
+	seedVulnerability,
+	waitForDependencyTrack,
+	waitForTokenProcessed,
+} from './test-lib/dependency-track.js';
+import {
+	clearReceivedNotifications,
+	DEPENDENCY_TRACK_NOTIFICATION_ROUTE,
+	getReceivedNotifications,
+} from '../src/features/sbom-management/index.js';
+import bom from './fixtures/28-dependency-track/bom.json' with { type: 'json' };
+import vex from './fixtures/28-dependency-track/vex.json' with { type: 'json' };
+import vulnerabilities from './fixtures/28-dependency-track/vulnerabilities.json' with { type: 'json' };
+import vulnPolicy from './fixtures/28-dependency-track/vuln-policy.json' with { type: 'json' };
+
+interface DependencyTrackProject {
+	uuid: string;
+	name: string;
+	version: string;
+}
+
+const lookupProject = async (
+	name: string,
+	version: string,
+): Promise<DependencyTrackProject | undefined> => {
+	const res = await dependencyTrackFetch(
+		`/api/v1/project/lookup?name=${encodeURIComponent(name)}&version=${encodeURIComponent(version)}`,
+	);
+	if (res.status === 404) {
+		return undefined;
+	}
+	if (!res.ok) {
+		throw new Error(`Project lookup failed: ${res.status} ${await res.text()}`);
+	}
+	return (await res.json()) as DependencyTrackProject;
+};
+
+/**
+ * Dependency-Track queues uploaded boms and processes them asynchronously, so the
+ * project an upload creates only becomes visible some time after the upload call
+ * has already returned.
+ */
+const waitForProject = async (
+	name: string,
+	version: string,
+	timeoutMs = 60_000,
+): Promise<DependencyTrackProject> => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const project = await lookupProject(name, version);
+		if (project != null) {
+			return project;
+		}
+		await setTimeout(1000);
+	}
+	throw new Error(
+		`Dependency-Track did not create a project for ${name}@${version} within ${timeoutMs}ms`,
+	);
+};
+
+/**
+ * Dependency-Track publishes once the work behind an event has finished, so
+ * deliveries trail the call that triggered them.
+ */
+const waitForNotification = async (group: string, timeoutMs = 90_000) => {
+	const deadline = Date.now() + timeoutMs;
+	let seen: string[] = [];
+	while (Date.now() < deadline) {
+		seen = getReceivedNotifications().map(
+			({ notification }) => notification.group,
+		);
+		if (seen.includes(group)) {
+			return;
+		}
+		await setTimeout(1000);
+	}
+	throw new Error(
+		`No ${group} notification reached ${DEPENDENCY_TRACK_NOTIFICATION_ROUTE} within ${timeoutMs}ms (received: ${seen.join(', ') || 'none'})`,
+	);
+};
+
+export default () => {
+	describe('dependency track', function () {
+		before(async function () {
+			// The apiserver boots a JVM and runs its schema migration on first start,
+			// which takes far longer than the suite's default timeout.
+			this.timeout(300_000);
+			await waitForDependencyTrack();
+			this.apiKey = await getDependencyTrackApiKey();
+
+			const fx = await fixtures.load('28-dependency-track');
+			this.loadedFixtures = fx;
+			this.application = fx.applications.app1;
+			this.release = fx.releases.release1;
+
+			// Seeded before the sbom is uploaded, so that the analysis which runs as
+			// part of processing it already has something to match against.
+			for (const vulnerability of Object.values(vulnerabilities)) {
+				await seedVulnerability(vulnerability);
+			}
+
+			// Registered before anything is uploaded, since Dependency-Track only
+			// publishes to rules that already existed when the event fired.
+			clearReceivedNotifications();
+			this.notificationRuleUuid = await createApiWebhookNotificationRule({
+				name: 'open-balena-api test receiver',
+				route: DEPENDENCY_TRACK_NOTIFICATION_ROUTE,
+				notifyOn: ['BOM_PROCESSED', 'VEX_PROCESSED'],
+			});
+			// A separate rule, so that a policy changing a finding's analysis is
+			// observed on its own rather than folded in with the upload events.
+			this.auditNotificationRuleUuid = await createApiWebhookNotificationRule({
+				name: 'open-balena-api test audit receiver',
+				route: DEPENDENCY_TRACK_NOTIFICATION_ROUTE,
+				notifyOn: ['PROJECT_AUDIT_CHANGE'],
+			});
+		});
+
+		after(async function () {
+			// `before` can fail ahead of the fixtures loading, and cleaning nothing
+			// throws an error of its own that buries whatever actually went wrong.
+			if (this.loadedFixtures != null) {
+				await fixtures.clean(this.loadedFixtures);
+			}
+		});
+
+		it('should provision an api key for the Administrators team', function () {
+			expect(this.apiKey).to.be.a('string').that.is.not.empty;
+		});
+
+		it('should authenticate an api request using the provisioned key', async function () {
+			const res = await dependencyTrackFetch('/api/v1/team?pageSize=1');
+			expect(res.status).to.equal(200);
+		});
+
+		it('should reject an api request carrying an unknown key', async function () {
+			const res = await fetch(`${dependencyTrackUrl}/api/v1/team`, {
+				headers: { 'X-Api-Key': 'not-a-valid-api-key' },
+			});
+			expect(res.status).to.be.oneOf([401, 403]);
+		});
+
+		it('should memoise the api key across calls', async function () {
+			expect(await getDependencyTrackApiKey()).to.equal(this.apiKey);
+		});
+
+		it('should expose the api key to the app via the environment', function () {
+			expect(process.env.DEPENDENCY_TRACK_API_KEY).to.equal(this.apiKey);
+		});
+
+		it('should record a notification posted straight to the api route', async function () {
+			// Exercises the receiver without involving Dependency-Track, so a broken
+			// route can be told apart from a delivery that was never made.
+			const before = getReceivedNotifications().length;
+			await supertest()
+				.post(DEPENDENCY_TRACK_NOTIFICATION_ROUTE)
+				.send({
+					notification: {
+						group: 'BOM_PROCESSED',
+						level: 'INFORMATIONAL',
+						scope: 'PORTFOLIO',
+						title: 'posted directly by the test suite',
+					},
+				})
+				.expect(204);
+
+			const recorded = getReceivedNotifications();
+			expect(recorded).to.have.lengthOf(before + 1);
+			expect(recorded.at(-1)?.notification.title).to.equal(
+				'posted directly by the test suite',
+			);
+		});
+
+		it('should have stored the webhook rule with our destination and events', async function () {
+			// Confirms Dependency-Track kept what we sent it. A rule that is disabled,
+			// or that lost its notifyOn set, silently never publishes.
+			const rules = await getNotificationRules();
+			const rule = rules.find(({ uuid }) => uuid === this.notificationRuleUuid);
+
+			expect(rule, 'the rule created in before() is missing').to.not.be
+				.undefined;
+			expect(rule).to.have.property('enabled', true);
+			expect(rule?.notifyOn ?? []).to.include('BOM_PROCESSED');
+			expect(rule?.publisherConfig ?? '').to.contain(
+				DEPENDENCY_TRACK_NOTIFICATION_ROUTE,
+			);
+		});
+
+		it('should accept a CycloneDX sbom and auto create the project', async function () {
+			// Mirrors how the api submits release assets: the fleet slug becomes the
+			// project name and the release commit its version.
+			this.timeout(120_000);
+			const projectName = this.application.slug;
+			const projectVersion = this.release.commit;
+
+			expect(projectName).to.be.a('string').that.is.not.empty;
+			expect(projectVersion).to.be.a('string').that.is.not.empty;
+
+			const form = new FormData();
+			form.append('projectName', projectName);
+			form.append('projectVersion', projectVersion);
+			form.append('autoCreate', 'true');
+			form.append(
+				'bom',
+				new Blob([JSON.stringify(bom)], { type: 'application/json' }),
+				'bom.json',
+			);
+
+			const uploadRes = await dependencyTrackFetch('/api/v1/bom', {
+				method: 'POST',
+				body: form,
+			});
+			expect(uploadRes.status).to.equal(200);
+
+			// The project appears as soon as processing starts, well before the
+			// components and their analysis are in place, so drain the upload's own
+			// token rather than letting later assertions race it.
+			const { token } = (await uploadRes.json()) as { token: string };
+			await waitForTokenProcessed(token);
+
+			const project = await waitForProject(projectName, projectVersion);
+			expect(project).to.have.property('name', projectName);
+			expect(project).to.have.property('version', projectVersion);
+		});
+
+		it('should cover both a triaged and an untriaged vulnerability', function () {
+			// Guards the fixture itself: the upload below is only meaningful while it
+			// carries a vulnerability that has been analysed and one that is merely
+			// known, so losing either shape should fail loudly rather than silently
+			// narrow what the vex test exercises.
+			const triaged = vex.vulnerabilities.filter(
+				(vulnerability) => 'analysis' in vulnerability,
+			);
+			expect(vex.vulnerabilities).to.have.lengthOf(2);
+			expect(triaged).to.have.lengthOf(1);
+		});
+
+		it('should accept a CycloneDX vex document for the project', async function () {
+			this.timeout(120_000);
+			const projectName = this.application.slug;
+			const projectVersion = this.release.commit;
+
+			// The api only submits vex once the sbom has created the project, so
+			// resolve the project first, the same way the release asset task does.
+			const project = await waitForProject(projectName, projectVersion);
+
+			const res = await dependencyTrackFetch('/api/v1/vex', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					project: project.uuid,
+					projectName,
+					projectVersion,
+					vex: Buffer.from(JSON.stringify(vex)).toString('base64'),
+				}),
+			});
+			expect(res.status).to.equal(200);
+		});
+
+		it('should deliver a notification to the api webhook route', async function () {
+			this.timeout(120_000);
+			await waitForNotification('BOM_PROCESSED');
+		});
+
+		it('should have stored the seeded vulnerabilities', async function () {
+			// If seeding silently dropped the affected components there is nothing for
+			// the internal analyzer to match, and every later step fails downstream of
+			// that rather than at the cause.
+			for (const { vulnId } of Object.values(vulnerabilities)) {
+				const stored = await getVulnerability('INTERNAL', vulnId);
+				expect(stored, `${vulnId} was not stored`).to.not.be.undefined;
+				expect(
+					stored?.affectedComponents ?? [],
+					`${vulnId} has no affected components`,
+				).to.not.be.empty;
+			}
+		});
+
+		it('should produce findings for the seeded vulnerabilities', async function () {
+			// The policy can only triage a finding that exists. Running the analysis
+			// explicitly — and waiting for its token — means an empty result here is a
+			// matching failure rather than a race, which is the difference between
+			// "the seeded purl is wrong" and "we looked too early".
+			this.timeout(180_000);
+			const project = await waitForProject(
+				this.application.slug,
+				this.release.commit,
+			);
+			await analyzeProject(project.uuid);
+
+			const findings = await getFindings(project.uuid);
+			const vulnIds = findings.map(({ vulnerability }) => vulnerability.vulnId);
+			const components = await getComponents(project.uuid);
+
+			// Reported together, because no finding with no components is a broken bom
+			// import, whereas no finding against components that are present points at
+			// the seeded affected-component identity.
+			expect(
+				vulnIds,
+				`no finding for the untriaged vulnerability (findings: ${
+					vulnIds.join(', ') || 'none'
+				}; components: ${
+					components.map(({ purl, name }) => purl ?? name).join(', ') || 'none'
+				})`,
+			).to.include('CVE-2020-8203');
+		});
+
+		it('should triage the untriaged finding through a vulnerability policy', async function () {
+			// The vex fixture leaves CVE-2020-8203 declared but unanalysed. A policy
+			// matching it in APPLY mode is what settles its analysis, and changing an
+			// analysis is what Dependency-Track reports as PROJECT_AUDIT_CHANGE.
+			this.timeout(180_000);
+			const project = await waitForProject(
+				this.application.slug,
+				this.release.commit,
+			);
+
+			this.vulnPolicyUuid = await createVulnPolicy(vulnPolicy);
+
+			// Policies are only evaluated while analysing a project, so one created
+			// after the upload takes effect on the next run rather than immediately.
+			await analyzeProject(project.uuid);
+
+			await waitForNotification('PROJECT_AUDIT_CHANGE');
+		});
+
+		it('should return 404 when looking up a project that was never uploaded', async function () {
+			expect(await lookupProject('no-such-fleet', 'no-such-commit')).to.be
+				.undefined;
+		});
+	});
+};

--- a/test/fixtures/28-dependency-track/applications.json
+++ b/test/fixtures/28-dependency-track/applications.json
@@ -1,0 +1,7 @@
+{
+	"app1": {
+		"user": "admin",
+		"app_name": "test_dependency_track",
+		"device_type": "raspberry-pi"
+	}
+}

--- a/test/fixtures/28-dependency-track/bom.json
+++ b/test/fixtures/28-dependency-track/bom.json
@@ -1,0 +1,29 @@
+{
+	"bomFormat": "CycloneDX",
+	"specVersion": "1.5",
+	"serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+	"version": 1,
+	"metadata": {
+		"component": {
+			"type": "application",
+			"name": "test_dependency_track",
+			"version": "00000028"
+		}
+	},
+	"components": [
+		{
+			"type": "library",
+			"bom-ref": "pkg:npm/lodash@4.17.21",
+			"name": "lodash",
+			"version": "4.17.21",
+			"purl": "pkg:npm/lodash@4.17.21"
+		},
+		{
+			"type": "library",
+			"bom-ref": "pkg:npm/express@4.18.2",
+			"name": "express",
+			"version": "4.18.2",
+			"purl": "pkg:npm/express@4.18.2"
+		}
+	]
+}

--- a/test/fixtures/28-dependency-track/releases.json
+++ b/test/fixtures/28-dependency-track/releases.json
@@ -1,0 +1,14 @@
+{
+	"release1": {
+		"user": "admin",
+		"application": "app1",
+		"commit": "00000028",
+		"status": "success",
+		"composition": {
+			"services": {
+				"main": {}
+			}
+		},
+		"source": "cloud"
+	}
+}

--- a/test/fixtures/28-dependency-track/vex.json
+++ b/test/fixtures/28-dependency-track/vex.json
@@ -1,0 +1,44 @@
+{
+	"bomFormat": "CycloneDX",
+	"specVersion": "1.5",
+	"serialNumber": "urn:uuid:8d7bf2a1-4c33-49f0-9d52-1b6c0a4e77aa",
+	"version": 1,
+	"metadata": {
+		"component": {
+			"type": "application",
+			"name": "test_dependency_track",
+			"version": "00000028"
+		}
+	},
+	"vulnerabilities": [
+		{
+			"id": "CVE-2021-23337",
+			"source": {
+				"name": "NVD",
+				"url": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337"
+			},
+			"analysis": {
+				"state": "not_affected",
+				"justification": "code_not_reachable",
+				"detail": "The vulnerable template path is never reached by this fleet."
+			},
+			"affects": [
+				{
+					"ref": "pkg:npm/lodash@4.17.21"
+				}
+			]
+		},
+		{
+			"id": "CVE-2020-8203",
+			"source": {
+				"name": "NVD",
+				"url": "https://nvd.nist.gov/vuln/detail/CVE-2020-8203"
+			},
+			"affects": [
+				{
+					"ref": "pkg:npm/lodash@4.17.21"
+				}
+			]
+		}
+	]
+}

--- a/test/fixtures/28-dependency-track/vuln-policy.json
+++ b/test/fixtures/28-dependency-track/vuln-policy.json
@@ -1,0 +1,14 @@
+{
+	"name": "open-balena-api test triage of untriaged lodash finding",
+	"description": "Triages the one vulnerability the vex fixture declares without an analysis of its own.",
+	"author": "open-balena-api test suite",
+	"condition": "vuln.id == \"CVE-2020-8203\" && component.name == \"lodash\"",
+	"operation_mode": "APPLY",
+	"priority": 0,
+	"analysis": {
+		"state": "NOT_AFFECTED",
+		"justification": "CODE_NOT_REACHABLE",
+		"details": "Triaged by policy: the vulnerable path is not reachable from this fleet.",
+		"suppress": false
+	}
+}

--- a/test/fixtures/28-dependency-track/vulnerabilities.json
+++ b/test/fixtures/28-dependency-track/vulnerabilities.json
@@ -1,0 +1,32 @@
+{
+	"commandInjection": {
+		"vulnId": "CVE-2021-23337",
+		"source": "INTERNAL",
+		"title": "Command injection in lodash",
+		"description": "Seeded by the test suite. The stack mirrors no vulnerability source, so without seeding there are no findings for a vex document or a policy to act on.",
+		"severity": "HIGH",
+		"affectedComponents": [
+			{
+				"identityType": "PURL",
+				"identity": "pkg:npm/lodash",
+				"version": "4.17.21",
+				"versionType": "EXACT"
+			}
+		]
+	},
+	"prototypePollution": {
+		"vulnId": "CVE-2020-8203",
+		"source": "INTERNAL",
+		"title": "Prototype pollution in lodash",
+		"description": "Seeded by the test suite. This is the vulnerability the vex fixture leaves untriaged, so that a vulnerability policy has something to triage.",
+		"severity": "HIGH",
+		"affectedComponents": [
+			{
+				"identityType": "PURL",
+				"identity": "pkg:npm/lodash",
+				"version": "4.17.21",
+				"versionType": "EXACT"
+			}
+		]
+	}
+}

--- a/test/test-lib/dependency-track.ts
+++ b/test/test-lib/dependency-track.ts
@@ -1,0 +1,479 @@
+import { setTimeout } from 'timers/promises';
+import { PORT } from '../../src/lib/config.js';
+
+// `DEPENDENCY_TRACK_URL` is a host:port pair rather than a full URL, matching how
+// the API itself consumes it. Normalise it so this helper can build request URLs
+// without caring which form it was given.
+const configuredUrl = process.env.DEPENDENCY_TRACK_URL ?? 'dtrack:8080';
+export const dependencyTrackUrl = /^https?:\/\//.test(configuredUrl)
+	? configuredUrl
+	: `http://${configuredUrl}`;
+
+const ADMIN_USERNAME = 'admin';
+const DEFAULT_ADMIN_PASSWORD = 'admin';
+// Dependency-Track forces a password change on first login and there is no way to
+// preseed credentials (v5 seeding creates structural defaults only), so the suite
+// picks the replacement password itself.
+const TEST_ADMIN_PASSWORD = 'DependencyTrackTest1!';
+
+interface DependencyTrackTeam {
+	uuid: string;
+	name: string;
+}
+
+const formPost = async (path: string, data: Record<string, string>) =>
+	await fetch(`${dependencyTrackUrl}${path}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams(data).toString(),
+	});
+
+/**
+ * Dependency-Track boots a JVM and runs its schema migration on first start, which
+ * takes far longer than the default mocha timeout. Only tests that actually need
+ * DT should pay for this, so nothing waits on it during suite startup.
+ */
+export const waitForDependencyTrack = async (timeoutMs = 300_000) => {
+	const deadline = Date.now() + timeoutMs;
+	let lastError = 'no attempt was made';
+	// `/health/ready` is the MicroProfile readiness probe and `/api/version` is the
+	// unauthenticated version endpoint; either answering means DT is serving.
+	const readinessPaths = ['/health/ready', '/api/version'];
+
+	while (Date.now() < deadline) {
+		for (const path of readinessPaths) {
+			try {
+				const res = await fetch(`${dependencyTrackUrl}${path}`);
+				if (res.ok) {
+					return;
+				}
+				lastError = `${path} returned ${res.status}`;
+			} catch (err) {
+				lastError = `${path}: ${err}`;
+			}
+		}
+		await setTimeout(2000);
+	}
+
+	throw new Error(
+		`Dependency-Track at ${dependencyTrackUrl} was not ready within ${timeoutMs}ms (last error: ${lastError})`,
+	);
+};
+
+const login = async (password: string): Promise<string | undefined> => {
+	const res = await formPost('/api/v1/user/login', {
+		username: ADMIN_USERNAME,
+		password,
+	});
+	if (!res.ok) {
+		return undefined;
+	}
+	// The JWT is returned as a plain-text body rather than JSON.
+	return (await res.text()).trim();
+};
+
+const getAdminJwt = async (): Promise<string> => {
+	// A DT instance carried over from a previous run (`--preserve-volumes`) already
+	// has the suite password set, so try that before touching the default.
+	const existing = await login(TEST_ADMIN_PASSWORD);
+	if (existing != null) {
+		return existing;
+	}
+
+	// On a fresh instance DT refuses to issue a token until the forced password
+	// change has happened, so drive that and log in again.
+	const changeRes = await formPost('/api/v1/user/forceChangePassword', {
+		username: ADMIN_USERNAME,
+		password: DEFAULT_ADMIN_PASSWORD,
+		newPassword: TEST_ADMIN_PASSWORD,
+		confirmPassword: TEST_ADMIN_PASSWORD,
+	});
+
+	const jwt = await login(TEST_ADMIN_PASSWORD);
+	if (jwt != null) {
+		return jwt;
+	}
+
+	// Some versions do not force the change; fall back to the untouched default.
+	const withDefault = await login(DEFAULT_ADMIN_PASSWORD);
+	if (withDefault != null) {
+		return withDefault;
+	}
+
+	throw new Error(
+		`Could not obtain a Dependency-Track admin token for '${ADMIN_USERNAME}' ` +
+			`(forceChangePassword returned ${changeRes.status})`,
+	);
+};
+
+const getAdministratorsTeam = async (
+	jwt: string,
+): Promise<DependencyTrackTeam> => {
+	const res = await fetch(`${dependencyTrackUrl}/api/v1/team?pageSize=100`, {
+		headers: { Authorization: `Bearer ${jwt}` },
+	});
+	if (!res.ok) {
+		throw new Error(
+			`Listing Dependency-Track teams failed: ${res.status} ${await res.text()}`,
+		);
+	}
+
+	// Team listings are paginated through query params and an X-Total-Count header,
+	// but the body itself stays a bare array. `pageSize` defaults to 100 anyway;
+	// it is passed explicitly so a future default change cannot truncate the list.
+	const teams = (await res.json()) as DependencyTrackTeam[];
+
+	// The built-in Administrators team already holds every permission, which saves
+	// the suite from assembling a permission set of its own.
+	const team = teams.find(({ name }) => name === 'Administrators');
+	if (team == null) {
+		throw new Error(
+			`No 'Administrators' team in Dependency-Track (found: ${
+				teams.map(({ name }) => name).join(', ') || 'none'
+			})`,
+		);
+	}
+	return team;
+};
+
+const createApiKey = async (jwt: string, teamUuid: string): Promise<string> => {
+	const res = await fetch(`${dependencyTrackUrl}/api/v1/team/${teamUuid}/key`, {
+		method: 'PUT',
+		headers: { Authorization: `Bearer ${jwt}` },
+	});
+	if (!res.ok) {
+		throw new Error(
+			`Creating a Dependency-Track api key failed: ${res.status} ${await res.text()}`,
+		);
+	}
+
+	// Keys are stored hashed, so `key` holds the plaintext only in the response to
+	// the call that created it — every later read returns `maskedKey` instead.
+	const { key } = (await res.json()) as { key?: string };
+	if (typeof key !== 'string' || key === '') {
+		throw new Error(
+			'Dependency-Track returned an api key without a plaintext value',
+		);
+	}
+	return key;
+};
+
+let apiKeyPromise: Promise<string> | undefined;
+
+/**
+ * Lazily provisions an api key and memoises it for the rest of the process.
+ *
+ * Dependency-Track generates keys server side, so there is nothing to preseed via
+ * the environment. Rather than bootstrapping during suite startup — which would
+ * make every non-DT run wait on the JVM — the REST dance runs the first time a
+ * test asks for a key.
+ */
+export const getDependencyTrackApiKey = async (): Promise<string> => {
+	apiKeyPromise ??= (async () => {
+		const jwt = await getAdminJwt();
+		const team = await getAdministratorsTeam(jwt);
+		const apiKey = await createApiKey(jwt, team.uuid);
+		// Publish it the same way a deployment would, so code under test reads it
+		// from the environment and stays unaware of how it was obtained.
+		process.env.DEPENDENCY_TRACK_API_KEY = apiKey;
+		return apiKey;
+	})().catch((err) => {
+		// Don't cache a failed bootstrap, so a later test can retry it.
+		apiKeyPromise = undefined;
+		throw err;
+	});
+
+	return await apiKeyPromise;
+};
+
+/** Issues an api-key-authenticated request against Dependency-Track. */
+export const dependencyTrackFetch = async (
+	path: string,
+	init: RequestInit = {},
+): Promise<Response> => {
+	const apiKey = await getDependencyTrackApiKey();
+	return await fetch(`${dependencyTrackUrl}${path}`, {
+		...init,
+		headers: { ...init.headers, 'X-Api-Key': apiKey },
+	});
+};
+
+/**
+ * Where Dependency-Track reaches the api to deliver notifications.
+ *
+ * Nothing needs publishing to the docker host for this: both containers sit on
+ * the `local-test` network, so traffic goes straight to the api's own port. The
+ * `sut` alias is what makes the suite addressable at all, because
+ * `docker compose run` does not name its containers after the service.
+ */
+export const apiWebhookOrigin = `http://sut:${PORT}`;
+
+interface NotificationPublisher {
+	uuid: string;
+	name: string;
+	extensionName?: string;
+}
+
+/**
+ * Registers a vulnerability with Dependency-Track's own `INTERNAL` source.
+ *
+ * The test stack mirrors no vulnerability source — that is what makes it cheap to
+ * run — so nothing would otherwise match the components in an uploaded sbom, and
+ * a vex document or a policy would have no findings to act on.
+ */
+export const seedVulnerability = async (
+	vulnerability: unknown,
+): Promise<void> => {
+	const res = await dependencyTrackFetch('/api/v1/vulnerability', {
+		method: 'PUT',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(vulnerability),
+	});
+	// A run against a preserved database has seeded it already.
+	if (res.status === 409) {
+		return;
+	}
+	if (!res.ok) {
+		throw new Error(
+			`Seeding a Dependency-Track vulnerability failed: ${res.status} ${await res.text()}`,
+		);
+	}
+};
+
+/**
+ * Creates a vulnerability policy through the v2 api, which is where policy
+ * management lives — v1 has no equivalent. Conditions are CEL, compiled server
+ * side, so a malformed one comes back as a 400 naming the line and column.
+ */
+export const createVulnPolicy = async (policy: unknown): Promise<string> => {
+	const res = await dependencyTrackFetch('/api/v2/vuln-policies', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(policy),
+	});
+	if (!res.ok) {
+		throw new Error(
+			`Creating a Dependency-Track vulnerability policy failed: ${res.status} ${await res.text()}`,
+		);
+	}
+	const { uuid } = (await res.json()) as { uuid: string };
+	return uuid;
+};
+
+/**
+ * Waits for a processing token to drain. Bom uploads, vex uploads and analyses
+ * all only queue their work and hand one back.
+ */
+export const waitForTokenProcessed = async (
+	token: string,
+	timeoutMs = 120_000,
+): Promise<void> => {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const res = await dependencyTrackFetch(`/api/v1/event/token/${token}`);
+		if (res.ok) {
+			const { processing } = (await res.json()) as { processing: boolean };
+			if (!processing) {
+				return;
+			}
+		}
+		await setTimeout(1000);
+	}
+	throw new Error(
+		`Dependency-Track token ${token} was still processing after ${timeoutMs}ms`,
+	);
+};
+
+/**
+ * Re-runs vulnerability analysis for a project and waits for it to finish.
+ *
+ * Policies are evaluated every time a project's vulnerabilities are analysed, so
+ * one created after an upload only takes effect once this has run. Nothing is
+ * visible — and nothing is published — until the returned token drains.
+ */
+export const analyzeProject = async (projectUuid: string): Promise<void> => {
+	const res = await dependencyTrackFetch(
+		`/api/v1/finding/project/${projectUuid}/analyze`,
+		{ method: 'POST' },
+	);
+	if (!res.ok) {
+		throw new Error(
+			`Re-analysing Dependency-Track project ${projectUuid} failed: ${res.status} ${await res.text()}`,
+		);
+	}
+	const { token } = (await res.json()) as { token: string };
+	await waitForTokenProcessed(token);
+};
+
+export interface DependencyTrackFinding {
+	vulnerability: { vulnId?: string; source?: string };
+	component: { name?: string; version?: string; purl?: string };
+	analysis?: { state?: string; isSuppressed?: boolean };
+}
+
+/** The findings a project's analysis produced. */
+export const getFindings = async (
+	projectUuid: string,
+): Promise<DependencyTrackFinding[]> => {
+	const res = await dependencyTrackFetch(
+		`/api/v1/finding/project/${projectUuid}`,
+	);
+	if (!res.ok) {
+		throw new Error(
+			`Listing Dependency-Track findings failed: ${res.status} ${await res.text()}`,
+		);
+	}
+	return (await res.json()) as DependencyTrackFinding[];
+};
+
+export interface DependencyTrackComponent {
+	name?: string;
+	version?: string;
+	purl?: string;
+}
+
+/** The components a bom import created for a project. */
+export const getComponents = async (
+	projectUuid: string,
+): Promise<DependencyTrackComponent[]> => {
+	const res = await dependencyTrackFetch(
+		`/api/v1/component/project/${projectUuid}?pageSize=100`,
+	);
+	if (!res.ok) {
+		throw new Error(
+			`Listing Dependency-Track components failed: ${res.status} ${await res.text()}`,
+		);
+	}
+	return (await res.json()) as DependencyTrackComponent[];
+};
+
+/** Reads a vulnerability back, to check what seeding actually stored. */
+export const getVulnerability = async (
+	source: string,
+	vulnId: string,
+): Promise<{ vulnId?: string; affectedComponents?: unknown[] } | undefined> => {
+	const res = await dependencyTrackFetch(
+		`/api/v1/vulnerability/source/${source}/vuln/${vulnId}`,
+	);
+	if (res.status === 404) {
+		return undefined;
+	}
+	if (!res.ok) {
+		throw new Error(
+			`Reading Dependency-Track vulnerability ${source}/${vulnId} failed: ${res.status} ${await res.text()}`,
+		);
+	}
+	return (await res.json()) as {
+		vulnId?: string;
+		affectedComponents?: unknown[];
+	};
+};
+
+export interface DependencyTrackNotificationRule {
+	uuid: string;
+	name: string;
+	enabled?: boolean;
+	notifyOn?: string[];
+	/** A JSON-encoded string, not an object. */
+	publisherConfig?: string;
+}
+
+/** Reads rules back, to check what Dependency-Track actually stored. */
+export const getNotificationRules = async (): Promise<
+	DependencyTrackNotificationRule[]
+> => {
+	const res = await dependencyTrackFetch(
+		'/api/v1/notification/rule?pageSize=100',
+	);
+	if (!res.ok) {
+		throw new Error(
+			`Listing Dependency-Track notification rules failed: ${res.status} ${await res.text()}`,
+		);
+	}
+	return (await res.json()) as DependencyTrackNotificationRule[];
+};
+
+const getWebhookPublisher = async (): Promise<NotificationPublisher> => {
+	const res = await dependencyTrackFetch('/api/v1/notification/publisher');
+	if (!res.ok) {
+		throw new Error(
+			`Listing Dependency-Track notification publishers failed: ${res.status} ${await res.text()}`,
+		);
+	}
+
+	const publishers = (await res.json()) as NotificationPublisher[];
+	const publisher = publishers.find(({ name, extensionName }) =>
+		/webhook/i.test(extensionName ?? name),
+	);
+	if (publisher == null) {
+		throw new Error(
+			`No outbound webhook publisher in Dependency-Track (found: ${
+				publishers.map(({ name }) => name).join(', ') || 'none'
+			})`,
+		);
+	}
+	return publisher;
+};
+
+/**
+ * Points Dependency-Track at an api route for the given events.
+ *
+ * Creation and configuration are two calls: the create request only accepts a
+ * name, scope, level and publisher, so the destination and the event selection
+ * have to follow in an update.
+ */
+export const createApiWebhookNotificationRule = async ({
+	name,
+	route,
+	notifyOn,
+}: {
+	name: string;
+	route: string;
+	notifyOn: string[];
+}): Promise<string> => {
+	const publisher = await getWebhookPublisher();
+
+	const createRes = await dependencyTrackFetch('/api/v1/notification/rule', {
+		method: 'PUT',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			name,
+			scope: 'PORTFOLIO',
+			level: 'INFORMATIONAL',
+			publisher: { uuid: publisher.uuid },
+		}),
+	});
+	if (!createRes.ok) {
+		throw new Error(
+			`Creating a Dependency-Track notification rule failed: ${createRes.status} ${await createRes.text()}`,
+		);
+	}
+	const { uuid } = (await createRes.json()) as { uuid: string };
+
+	const updateRes = await dependencyTrackFetch('/api/v1/notification/rule', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			uuid,
+			name,
+			scope: 'PORTFOLIO',
+			level: 'INFORMATIONAL',
+			enabled: true,
+			notifyOn,
+			// publisherConfig is itself a JSON-encoded string rather than an object,
+			// and it is validated against the publisher's own runtime config schema
+			// — readable at /api/v1/notification/publisher/{uuid}/configSchema if a
+			// future version wants different keys than this one.
+			publisherConfig: JSON.stringify({
+				destinationUrl: `${apiWebhookOrigin}${route}`,
+			}),
+		}),
+	});
+	if (!updateRes.ok) {
+		throw new Error(
+			`Configuring the Dependency-Track notification rule failed: ${updateRes.status} ${await updateRes.text()}`,
+		);
+	}
+
+	return uuid;
+};

--- a/test/test-lib/mockttp-server.ts
+++ b/test/test-lib/mockttp-server.ts
@@ -44,6 +44,7 @@ export async function start() {
 		'redis',
 		'loki',
 		'minio-server',
+		'dtrack',
 	].join(',');
 }
 


### PR DESCRIPTION
- Initializing DTrack on the same DB
- Connecting API to DTrack with API key usage
- Seeding Fixtures into DTrack (CVEs, SBOMs, VEX)
- Configuring Webhook Poublishers
- Testing WebHook triggering from DTrack to API

Change-type: minor