### PR TITLE
Do not change supervisor pin when provisioning if pin already set

### DIFF
--- a/src/features/supervisor-app/hooks/supervisor-app.ts
+++ b/src/features/supervisor-app/hooks/supervisor-app.ts
@@ -36,7 +36,10 @@ hooks.addPureHook('POST', 'resin', 'device', {
 				},
 			);
 
-			if (supervisorRelease == null) {
+			if (
+				supervisorRelease == null &&
+				request.values.should_be_managed_by__release != null
+			) {
 				return;
 			}
 			// We are not using setSupervisorReleaseResource in a POSTRUN, since that only sets

--- a/test/16_supervisor_releases.ts
+++ b/test/16_supervisor_releases.ts
@@ -375,6 +375,27 @@ export default () => {
 					});
 				});
 
+				it('should not change the supervisor pin if already set', async () => {
+					await supertest(ctx.admin)
+						.patch(`/${version}/device(${device.id})`)
+						.send({
+							supervisor_version: null,
+							should_be_managed_by__release: ctx.supervisorReleases['8.0.4'].id,
+						})
+						.expect(200);
+					await supertest(ctx.admin)
+						.patch(`/${version}/device(${device.id})`)
+						.send({
+							supervisor_version: '8.0.4',
+						})
+						.expect(200);
+					await expectResourceToMatch(pineUser, 'device', device.id, {
+						should_be_managed_by__release: {
+							__id: ctx.supervisorReleases['8.0.4'].id,
+						},
+					});
+				});
+
 				it('should provision to an invalidated release', async () => {
 					await supertest(ctx.admin)
 						.patch(`/${version}/device(${device.id})`)


### PR DESCRIPTION
The API sets the `should_be_managed_by__release` property on the device on first report of the `supervisor_version`, however it sets this value even if there is already a pin set. This should not really cause issues for customers but it affects supervisor developers testing with draft releases.

Change-type: patch