### PR TITLE
Registry: Add API client fallback for image deletions

### DIFF
--- a/src/features/images/hooks/delete-registry-images.ts
+++ b/src/features/images/hooks/delete-registry-images.ts
@@ -15,8 +15,8 @@ interface DeleteRequestCustomObject {
 
 if (ASYNC_TASK_DELETE_REGISTRY_IMAGES_ENABLED) {
 	if (s3Client == null) {
-		throw new Error(
-			'Cannot enable this hook when registry S3 client is not initialized',
+		console.warn(
+			'Registry S3 client not available, falling back to registry API client for image deletion',
 		);
 	}
 	hooks.addPureHook('DELETE', 'resin', 'image', {

--- a/src/features/images/tasks/delete-registry-images.ts
+++ b/src/features/images/tasks/delete-registry-images.ts
@@ -1,7 +1,13 @@
 import { permissions, sbvrUtils, tasks } from '@balena/pinejs';
 import type { FromSchema } from 'json-schema-to-ts';
 import PQueue from 'p-queue';
-import { s3Client } from '../../../features/registry/registry.js';
+import {
+	deleteImage,
+	generateDeleteToken,
+	getManifestDigest,
+	listRepoTags,
+	s3Client,
+} from '../../../features/registry/registry.js';
 import {
 	ASYNC_TASK_ATTEMPT_LIMIT,
 	ASYNC_TASK_DELETE_REGISTRY_IMAGES_CONCURRENCY,
@@ -63,30 +69,70 @@ if (ASYNC_TASK_DELETE_REGISTRY_IMAGES_ENABLED) {
 	);
 }
 
+const subject = `task:${handlerName}`;
+
+// Fallback used when the registry's S3 client isn't available.
+async function deleteRepoViaApi(
+	repo: string,
+	signal: AbortSignal,
+): Promise<boolean> {
+	signal.throwIfAborted();
+	const token = generateDeleteToken(subject, repo);
+	const tags = await listRepoTags(token, repo);
+	if (tags == null) {
+		return false;
+	}
+
+	// Several tags can point at the same manifest, so resolve them all
+	// before deleting to avoid repeated deletes of the same digest.
+	const digests = new Set<string>();
+	for (const tag of tags) {
+		signal.throwIfAborted();
+		const digest = await getManifestDigest(token, repo, tag);
+		if (digest != null) {
+			digests.add(digest);
+		}
+	}
+
+	for (const digest of digests) {
+		signal.throwIfAborted();
+		await deleteImage(token, repo, digest);
+	}
+	return true;
+}
+
 // Delete all manifests within a given registry repository (and its multi-stage
 // build cache repositories) by removing the entire `_manifests` directory.
 // We delete the directory directly rather than marking each manifest for
 // deletion via the registry API, as the API leaves behind legacy signature
 // links that keep the `_manifests` directory (and thus the repository in the
-// catalog list) alive.
-async function deleteRepo(
-	s3: NonNullable<typeof s3Client>,
-	repo: string,
-	signal: AbortSignal,
-): Promise<void> {
-	const cacheRepos = await s3.listCacheRepos(repo);
-	for (const target of [...cacheRepos, repo]) {
-		await s3.deleteRepoManifests(target, signal);
+// catalog list) alive. The registry API is only used as a fallback for when
+// registry's S3 client isn't available.
+async function deleteRepo(repo: string, signal: AbortSignal): Promise<void> {
+	if (s3Client != null) {
+		const cacheRepos = await s3Client.listCacheRepos(repo);
+		for (const target of [...cacheRepos, repo]) {
+			await s3Client.deleteRepoManifests(target, signal);
+		}
+		return;
 	}
+
+	// Without the S3 client we can't list the multi-stage build cache
+	// repositories, so try until one is missing.
+	let stage = 0;
+	while (true) {
+		const deleted = await deleteRepoViaApi(`${repo}-${stage}`, signal);
+		if (!deleted) {
+			break;
+		}
+		stage++;
+	}
+	await deleteRepoViaApi(repo, signal);
 }
 
 const deleteRegistryImages = async ({
 	images,
 }: DeleteRegistryImagesTaskParams) => {
-	if (s3Client == null) {
-		throw new Error('Registry S3 client not initialized.');
-	}
-
 	// Avoid deleting any blobs that are still referenced by other images
 	// This shouldn't normally be necessary as is_stored_at__image_location
 	// should be enforced as unique at the database level, but just in case
@@ -131,7 +177,7 @@ const deleteRegistryImages = async ({
 						`[${logHeader}] Skipping deletion of image with empty repo: ${location}`,
 					);
 				} else {
-					await deleteRepo(s3Client!, repo, signal);
+					await deleteRepo(repo, signal);
 				}
 				remaining.delete(location);
 			}),

--- a/src/features/registry/registry.ts
+++ b/src/features/registry/registry.ts
@@ -36,6 +36,7 @@ import {
 	RESOLVE_IMAGE_LOCATION_CACHE_TIMEOUT,
 	RESOLVE_IMAGE_READ_ACCESS_CACHE_TIMEOUT,
 	TOKEN_AUTH_BUILDER_TOKEN,
+	guardTestMockOnly,
 } from '../../lib/config.js';
 import {
 	createValidatedRequestHandler,
@@ -741,7 +742,7 @@ const getSubject = async (
 // S3 client primarily for finding multi-stage build cache image
 // repositories and all digests for a given repository. The
 // Docker Distribution API doesn't support such queries.
-class S3Client {
+export class S3Client {
 	private s3: AWS.S3;
 	private bucket: string;
 	private rootPath: string;
@@ -866,7 +867,7 @@ class S3Client {
 	}
 }
 
-export const s3Client: S3Client | undefined =
+export let s3Client: S3Client | undefined =
 	REGISTRY_STORAGE_BUCKET != null &&
 	REGISTRY_STORAGE_ROOT_PATH != null &&
 	REGISTRY_STORAGE_ENDPOINT != null &&
@@ -881,13 +882,22 @@ export const s3Client: S3Client | undefined =
 			})
 		: undefined;
 
+export const TEST_MOCK_ONLY = {
+	set s3Client(v: S3Client | undefined) {
+		guardTestMockOnly();
+		s3Client = v;
+	},
+};
+
 // Generate a token for deleting images for a given repository.
+// `pull` is included as listing a repository's tags and resolving them to
+// manifest digests (both needed to know what to delete) require read access.
 export function generateDeleteToken(subject: string, repo: string) {
 	return generateToken(subject, REGISTRY2_HOST, [
 		{
 			name: repo,
 			type: 'repository',
-			actions: ['delete'],
+			actions: ['pull', 'delete'],
 		},
 	]);
 }
@@ -909,4 +919,72 @@ export async function deleteImage(
 			`Failed to mark ${repo}/${digest} for deletion: [${statusCode}] ${statusMessage} ${body}`,
 		);
 	}
+}
+
+// The manifest media types we're prepared to handle.
+const MANIFEST_ACCEPT_HEADER = [
+	'application/vnd.docker.distribution.manifest.v2+json',
+	'application/vnd.docker.distribution.manifest.list.v2+json',
+	'application/vnd.oci.image.manifest.v1+json',
+	'application/vnd.oci.image.index.v1+json',
+].join(', ');
+
+// List the tags of a given repository via the Docker Distribution API.
+// Returns undefined when the repository doesn't exist.
+export async function listRepoTags(
+	registryToken: string,
+	repo: string,
+): Promise<string[] | undefined> {
+	const [{ statusCode, statusMessage }, body] = await requestAsync({
+		url: `https://${REGISTRY2_HOST}/v2/${repo}/tags/list`,
+		headers: { Authorization: `Bearer ${registryToken}` },
+		method: 'GET',
+		json: true,
+	});
+
+	if (statusCode === 404) {
+		return undefined;
+	}
+	if (statusCode !== 200) {
+		throw new Error(
+			`Failed to list tags of ${repo}: [${statusCode}] ${statusMessage} ${JSON.stringify(body)}`,
+		);
+	}
+	if (body?.name !== repo || !Array.isArray(body.tags)) {
+		return undefined;
+	}
+	return body.tags;
+}
+
+// Resolve a repository tag to its manifest digest via the Docker Distribution
+// API. Returns undefined when the tag doesn't exist.
+export async function getManifestDigest(
+	registryToken: string,
+	repo: string,
+	tag: string,
+): Promise<string | undefined> {
+	const [{ statusCode, statusMessage, headers }, body] = await requestAsync({
+		url: `https://${REGISTRY2_HOST}/v2/${repo}/manifests/${tag}`,
+		headers: {
+			Authorization: `Bearer ${registryToken}`,
+			Accept: MANIFEST_ACCEPT_HEADER,
+		},
+		method: 'HEAD',
+	});
+
+	if (statusCode === 404) {
+		return undefined;
+	}
+	if (statusCode !== 200) {
+		throw new Error(
+			`Failed to resolve ${repo}:${tag} to a digest: [${statusCode}] ${statusMessage} ${body}`,
+		);
+	}
+	const digest = headers['docker-content-digest'];
+	if (typeof digest !== 'string' || digest === '') {
+		throw new Error(
+			`Registry did not return a Docker-Content-Digest for ${repo}:${tag}`,
+		);
+	}
+	return digest;
 }

--- a/test/26_registry-image-deletion.ts
+++ b/test/26_registry-image-deletion.ts
@@ -3,7 +3,10 @@ import * as registryMock from './test-lib/registry-mock.js';
 import { waitFor } from './test-lib/common.js';
 import * as versions from './test-lib/versions.js';
 import * as config from '../src/lib/config.js';
-import { s3Client } from '../src/features/registry/registry.js';
+import {
+	s3Client,
+	TEST_MOCK_ONLY as registryTestMockOnly,
+} from '../src/features/registry/registry.js';
 import { strict as assert } from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { permissions, sbvrUtils } from '@balena/pinejs';
@@ -36,6 +39,7 @@ export default () => {
 				options?: {
 					releaseId?: number;
 					stages?: number;
+					tags?: string[];
 				},
 			) {
 				const now = new Date();
@@ -68,8 +72,16 @@ export default () => {
 				return {
 					repository,
 					dbImage: image,
-					registryImage: registryMock.addImage(repository, digest),
-					cacheImages: registryMock.addCacheImages(repository, stages),
+					registryImage: registryMock.addImage(
+						repository,
+						digest,
+						options?.tags,
+					),
+					cacheImages: registryMock.addCacheImages(
+						repository,
+						stages,
+						options?.tags,
+					),
 				};
 			}
 
@@ -110,6 +122,7 @@ export default () => {
 				ctx.app1 = fx.applications.app1;
 				ctx.service1 = fx.services.service1;
 				ctx.service2 = fx.services.service2;
+				ctx.service3 = fx.services.service3;
 				await resetLatestTaskIds('delete_registry_images');
 
 				// Create an image that should not be deleted.
@@ -361,6 +374,39 @@ export default () => {
 				const digests = await s3Client.listTagDigests(repo, 'latest');
 				expect(digests).to.have.lengthOf(2);
 				expect(digests).to.have.members([digestA, digestB]);
+			});
+
+			// For environments that store registry data in the registry's
+			// local filesystem and not in an S3 bucket.
+			describe('registry API fallback', () => {
+				// We need to undefine the s3Client so the logic
+				// uses the registry API fallback instead.
+				const realS3Client = s3Client;
+
+				before(() => {
+					registryTestMockOnly.s3Client = undefined;
+				});
+
+				after(() => {
+					registryTestMockOnly.s3Client = realS3Client;
+				});
+
+				it('should mark an image and its cache images for deletion', async () => {
+					const image = await createImage(ctx.service3.id, {
+						stages: 3,
+						tags: ['latest'],
+					});
+					await pineUser.delete({
+						resource: 'image',
+						id: image.dbImage.id,
+					});
+
+					await waitFor({
+						delayMs: 500,
+						checkFn: () => checkIsDeleted([image]),
+					});
+					await expectSettledTasks([image]);
+				});
 			});
 		});
 	});

--- a/test/fixtures/26-registry-image-deletion/applications.json
+++ b/test/fixtures/26-registry-image-deletion/applications.json
@@ -15,5 +15,10 @@
 		"user": "admin",
 		"device_type": "intel-nuc",
 		"app_name": "test-app-2"
+	},
+	"app3": {
+		"user": "admin",
+		"device_type": "intel-nuc",
+		"app_name": "test-app-3"
 	}
 }

