### PR TITLE
fasttest: Don't sync node_modules/@swc-node for container-hostOS arch compatibility reasons

### DIFF
--- a/docker-compose.test-custom.yml
+++ b/docker-compose.test-custom.yml
@@ -163,6 +163,7 @@ services:
       - /usr/src/app/node_modules/@napi-rs
       - /usr/src/app/node_modules/@node-rs
       - /usr/src/app/node_modules/@swc
+      - /usr/src/app/node_modules/@swc-node
       - /usr/src/app/node_modules/@oxc-resolver
       - /usr/src/app/node_modules/oxc-resolver
       - ./package.json:/usr/src/app/package.json


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Project/2840