### PR TITLE
Test checksum enabled open-balena-db by default

### DIFF
--- a/docker-compose.test-custom.yml
+++ b/docker-compose.test-custom.yml
@@ -1,7 +1,7 @@
 version: "2.4"
 services:
   db:
-    image: balena/open-balena-db:8.0.20@sha256:89ec1fb9e360e64482f1fc9c3464b95e141ebc97105ca13676b09516aa29e40d
+    image: balena/build-jaomaloy-enable-checksum
     ports:
       - "5432"
       - "5431:5432"


### PR DESCRIPTION
PG18 now enables checksum by default so migrating
from 17 or older fails. This tests a branch
of open-balena-db that resolves it.

Change-type: patch