--- a/test/fixtures/26-registry-image-deletion/services.json
+++ b/test/fixtures/26-registry-image-deletion/services.json
@@ -13,5 +13,10 @@
 		"user": "admin",
 		"application": "app2",
 		"service_name": "service2"
+	},
+	"service3": {
+		"user": "admin",
+		"application": "app3",
+		"service_name": "service3"
 	}
 }

--- a/test/test-lib/registry-mock.ts
+++ b/test/test-lib/registry-mock.ts
@@ -1,9 +1,13 @@
-import { REGISTRY_STORAGE_ROOT_PATH } from '../../src/lib/config.js';
+import {
+	REGISTRY2_HOST,
+	REGISTRY_STORAGE_ROOT_PATH,
+} from '../../src/lib/config.js';
 import { randomUUID } from 'node:crypto';
 import {
 	addDeleteObjectsResolver,
 	addListObjectsV2Resolver,
 } from './aws-mock.js';
+import { getMockServer } from './mockttp-server.js';
 
 interface RegistryImage {
 	repository: string;
@@ -88,10 +92,14 @@ export function getManifestObjectKeys(repository: string) {
 	return [...store.objects].filter((key) => key.startsWith(prefix));
 }
 
-export function addCacheImages(repository: string, stages: number) {
+export function addCacheImages(
+	repository: string,
+	stages: number,
+	tags?: string[],
+) {
 	const cacheImages: RegistryImage[] = [];
 	for (let i = 0; i < stages; i++) {
-		cacheImages.push(addImage(`${repository}-${i}`, genDigest()));
+		cacheImages.push(addImage(`${repository}-${i}`, genDigest(), tags));
 	}
 	return cacheImages;
 }
@@ -178,13 +186,91 @@ function registerDeleteObjectsResolver() {
 	});
 }
 
+// Docker Distribution HTTP API mocks for when the registry s3Client
+// isn't available and falls back to making registry API calls.
+
+function getNonDeletedImages(repository: string) {
+	return store.images.filter(
+		(i) => i.repository === repository && !i.isDeleted,
+	);
+}
+
+function parseManifestPath(url: string) {
+	const { pathname } = new URL(url);
+	const [, repo, reference] = /^\/v2\/(.+)\/manifests\/(.+)$/.exec(pathname)!;
+	return { repo, reference };
+}
+
+async function startRegistryApi() {
+	const server = getMockServer();
+
+	await server
+		.forGet(/\/v2\/.+\/tags\/list$/)
+		.forHostname(REGISTRY2_HOST)
+		.always()
+		.thenCallback((req) => {
+			const repo = new URL(req.url).pathname.slice(
+				'/v2/'.length,
+				-'/tags/list'.length,
+			);
+			const images = getNonDeletedImages(repo);
+			if (images.length === 0) {
+				return {
+					statusCode: 404,
+					json: { errors: [{ code: 'NAME_UNKNOWN' }] },
+				};
+			}
+			return {
+				statusCode: 200,
+				json: {
+					name: repo,
+					tags: [...new Set(images.flatMap((i) => i.tags ?? []))],
+				},
+			};
+		});
+
+	await server
+		.forHead(/\/v2\/.+\/manifests\/.+$/)
+		.forHostname(REGISTRY2_HOST)
+		.always()
+		.thenCallback((req) => {
+			const { repo, reference } = parseManifestPath(req.url);
+			const image = getNonDeletedImages(repo).find((i) =>
+				i.tags?.includes(reference),
+			);
+			if (image == null) {
+				return { statusCode: 404 };
+			}
+			return {
+				statusCode: 200,
+				headers: { 'docker-content-digest': image.digest },
+			};
+		});
+
+	await server
+		.forDelete(/\/v2\/.+\/manifests\/.+$/)
+		.forHostname(REGISTRY2_HOST)
+		.always()
+		.thenCallback((req) => {
+			const { repo, reference } = parseManifestPath(req.url);
+			const image = getNonDeletedImages(repo).find(
+				(i) => i.digest === reference,
+			);
+			if (image == null) {
+				return { statusCode: 404 };
+			}
+			image.isDeleted = true;
+			return { statusCode: 202 };
+		});
+}
+
 let disposeS3Resolver: (() => void) | undefined;
 let disposeDeleteObjectsResolver: (() => void) | undefined;
 
-// eslint-disable-next-line @typescript-eslint/require-await -- kept async to match the mock lifecycle contract used by init-tests.
 export async function start() {
 	disposeS3Resolver = registerS3Resolver();
 	disposeDeleteObjectsResolver = registerDeleteObjectsResolver();
+	await startRegistryApi();
 }
 
 export function stop() {


### PR DESCRIPTION
For environments that do not use S3 for registry storage, fallback to making calls to the Docker Distribution API when marking images for deletion from the registry.

Change-type: patch

---

See: https://balena.fibery.io/Work/Project/Continue-executing-registry-cleanup-job-on-production-2806